### PR TITLE
fix(cors): 确保 PATCH 方法始终在 CORS 允许列表中

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -73,6 +73,7 @@ cors:
     - GET
     - POST
     - PUT
+    - PATCH
     - DELETE
     - OPTIONS
   allowed_headers:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -262,7 +262,7 @@ func Load() *Config {
 	viper.SetDefault("upload.max_width", 4096)
 	viper.SetDefault("upload.max_height", 4096)
 	viper.SetDefault("cors.allowed_origins", []string{"*"})
-	viper.SetDefault("cors.allowed_methods", []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"})
+	viper.SetDefault("cors.allowed_methods", []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"})
 	viper.SetDefault("cors.allowed_headers", []string{
 		"Content-Type",
 		"Content-Length",

--- a/internal/router/middleware.go
+++ b/internal/router/middleware.go
@@ -33,7 +33,18 @@ func CORSMiddleware(cfg config.CORSConfig) gin.HandlerFunc {
 	}
 	allowedMethods := cfg.AllowedMethods
 	if len(allowedMethods) == 0 {
-		allowedMethods = []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}
+		allowedMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"}
+	}
+	// 确保 PATCH 始终在允许的方法列表中（RESTful API 必需）
+	hasPatch := false
+	for _, m := range allowedMethods {
+		if strings.EqualFold(m, "PATCH") {
+			hasPatch = true
+			break
+		}
+	}
+	if !hasPatch {
+		allowedMethods = append(allowedMethods, "PATCH")
 	}
 	allowedHeaders := cfg.AllowedHeaders
 	if len(allowedHeaders) == 0 {


### PR DESCRIPTION
## 问题

管理后台修改订单状态时使用 PATCH 请求，但 CORS 中间件的 fallback 默认方法列表缺少 PATCH，
当用户在 config.yml 中配置了 allowed_methods 但遗漏 PATCH 时，会导致跨域请求被拒绝。

## 修复方案

三层保障，确保 PATCH 方法不会因配置遗漏而丢失：

1. **middleware.go**: CORS 中间件自动检测并补充 PATCH 方法（治本）
2. **config.go**: viper.SetDefault 默认值添加 PATCH
3. **config.yml.example**: 示例配置同步更新

## 改动文件

- `internal/router/middleware.go` - 自动补充 PATCH 到允许方法列表
- `internal/config/config.go` - 默认配置添加 PATCH
- `config.yml.example` - 示例配置添加 PATCH
