### PR TITLE
feat(auth): add configurable user registration toggle

### DIFF
--- a/internal/http/handlers/public/public.go
+++ b/internal/http/handlers/public/public.go
@@ -103,6 +103,23 @@ func (h *Handler) GetConfig(c *gin.Context) {
 	}
 	data["telegram_auth"] = telegramAuthConfig
 
+	// 用户注册配置
+	userRegConfig := map[string]interface{}{
+		"enabled":              true,
+		"require_email_verify": true,
+	}
+	if siteConfig, err := h.SettingService.GetByKey(constants.SettingKeySiteConfig); err == nil && siteConfig != nil {
+		if regConfig, ok := siteConfig["user_registration"].(map[string]interface{}); ok {
+			if v, ok := regConfig["enabled"].(bool); ok {
+				userRegConfig["enabled"] = v
+			}
+			if v, ok := regConfig["require_email_verify"].(bool); ok {
+				userRegConfig["require_email_verify"] = v
+			}
+		}
+	}
+	data["user_registration"] = userRegConfig
+
 	_ = cache.SetJSON(c.Request.Context(), publicConfigCacheKey, data, publicConfigCacheTTL)
 	response.Success(c, data)
 }

--- a/internal/http/handlers/public/user_auth.go
+++ b/internal/http/handlers/public/user_auth.go
@@ -87,7 +87,7 @@ func (h *Handler) SendUserVerifyCode(c *gin.Context) {
 type UserRegisterRequest struct {
 	Email             string `json:"email" binding:"required"`
 	Password          string `json:"password" binding:"required"`
-	Code              string `json:"code" binding:"required"`
+	Code              string `json:"code"`
 	AgreementAccepted bool   `json:"agreement_accepted"`
 }
 
@@ -114,6 +114,8 @@ func (h *Handler) UserRegister(c *gin.Context) {
 			respondError(c, response.CodeBadRequest, "error.verify_code_attempts_exceeded", nil)
 		case errors.Is(err, service.ErrAgreementRequired):
 			respondError(c, response.CodeBadRequest, "error.agreement_required", nil)
+		case errors.Is(err, service.ErrRegistrationDisabled):
+			respondError(c, response.CodeForbidden, "error.registration_disabled", nil)
 		case errors.Is(err, service.ErrWeakPassword):
 			locale := i18n.ResolveLocale(c)
 			if perr, ok := err.(interface {

--- a/internal/provider/container.go
+++ b/internal/provider/container.go
@@ -166,7 +166,7 @@ func (c *Container) initServices() {
 	c.CaptchaService = service.NewCaptchaService(c.SettingService, c.Config.Captcha)
 	c.AuthService = service.NewAuthService(c.Config, c.AdminRepo)
 	c.TelegramAuthService = service.NewTelegramAuthService(c.Config.TelegramAuth)
-	c.UserAuthService = service.NewUserAuthService(c.Config, c.UserRepo, c.UserOAuthIdentityRepo, c.EmailVerifyCodeRepo, c.EmailService, c.TelegramAuthService)
+	c.UserAuthService = service.NewUserAuthService(c.Config, c.UserRepo, c.UserOAuthIdentityRepo, c.EmailVerifyCodeRepo, c.EmailService, c.TelegramAuthService, c.SettingService)
 	c.UploadService = service.NewUploadService(c.Config)
 	c.ProductService = service.NewProductService(c.ProductRepo, c.ProductSKURepo)
 	c.PostService = service.NewPostService(c.PostRepo)

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -16,6 +16,7 @@ var (
 	ErrInvalidEmail                  = errors.New("invalid email")
 	ErrInvalidVerifyPurpose          = errors.New("invalid verify purpose")
 	ErrAgreementRequired             = errors.New("agreement required")
+	ErrRegistrationDisabled          = errors.New("registration disabled")
 	ErrVerifyCodeInvalid             = errors.New("verify code invalid")
 	ErrVerifyCodeExpired             = errors.New("verify code expired")
 	ErrVerifyCodeTooFrequent         = errors.New("verify code too frequent")

--- a/internal/service/setting_normalize.go
+++ b/internal/service/setting_normalize.go
@@ -70,6 +70,7 @@ func normalizeSiteSetting(value map[string]interface{}) models.JSON {
 	normalized["seo"] = normalizeSiteLocalizedBlock(value["seo"], []string{"title", "keywords", "description"})
 	normalized["legal"] = normalizeSiteLocalizedBlock(value["legal"], []string{"terms", "privacy"})
 	normalized["about"] = normalizeSiteAbout(value["about"])
+	normalized["user_registration"] = normalizeSiteUserRegistration(value["user_registration"])
 	normalized["scripts"] = normalizeSiteScripts(value["scripts"])
 	normalized[constants.SettingFieldSiteCurrency] = normalizeSiteCurrency(value[constants.SettingFieldSiteCurrency])
 
@@ -125,6 +126,26 @@ func normalizeSiteCurrency(raw interface{}) string {
 	}
 	return currency
 }
+
+// normalizeSiteUserRegistration 归一化用户注册配置。
+func normalizeSiteUserRegistration(raw interface{}) map[string]interface{} {
+	result := map[string]interface{}{
+		"enabled":              true,
+		"require_email_verify": true,
+	}
+	regMap, ok := raw.(map[string]interface{})
+	if !ok {
+		return result
+	}
+	if v, ok := regMap["enabled"].(bool); ok {
+		result["enabled"] = v
+	}
+	if v, ok := regMap["require_email_verify"].(bool); ok {
+		result["require_email_verify"] = v
+	}
+	return result
+}
+
 
 func normalizeSiteContact(raw interface{}) map[string]interface{} {
 	result := map[string]interface{}{

--- a/internal/service/user_auth_service.go
+++ b/internal/service/user_auth_service.go
@@ -28,6 +28,7 @@ type UserAuthService struct {
 	codeRepo              repository.EmailVerifyCodeRepository
 	emailService          *EmailService
 	telegramAuthService   *TelegramAuthService
+	settingService        *SettingService
 }
 
 // NewUserAuthService 创建用户认证服务
@@ -38,6 +39,7 @@ func NewUserAuthService(
 	codeRepo repository.EmailVerifyCodeRepository,
 	emailService *EmailService,
 	telegramAuthService *TelegramAuthService,
+	settingService *SettingService,
 ) *UserAuthService {
 	return &UserAuthService{
 		cfg:                   cfg,
@@ -46,6 +48,7 @@ func NewUserAuthService(
 		codeRepo:              codeRepo,
 		emailService:          emailService,
 		telegramAuthService:   telegramAuthService,
+		settingService:        settingService,
 	}
 }
 
@@ -156,6 +159,26 @@ func (s *UserAuthService) Register(email, password, code string, agreementAccept
 	if !agreementAccepted {
 		return nil, "", time.Time{}, ErrAgreementRequired
 	}
+
+	// 检查注册是否开启
+	registrationEnabled := true
+	requireEmailVerify := true
+	if s.settingService != nil {
+		if siteConfig, err := s.settingService.GetByKey(constants.SettingKeySiteConfig); err == nil && siteConfig != nil {
+			if regConfig, ok := siteConfig["user_registration"].(map[string]interface{}); ok {
+				if v, ok := regConfig["enabled"].(bool); ok {
+					registrationEnabled = v
+				}
+				if v, ok := regConfig["require_email_verify"].(bool); ok {
+					requireEmailVerify = v
+				}
+			}
+		}
+	}
+	if !registrationEnabled {
+		return nil, "", time.Time{}, ErrRegistrationDisabled
+	}
+
 	normalized, err := normalizeEmail(email)
 	if err != nil {
 		return nil, "", time.Time{}, err
@@ -172,8 +195,10 @@ func (s *UserAuthService) Register(email, password, code string, agreementAccept
 		return nil, "", time.Time{}, ErrEmailExists
 	}
 
-	if _, err := s.verifyCode(normalized, constants.VerifyPurposeRegister, code); err != nil {
-		return nil, "", time.Time{}, err
+	if requireEmailVerify {
+		if _, err := s.verifyCode(normalized, constants.VerifyPurposeRegister, code); err != nil {
+			return nil, "", time.Time{}, err
+		}
 	}
 
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)


### PR DESCRIPTION
Add two admin-configurable settings for user registration:
- `user_registration.enabled`: enable/disable new user registration
- `user_registration.require_email_verify`: toggle email verification requirement

When registration is disabled, the register endpoint returns an error.
When email verification is disabled, users can register with just email + password.

Both settings default to `true` (current behavior unchanged).

---
Related: dujiao-next/admin#8, dujiao-next/user#4
