### PR TITLE
feat(category): add icon field to category model

### DIFF
--- a/internal/http/handlers/admin/admin.go
+++ b/internal/http/handlers/admin/admin.go
@@ -521,6 +521,7 @@ func (h *Handler) DeletePost(c *gin.Context) {
 type CreateCategoryRequest struct {
 	Slug      string                 `json:"slug" binding:"required"`
 	NameJSON  map[string]interface{} `json:"name" binding:"required"`
+	Icon      string                 `json:"icon"`
 	SortOrder int                    `json:"sort_order"`
 }
 
@@ -535,6 +536,7 @@ func (h *Handler) CreateCategory(c *gin.Context) {
 	category, err := h.CategoryService.Create(service.CreateCategoryInput{
 		Slug:      req.Slug,
 		NameJSON:  req.NameJSON,
+		Icon:      req.Icon,
 		SortOrder: req.SortOrder,
 	})
 	if err != nil {
@@ -562,6 +564,7 @@ func (h *Handler) UpdateCategory(c *gin.Context) {
 	category, err := h.CategoryService.Update(id, service.CreateCategoryInput{
 		Slug:      req.Slug,
 		NameJSON:  req.NameJSON,
+		Icon:      req.Icon,
 		SortOrder: req.SortOrder,
 	})
 	if err != nil {

--- a/internal/models/category.go
+++ b/internal/models/category.go
@@ -61,6 +61,7 @@ type Category struct {
 	ID        uint           `gorm:"primarykey" json:"id"`              // 主键
 	Slug      string         `gorm:"uniqueIndex;not null" json:"slug"`  // 唯一标识
 	NameJSON  JSON           `gorm:"type:json;not null" json:"name"`    // 多语言名称
+	Icon      string         `gorm:"type:varchar(500)" json:"icon"`     // 分类图标（图片路径）
 	SortOrder int            `gorm:"default:0;index" json:"sort_order"` // 排序权重
 	CreatedAt time.Time      `gorm:"index" json:"created_at"`           // 创建时间
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`                    // 软删除时间

--- a/internal/service/category_service.go
+++ b/internal/service/category_service.go
@@ -19,6 +19,7 @@ func NewCategoryService(repo repository.CategoryRepository) *CategoryService {
 type CreateCategoryInput struct {
 	Slug      string
 	NameJSON  map[string]interface{}
+	Icon      string
 	SortOrder int
 }
 
@@ -40,6 +41,7 @@ func (s *CategoryService) Create(input CreateCategoryInput) (*models.Category, e
 	category := models.Category{
 		Slug:      input.Slug,
 		NameJSON:  models.JSON(input.NameJSON),
+		Icon:      input.Icon,
 		SortOrder: input.SortOrder,
 	}
 	if err := s.repo.Create(&category); err != nil {
@@ -68,6 +70,7 @@ func (s *CategoryService) Update(id string, input CreateCategoryInput) (*models.
 
 	category.Slug = input.Slug
 	category.NameJSON = models.JSON(input.NameJSON)
+	category.Icon = input.Icon
 	category.SortOrder = input.SortOrder
 
 	if err := s.repo.Update(category); err != nil {

--- a/internal/service/upload_service.go
+++ b/internal/service/upload_service.go
@@ -22,11 +22,12 @@ import (
 )
 
 var allowedUploadScenes = map[string]struct{}{
-	"product": {},
-	"post":    {},
-	"banner":  {},
-	"editor":  {},
-	"common":  {},
+	"product":  {},
+	"post":     {},
+	"banner":   {},
+	"editor":   {},
+	"common":   {},
+	"category": {},
 }
 
 // UploadService 文件上传服务


### PR DESCRIPTION
## Summary
Add an optional `icon` field to the Category model, allowing admins to upload a category icon image via the existing upload service.

## Changes
- Add `Icon string` field (varchar 500) to `Category` model - auto-migrated by GORM
- Add `Icon` to `CreateCategoryInput` and wire through `Create`/`Update` service methods
- Add `Icon` to `CreateCategoryRequest` in admin handler (optional, no binding required)
- Register `category` as an allowed upload scene

## Related PRs
This is part of the category icon feature.
- Admin UI: dujiao-next/admin#10
- User frontend: dujiao-next/user#6