### PR TITLE
fix(product): persist category changes when updating products

### DIFF
--- a/internal/repository/product_repository.go
+++ b/internal/repository/product_repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dujiao-next/internal/models"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // ProductRepository 商品数据访问接口
@@ -214,7 +215,7 @@ func (r *GormProductRepository) Create(product *models.Product) error {
 
 // Update 更新商品
 func (r *GormProductRepository) Update(product *models.Product) error {
-	return r.db.Save(product).Error
+	return r.db.Omit(clause.Associations).Save(product).Error
 }
 
 // Delete 删除商品

--- a/internal/repository/product_repository_test.go
+++ b/internal/repository/product_repository_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/dujiao-next/internal/constants"
@@ -17,8 +18,8 @@ func setupProductRepositoryTest(t *testing.T) (*GormProductRepository, *gorm.DB)
 	if err != nil {
 		t.Fatalf("open sqlite failed: %v", err)
 	}
-	if err := db.AutoMigrate(&models.Product{}, &models.ProductSKU{}); err != nil {
-		t.Fatalf("migrate product/sku failed: %v", err)
+	if err := db.AutoMigrate(&models.Category{}, &models.Product{}, &models.ProductSKU{}); err != nil {
+		t.Fatalf("migrate category/product/sku failed: %v", err)
 	}
 	return NewProductRepository(db), db
 }
@@ -171,6 +172,68 @@ func TestManualStockUnlimitedDoesNotReserve(t *testing.T) {
 	}
 	if affected != 0 {
 		t.Fatalf("consume unlimited affected want 0 got %d", affected)
+	}
+}
+
+func TestUpdatePersistsChangedCategoryIDWithPreloadedCategory(t *testing.T) {
+	repo, db := setupProductRepositoryTest(t)
+
+	sourceCategory := &models.Category{
+		Slug:     "source-category",
+		NameJSON: models.JSON{"zh-CN": "source"},
+	}
+	targetCategory := &models.Category{
+		Slug:     "target-category",
+		NameJSON: models.JSON{"zh-CN": "target"},
+	}
+	if err := db.Create(sourceCategory).Error; err != nil {
+		t.Fatalf("create source category failed: %v", err)
+	}
+	if err := db.Create(targetCategory).Error; err != nil {
+		t.Fatalf("create target category failed: %v", err)
+	}
+
+	product := &models.Product{
+		CategoryID:      sourceCategory.ID,
+		Slug:            "category-switch-product",
+		TitleJSON:       models.JSON{"zh-CN": "测试商品"},
+		PriceAmount:     models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		PurchaseType:    constants.ProductPurchaseMember,
+		FulfillmentType: constants.FulfillmentTypeManual,
+		IsActive:        true,
+	}
+	if err := repo.Create(product); err != nil {
+		t.Fatalf("create product failed: %v", err)
+	}
+
+	loaded, err := repo.GetByID(strconv.FormatUint(uint64(product.ID), 10))
+	if err != nil {
+		t.Fatalf("load product failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected product to exist")
+	}
+	if loaded.Category.ID != sourceCategory.ID {
+		t.Fatalf("expected preloaded category id=%d, got %d", sourceCategory.ID, loaded.Category.ID)
+	}
+
+	loaded.CategoryID = targetCategory.ID
+	if err := repo.Update(loaded); err != nil {
+		t.Fatalf("update product failed: %v", err)
+	}
+
+	reloaded, err := repo.GetByID(strconv.FormatUint(uint64(product.ID), 10))
+	if err != nil {
+		t.Fatalf("reload product failed: %v", err)
+	}
+	if reloaded == nil {
+		t.Fatal("expected reloaded product to exist")
+	}
+	if reloaded.CategoryID != targetCategory.ID {
+		t.Fatalf("expected category_id=%d, got %d", targetCategory.ID, reloaded.CategoryID)
+	}
+	if reloaded.Category.ID != targetCategory.ID {
+		t.Fatalf("expected preloaded category id=%d after update, got %d", targetCategory.ID, reloaded.Category.ID)
 	}
 }
 


### PR DESCRIPTION
﻿## 背景

在后台编辑商品时，前端已经正确提交了新的 `category_id`，但分类修改没有真正生效。

排查后确认，直接原因在后端更新链路：
`Product` 实例带着预加载的旧 `Category` 关联，更新时使用 `Save(product)` 会把旧关联状态一并带回，导致新的 `category_id` 被旧值覆盖。

## 本次修复

- 修复后台编辑商品时分类修改不生效的问题
- 更新商品时忽略关联字段，仅更新 `products` 主表
- 避免预加载的旧分类关联干扰 `category_id` 持久化

## 影响范围

- 一级分类商品改为二级分类
- 二级分类商品改为一级分类
- 一级分类之间互相切换

## 验证

- 本地开发环境复现并抓包确认：
  - 前端请求中的 `category_id` 为新值
  - 修复前后端响应中的 `category_id` 会回退为旧值
  - 修复后分类修改可正确保存
- 相关分类切换场景已手工验证通过

## 关联 PR

- admin PR: https://github.com/dujiao-next/admin/pull/16
