### PR TITLE
feat(db): 添加 MySQL / MariaDB 数据库驱动支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Dujiao-Next API is the backend service for the Dujiao-Next ecosystem. It provide
 - Go
 - Gin
 - GORM
-- SQLite / PostgreSQL
+- SQLite / MySQL / PostgreSQL
 
 ## What This Service Does
 

--- a/config.yml.example
+++ b/config.yml.example
@@ -14,8 +14,10 @@ log:
   compress: true
 
 database:
-  driver: sqlite  # sqlite / postgres
+  driver: sqlite  # sqlite / mysql / postgres
   dsn: ./db/dujiao.db
+  # MySQL DSN 示例: root:password@tcp(127.0.0.1:3306)/dujiao?charset=utf8mb4&parseTime=True&loc=Local
+  # PostgreSQL DSN 示例: host=127.0.0.1 port=5432 user=postgres password=password dbname=dujiao sslmode=disable
   pool:
     max_open_conns: 1
     max_idle_conns: 1

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.47.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
 )
@@ -88,7 +89,6 @@ require (
 	golang.org/x/time v0.8.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
-	gorm.io/driver/mysql v1.6.0 // indirect
 	gorm.io/driver/sqlserver v1.6.3 // indirect
 	gorm.io/plugin/dbresolver v1.6.2 // indirect
 	modernc.org/libc v1.67.6 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,7 +65,7 @@ type DatabasePoolConfig struct {
 
 // DatabaseConfig 数据库配置
 type DatabaseConfig struct {
-	Driver string             `mapstructure:"driver"` // 数据库驱动（sqlite/postgres）
+	Driver string             `mapstructure:"driver"` // 数据库驱动（sqlite/mysql/postgres）
 	DSN    string             `mapstructure:"dsn"`    // 数据库连接串
 	Pool   DatabasePoolConfig `mapstructure:"pool"`
 }

--- a/internal/models/db.go
+++ b/internal/models/db.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/glebarez/sqlite" // 纯 Go SQLite 驱动（基于 modernc.org/sqlite）
+	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -31,6 +32,8 @@ func InitDB(driver, dsn string, pool DBPoolConfig) error {
 	case "", "sqlite":
 		// glebarez/sqlite 是基于 modernc.org/sqlite 的纯 Go 驱动
 		dialector = sqlite.Open(dsn)
+	case "mysql", "mariadb":
+		dialector = mysql.Open(dsn)
 	case "postgres", "postgresql":
 		dialector = postgres.Open(dsn)
 	default:


### PR DESCRIPTION
## 功能描述

添加 MySQL / MariaDB 数据库驱动支持，使项目支持 SQLite、MySQL、PostgreSQL 三种数据库。

## 改动内容

### `internal/models/db.go`
- 新增 `gorm.io/driver/mysql` 导入
- 在 `InitDB` 的驱动 switch 中添加 `mysql`、`mariadb` 分支，调用 `mysql.Open(dsn)` 初始化连接

### `internal/config/config.go`
- `DatabaseConfig.Driver` 字段注释由 `sqlite/postgres` 更新为 `sqlite/mysql/postgres`

### `config.yml.example`
- `driver` 注释补充 `mysql` 选项
- 新增 MySQL DSN 示例：`root:password@tcp(127.0.0.1:3306)/dujiao?charset=utf8mb4&parseTime=True&loc=Local`
- 新增 PostgreSQL DSN 示例

### `README.md`
- Tech Stack 中数据库描述由 `SQLite / PostgreSQL` 更新为 `SQLite / MySQL / PostgreSQL`

### `go.mod`
- `gorm.io/driver/mysql v1.6.0` 由间接依赖提升为直接依赖（该包原本已作为 casbin gorm-adapter 的间接依赖存在，无新增外部包）
