### PR TITLE
fix(auth): block telegram signup when registration is disabled

### DIFF
--- a/internal/http/handlers/channel/channel_affiliate_test.go
+++ b/internal/http/handlers/channel/channel_affiliate_test.go
@@ -73,7 +73,7 @@ func setupChannelAffiliateHandlerTest(t *testing.T) (*gorm.DB, *httptest.Server)
 	}
 
 	affiliateSvc := service.NewAffiliateService(affiliateRepo, userRepo, orderRepo, nil, settingSvc)
-	userAuthSvc := service.NewUserAuthService(&config.Config{}, userRepo, identityRepo, emailVerifyRepo, nil, nil)
+	userAuthSvc := service.NewUserAuthService(&config.Config{}, userRepo, identityRepo, emailVerifyRepo, nil, nil, nil)
 
 	handler := New(&provider.Container{
 		UserRepo:              userRepo,

--- a/internal/http/handlers/channel/channel_wallet_gift_card_test.go
+++ b/internal/http/handlers/channel/channel_wallet_gift_card_test.go
@@ -65,7 +65,7 @@ func setupChannelGiftCardHandlerTest(t *testing.T) (*gorm.DB, *httptest.Server) 
 	settingSvc := service.NewSettingService(settingRepo)
 	walletSvc := service.NewWalletService(walletRepo, orderRepo, userRepo, nil)
 	giftCardSvc := service.NewGiftCardService(giftCardRepo, userRepo, walletSvc, settingSvc)
-	userAuthSvc := service.NewUserAuthService(&config.Config{}, userRepo, identityRepo, emailVerifyRepo, nil, nil)
+	userAuthSvc := service.NewUserAuthService(&config.Config{}, userRepo, identityRepo, emailVerifyRepo, nil, nil, nil)
 
 	handler := New(&provider.Container{
 		UserRepo:              userRepo,

--- a/internal/http/handlers/public/user_auth.go
+++ b/internal/http/handlers/public/user_auth.go
@@ -330,6 +330,9 @@ func (h *Handler) UserTelegramLogin(c *gin.Context) {
 		case errors.Is(err, service.ErrUserDisabled):
 			h.recordUserLogin(c, "", 0, constants.LoginLogStatusFailed, constants.LoginLogFailReasonUserDisabled, constants.LoginLogSourceTelegram)
 			shared.RespondError(c, response.CodeUnauthorized, "error.user_disabled", nil)
+		case errors.Is(err, service.ErrRegistrationDisabled):
+			h.recordUserLogin(c, "", 0, constants.LoginLogStatusFailed, constants.LoginLogFailReasonBadRequest, constants.LoginLogSourceTelegram)
+			shared.RespondError(c, response.CodeForbidden, "error.registration_disabled", nil)
 		default:
 			h.recordUserLogin(c, "", 0, constants.LoginLogStatusFailed, constants.LoginLogFailReasonInternalError, constants.LoginLogSourceTelegram)
 			shared.RespondError(c, response.CodeInternal, "error.login_failed", err)
@@ -386,6 +389,9 @@ func (h *Handler) UserTelegramMiniAppLogin(c *gin.Context) {
 		case errors.Is(err, service.ErrUserDisabled):
 			h.recordUserLogin(c, "", 0, constants.LoginLogStatusFailed, constants.LoginLogFailReasonUserDisabled, constants.LoginLogSourceTelegram)
 			shared.RespondError(c, response.CodeUnauthorized, "error.user_disabled", nil)
+		case errors.Is(err, service.ErrRegistrationDisabled):
+			h.recordUserLogin(c, "", 0, constants.LoginLogStatusFailed, constants.LoginLogFailReasonBadRequest, constants.LoginLogSourceTelegram)
+			shared.RespondError(c, response.CodeForbidden, "error.registration_disabled", nil)
 		default:
 			h.recordUserLogin(c, "", 0, constants.LoginLogStatusFailed, constants.LoginLogFailReasonInternalError, constants.LoginLogSourceTelegram)
 			shared.RespondError(c, response.CodeInternal, "error.login_failed", err)

--- a/internal/provider/container.go
+++ b/internal/provider/container.go
@@ -210,7 +210,7 @@ func (c *Container) initServices() {
 	c.CaptchaService = service.NewCaptchaService(c.SettingService, c.Config.Captcha)
 	c.AuthService = service.NewAuthService(c.Config, c.AdminRepo)
 	c.TelegramAuthService = service.NewTelegramAuthService(c.Config.TelegramAuth)
-	c.UserAuthService = service.NewUserAuthService(c.Config, c.UserRepo, c.UserOAuthIdentityRepo, c.EmailVerifyCodeRepo, c.EmailService, c.TelegramAuthService)
+	c.UserAuthService = service.NewUserAuthService(c.Config, c.UserRepo, c.UserOAuthIdentityRepo, c.EmailVerifyCodeRepo, c.SettingService, c.EmailService, c.TelegramAuthService)
 	c.UploadService = service.NewUploadService(c.Config)
 	c.AffiliateService = service.NewAffiliateService(c.AffiliateRepo, c.UserRepo, c.OrderRepo, c.ProductRepo, c.SettingService)
 	c.ProductService = service.NewProductService(c.ProductRepo, c.ProductSKURepo, c.CardSecretRepo, c.CategoryRepo)

--- a/internal/service/user_auth_service.go
+++ b/internal/service/user_auth_service.go
@@ -26,6 +26,7 @@ type UserAuthService struct {
 	userRepo              repository.UserRepository
 	userOAuthIdentityRepo repository.UserOAuthIdentityRepository
 	codeRepo              repository.EmailVerifyCodeRepository
+	settingService        *SettingService
 	emailService          *EmailService
 	telegramAuthService   *TelegramAuthService
 	memberLevelSvc        *MemberLevelService
@@ -42,6 +43,7 @@ func NewUserAuthService(
 	userRepo repository.UserRepository,
 	userOAuthIdentityRepo repository.UserOAuthIdentityRepository,
 	codeRepo repository.EmailVerifyCodeRepository,
+	settingService *SettingService,
 	emailService *EmailService,
 	telegramAuthService *TelegramAuthService,
 ) *UserAuthService {
@@ -50,6 +52,7 @@ func NewUserAuthService(
 		userRepo:              userRepo,
 		userOAuthIdentityRepo: userOAuthIdentityRepo,
 		codeRepo:              codeRepo,
+		settingService:        settingService,
 		emailService:          emailService,
 		telegramAuthService:   telegramAuthService,
 	}

--- a/internal/service/user_auth_service_channel_identity_test.go
+++ b/internal/service/user_auth_service_channel_identity_test.go
@@ -29,7 +29,7 @@ func setupUserAuthServiceChannelIdentityTest(t *testing.T) (*UserAuthService, *g
 	userRepo := repository.NewUserRepository(db)
 	identityRepo := repository.NewUserOAuthIdentityRepository(db)
 
-	return NewUserAuthService(&config.Config{}, userRepo, identityRepo, repository.NewEmailVerifyCodeRepository(db), nil, nil), db
+	return NewUserAuthService(&config.Config{}, userRepo, identityRepo, repository.NewEmailVerifyCodeRepository(db), nil, nil, nil), db
 }
 
 func TestResolveTelegramChannelIdentityReturnsBoundUser(t *testing.T) {

--- a/internal/service/user_auth_service_oauth.go
+++ b/internal/service/user_auth_service_oauth.go
@@ -523,6 +523,15 @@ func (s *UserAuthService) findOrCreateTelegramUser(verified *TelegramIdentityVer
 		}
 		return user, nil
 	}
+	if s.settingService != nil {
+		registrationEnabled, err := s.settingService.GetRegistrationEnabled(true)
+		if err != nil {
+			return nil, err
+		}
+		if !registrationEnabled {
+			return nil, ErrRegistrationDisabled
+		}
+	}
 
 	randomSuffix, err := randomNumericCode(16)
 	if err != nil {

--- a/internal/service/user_auth_service_oauth_miniapp_test.go
+++ b/internal/service/user_auth_service_oauth_miniapp_test.go
@@ -47,6 +47,7 @@ func TestLoginWithTelegramMiniAppCreatesUserIdentityAndToken(t *testing.T) {
 		repository.NewUserOAuthIdentityRepository(db),
 		repository.NewEmailVerifyCodeRepository(db),
 		nil,
+		nil,
 		telegramSvc,
 	)
 

--- a/internal/service/user_auth_service_oauth_test.go
+++ b/internal/service/user_auth_service_oauth_test.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dujiao-next/internal/config"
+	"github.com/dujiao-next/internal/constants"
+	"github.com/dujiao-next/internal/models"
+	"github.com/dujiao-next/internal/repository"
+	"github.com/dujiao-next/internal/telegramidentity"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTelegramOAuthTestService(t *testing.T) (*UserAuthService, *gorm.DB) {
+	t.Helper()
+
+	dsn := fmt.Sprintf("file:user_auth_service_oauth_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite failed: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.UserOAuthIdentity{}, &models.EmailVerifyCode{}, &models.Setting{}); err != nil {
+		t.Fatalf("auto migrate failed: %v", err)
+	}
+
+	cfg := &config.Config{
+		UserJWT: config.JWTConfig{
+			SecretKey:   "user-jwt-test-secret",
+			ExpireHours: 24,
+		},
+	}
+	settingSvc := NewSettingService(repository.NewSettingRepository(db))
+	svc := NewUserAuthService(
+		cfg,
+		repository.NewUserRepository(db),
+		repository.NewUserOAuthIdentityRepository(db),
+		repository.NewEmailVerifyCodeRepository(db),
+		settingSvc,
+		nil,
+		nil,
+	)
+	return svc, db
+}
+
+func TestFindOrCreateTelegramUserRespectsRegistrationSetting(t *testing.T) {
+	svc, db := setupTelegramOAuthTestService(t)
+
+	if _, err := svc.settingService.Update(constants.SettingKeyRegistrationConfig, map[string]interface{}{
+		constants.SettingFieldRegistrationEnabled: false,
+	}); err != nil {
+		t.Fatalf("disable registration failed: %v", err)
+	}
+
+	user, err := svc.findOrCreateTelegramUser(&TelegramIdentityVerified{
+		Provider:       constants.UserOAuthProviderTelegram,
+		ProviderUserID: "10001",
+		Username:       "tg_new_user",
+		AuthAt:         time.Now(),
+	})
+	if !errors.Is(err, ErrRegistrationDisabled) {
+		t.Fatalf("expected ErrRegistrationDisabled, got user=%v err=%v", user, err)
+	}
+
+	var count int64
+	if err := db.Model(&models.User{}).Count(&count).Error; err != nil {
+		t.Fatalf("count users failed: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no users created, got %d", count)
+	}
+}
+
+func TestLoginWithTelegramAllowsExistingIdentityWhenRegistrationDisabled(t *testing.T) {
+	svc, db := setupTelegramOAuthTestService(t)
+
+	now := time.Now()
+	user := &models.User{
+		Email:       telegramidentity.BuildPlaceholderEmail("10002"),
+		PasswordHash: "telegram-auto",
+		DisplayName: "TG Existing",
+		Status:      constants.UserStatusActive,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := db.Create(user).Error; err != nil {
+		t.Fatalf("create user failed: %v", err)
+	}
+	identity := &models.UserOAuthIdentity{
+		UserID:         user.ID,
+		Provider:       constants.UserOAuthProviderTelegram,
+		ProviderUserID: "10002",
+		Username:       "tg_existing",
+		AuthAt:         &now,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := db.Create(identity).Error; err != nil {
+		t.Fatalf("create identity failed: %v", err)
+	}
+	if _, err := svc.settingService.Update(constants.SettingKeyRegistrationConfig, map[string]interface{}{
+		constants.SettingFieldRegistrationEnabled: false,
+	}); err != nil {
+		t.Fatalf("disable registration failed: %v", err)
+	}
+
+	gotUser, token, expiresAt, err := svc.loginWithVerifiedTelegram(&TelegramIdentityVerified{
+		Provider:       constants.UserOAuthProviderTelegram,
+		ProviderUserID: "10002",
+		Username:       "tg_existing",
+		AuthAt:         time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("loginWithVerifiedTelegram returned error: %v", err)
+	}
+	if gotUser == nil || gotUser.ID != user.ID {
+		t.Fatalf("expected existing user %d, got %+v", user.ID, gotUser)
+	}
+	if token == "" {
+		t.Fatalf("expected token")
+	}
+	if expiresAt.Before(time.Now()) {
+		t.Fatalf("expected future expiresAt")
+	}
+}
+
+func TestTelegramMiniAppLoginReturnsRegistrationDisabledWhenCreatingNewUser(t *testing.T) {
+	svc, _ := setupTelegramOAuthTestService(t)
+	telegramSvc := NewTelegramAuthService(config.TelegramAuthConfig{
+		Enabled:            true,
+		BotToken:           "test-bot-token",
+		LoginExpireSeconds: 300,
+		ReplayTTLSeconds:   300,
+	})
+	telegramSvc.replaySetNX = func(ctx context.Context, key string, value interface{}, ttl time.Duration) (bool, error) {
+		return true, nil
+	}
+	svc.telegramAuthService = telegramSvc
+
+	if _, err := svc.settingService.Update(constants.SettingKeyRegistrationConfig, map[string]interface{}{
+		constants.SettingFieldRegistrationEnabled: false,
+	}); err != nil {
+		t.Fatalf("disable registration failed: %v", err)
+	}
+
+	initData := buildTestTelegramMiniAppInitData(t, "test-bot-token", time.Now().Unix(), `{"id":10003,"first_name":"Mini","last_name":"Blocked","username":"mini_blocked"}`)
+	user, token, expiresAt, err := svc.LoginWithTelegramMiniApp(LoginWithTelegramMiniAppInput{
+		InitData: initData,
+		Context:  context.Background(),
+	})
+	if !errors.Is(err, ErrRegistrationDisabled) {
+		t.Fatalf("expected ErrRegistrationDisabled, got user=%v token=%q expiresAt=%v err=%v", user, token, expiresAt, err)
+	}
+}


### PR DESCRIPTION
## 功能描述

修复关闭注册后，用户仍可通过 Telegram 登录自动创建新账号的问题。

## 背景

当前站点支持普通注册开关控制：当注册关闭时，邮箱注册会被禁止。

不过 Telegram 登录链路中，未绑定身份的用户会走自动建号逻辑。由于这条路径没有复用注册开关校验，即使站点已经关闭注册，首次使用 Telegram 登录的用户仍然会被自动创建，从而绕过注册限制。

这个问题只影响“首次通过 Telegram 登录创建账号”的场景，不应该影响已经绑定 Telegram 的存量用户正常登录。

## 改动内容

- 在 `UserAuthService` 中注入 `SettingService`
- 在 Telegram 自动建号路径中增加注册开关校验
- 当注册已关闭且当前 Telegram 身份尚未绑定账号时，返回 `ErrRegistrationDisabled`
- 在 public Telegram 登录与 Telegram Mini App 登录 handler 中补充对应错误映射，返回 `error.registration_disabled`
- 保持已绑定 Telegram 用户登录逻辑不变

## 技术细节

- 校验位置收敛在 `findOrCreateTelegramUser(...)`，只拦截“需要新建用户”的分支
- 已存在的 Telegram 占位账号或已绑定身份，仍然允许正常登录
- 没有在 handler 层做全量拦截，避免误伤存量已绑定用户
- 同步更新 `NewUserAuthService(...)` 的依赖注入和相关测试构造

## 测试情况

- `go test ./internal/service -run 'Test(LoginWithTelegramMiniAppCreatesUserIdentityAndToken|FindOrCreateTelegramUserRespectsRegistrationSetting|LoginWithTelegramAllowsExistingIdentityWhenRegistrationDisabled|TelegramMiniAppLoginReturnsRegistrationDisabledWhenCreatingNewUser)' -count=1`
- `go test ./internal/http/handlers/public -run '^$'`
- `go test ./internal/http/handlers/channel -run '^$'`

## 影响范围

仅影响：
- 首次通过 Telegram 登录 / Telegram Mini App 登录自动创建账号的场景
- 注册关闭时的 Telegram 登录行为

不影响：
- 普通邮箱注册开关逻辑
- 已绑定 Telegram 账号的存量用户登录
- Telegram 绑定 / 换绑逻辑

## 相关说明

这个修复的目标是让 Telegram 登录和现有注册开关语义保持一致：
关闭注册后，不能再通过 Telegram 首次登录绕过注册限制；但已注册并已绑定 Telegram 的用户仍可继续登录。
