### PR TITLE
payment service: The OrderNo includes its payment.ID to generate a unique order

### DIFF
--- a/internal/service/payment_service_callback.go
+++ b/internal/service/payment_service_callback.go
@@ -68,7 +68,7 @@ func (s *PaymentService) HandleCallback(input PaymentCallbackInput) (*models.Pay
 		)
 		return nil, ErrPaymentInvalid
 	}
-	if input.OrderNo != "" && input.OrderNo != order.OrderNo {
+	if input.OrderNo != "" && input.OrderNo != order.OrderNo && input.OrderNo != fmt.Sprintf("%s-%d", order.OrderNo, payment.ID) {
 		log.Warnw("payment_callback_order_no_mismatch",
 			"stored_order_no", order.OrderNo,
 			"callback_order_no", input.OrderNo,
@@ -160,7 +160,8 @@ func (s *PaymentService) handleWalletRechargeCallback(payment *models.Payment, s
 		)
 		return nil, ErrPaymentInvalid
 	}
-	if input.OrderNo != "" && input.OrderNo != recharge.RechargeNo {
+	uniqueOrderNo := fmt.Sprintf("%s-%d", recharge.RechargeNo, payment.ID)
+	if input.OrderNo != "" && input.OrderNo != recharge.RechargeNo && input.OrderNo != uniqueOrderNo {
 		log.Warnw("wallet_recharge_callback_order_no_mismatch",
 			"stored_recharge_no", recharge.RechargeNo,
 			"callback_order_no", input.OrderNo,

--- a/internal/service/payment_service_provider.go
+++ b/internal/service/payment_service_provider.go
@@ -24,6 +24,7 @@ import (
 func (s *PaymentService) applyProviderPayment(input CreatePaymentInput, order *models.Order, channel *models.PaymentChannel, payment *models.Payment) (err error) {
 	providerType := strings.ToLower(strings.TrimSpace(channel.ProviderType))
 	channelType := strings.ToLower(strings.TrimSpace(channel.ChannelType))
+	uniqueOrderNo := fmt.Sprintf("%s-%d", order.OrderNo, payment.ID)
 	log := paymentLogger(
 		"order_id", order.ID,
 		"order_no", order.OrderNo,
@@ -61,7 +62,7 @@ func (s *PaymentService) applyProviderPayment(input CreatePaymentInput, order *m
 		subject := buildOrderSubject(order)
 		param := strconv.FormatUint(uint64(payment.ID), 10)
 		result, err := epay.CreatePayment(ctx, cfg, epay.CreateInput{
-			OrderNo:     order.OrderNo,
+			OrderNo:     uniqueOrderNo,
 			PaymentID:   payment.ID,
 			Amount:      payment.Amount.String(),
 			Subject:     subject,
@@ -123,7 +124,7 @@ func (s *PaymentService) applyProviderPayment(input CreatePaymentInput, order *m
 		}
 		subject := buildOrderSubject(order)
 		result, err := epusdt.CreatePayment(ctx, cfg, epusdt.CreateInput{
-			OrderNo:   order.OrderNo,
+			OrderNo:   uniqueOrderNo,
 			PaymentID: payment.ID,
 			Amount:    payment.Amount.String(),
 			Name:      subject,
@@ -178,7 +179,7 @@ func (s *PaymentService) applyProviderPayment(input CreatePaymentInput, order *m
 			redirectURL = appendURLQuery(redirectURL, buildOrderReturnQuery(order, "tokenpay_return", ""))
 		}
 		createResult, err := tokenpay.CreatePayment(ctx, cfg, tokenpay.CreateInput{
-			OutOrderID:      strings.TrimSpace(order.OrderNo),
+			OutOrderID:      uniqueOrderNo,
 			OrderUserKey:    resolveTokenPayOrderUserKey(order),
 			ActualAmount:    payment.Amount.String(),
 			Currency:        strings.TrimSpace(cfg.Currency),
@@ -226,7 +227,7 @@ func (s *PaymentService) applyProviderPayment(input CreatePaymentInput, order *m
 				ctx = context.Background()
 			}
 			createResult, err := paypal.CreateOrder(ctx, cfg, paypal.CreateInput{
-				OrderNo:     order.OrderNo,
+				OrderNo:     uniqueOrderNo,
 				PaymentID:   payment.ID,
 				Amount:      payment.Amount.String(),
 				Currency:    payment.Currency,
@@ -272,7 +273,7 @@ func (s *PaymentService) applyProviderPayment(input CreatePaymentInput, order *m
 				ctx = context.Background()
 			}
 			createResult, err := alipay.CreatePayment(ctx, cfg, alipay.CreateInput{
-				OrderNo:        order.OrderNo,
+				OrderNo:        uniqueOrderNo,
 				PaymentID:      payment.ID,
 				Amount:         payment.Amount.String(),
 				Subject:        buildOrderSubject(order),
@@ -320,7 +321,7 @@ func (s *PaymentService) applyProviderPayment(input CreatePaymentInput, order *m
 				ctx = context.Background()
 			}
 			createResult, err := wechatpay.CreatePayment(ctx, &cfgForCreate, wechatpay.CreateInput{
-				OrderNo:     order.OrderNo,
+				OrderNo:     uniqueOrderNo,
 				PaymentID:   payment.ID,
 				Amount:      payment.Amount.String(),
 				Currency:    payment.Currency,
@@ -365,7 +366,7 @@ func (s *PaymentService) applyProviderPayment(input CreatePaymentInput, order *m
 				ctx = context.Background()
 			}
 			createResult, err := stripe.CreatePayment(ctx, cfg, stripe.CreateInput{
-				OrderNo:     order.OrderNo,
+				OrderNo:     uniqueOrderNo,
 				PaymentID:   payment.ID,
 				Amount:      payment.Amount.String(),
 				Currency:    payment.Currency,


### PR DESCRIPTION
解决什么问题：

BEPUSDT 等付款方式

1. 用户切换付款方式，向网关传递了相同的网站订单号，付款网关由于没有生成新的内部付款订单号，将导致“继续使用原记录”失效。例如 TRC20->BEP20 再切回 BEP20，即使点了 BEP20 按钮，由于没有触发重建订单，点过去仍然是 TRC20。

2. 付款网关设置的费率不同，用户切换付款方式，会直接返回缓存的旧交易信息（这就导致了 provider_payload 里的支付链接和金额依然是旧费率的金额），用户支付后，网关回调也是按旧金额通知，从而导致后端对账时触发 payment_callback_amount_mismatch 异常。

解决方案是订单号带付款ID，这样就行了。

