### PR TITLE
fix(member-level): 同 sort_order 场景下达到阈值也能自动升级

### DIFF
--- a/internal/repository/member_level_repository.go
+++ b/internal/repository/member_level_repository.go
@@ -82,7 +82,7 @@ func (r *GormMemberLevelRepository) GetDefault() (*models.MemberLevel, error) {
 // ListAllActive 获取所有启用的等级，按 sort_order DESC
 func (r *GormMemberLevelRepository) ListAllActive() ([]models.MemberLevel, error) {
 	var levels []models.MemberLevel
-	if err := r.db.Where("is_active = ?", true).Order("sort_order desc").Find(&levels).Error; err != nil {
+	if err := r.db.Where("is_active = ?", true).Order("sort_order desc, id desc").Find(&levels).Error; err != nil {
 		return nil, err
 	}
 	return levels, nil

--- a/internal/service/member_level_service.go
+++ b/internal/service/member_level_service.go
@@ -200,7 +200,10 @@ func (s *MemberLevelService) CheckAndUpgrade(userID uint) error {
 	}
 
 	for _, level := range levels {
-		if level.SortOrder <= currentSortOrder {
+		if level.SortOrder < currentSortOrder {
+			continue
+		}
+		if level.ID == user.MemberLevelID {
 			continue
 		}
 		if s.meetsThreshold(user, &level) {

--- a/internal/service/member_level_service_test.go
+++ b/internal/service/member_level_service_test.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dujiao-next/internal/models"
+	"github.com/dujiao-next/internal/repository"
+	"github.com/glebarez/sqlite"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+func newMemberLevelServiceForTest(t *testing.T) (*MemberLevelService, *gorm.DB) {
+	t.Helper()
+
+	dsn := fmt.Sprintf("file:member_level_service_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite failed: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.MemberLevel{}, &models.MemberLevelPrice{}); err != nil {
+		t.Fatalf("auto migrate failed: %v", err)
+	}
+
+	levelRepo := repository.NewMemberLevelRepository(db)
+	priceRepo := repository.NewMemberLevelPriceRepository(db)
+	userRepo := repository.NewUserRepository(db)
+	return NewMemberLevelService(levelRepo, priceRepo, userRepo), db
+}
+
+func createMemberLevelFixture(
+	t *testing.T,
+	db *gorm.DB,
+	slug string,
+	sortOrder int,
+	spendThreshold string,
+	isDefault bool,
+) models.MemberLevel {
+	t.Helper()
+
+	level := models.MemberLevel{
+		NameJSON: models.JSON{
+			"zh-CN": slug,
+		},
+		Slug:              slug,
+		DiscountRate:      models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		RechargeThreshold: models.NewMoneyFromDecimal(decimal.Zero),
+		SpendThreshold:    models.NewMoneyFromDecimal(decimal.RequireFromString(spendThreshold)),
+		IsDefault:         isDefault,
+		SortOrder:         sortOrder,
+		IsActive:          true,
+	}
+	if err := db.Create(&level).Error; err != nil {
+		t.Fatalf("create member level fixture failed: %v", err)
+	}
+	return level
+}
+
+func createUserFixture(t *testing.T, db *gorm.DB, email string, memberLevelID uint) models.User {
+	t.Helper()
+
+	user := models.User{
+		Email:          email,
+		PasswordHash:   "test-hash",
+		Status:         "active",
+		MemberLevelID:  memberLevelID,
+		TotalRecharged: models.NewMoneyFromDecimal(decimal.Zero),
+		TotalSpent:     models.NewMoneyFromDecimal(decimal.Zero),
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create user fixture failed: %v", err)
+	}
+	return user
+}
+
+func TestMemberLevelServiceOnOrderPaidUpgradesWithEqualSortOrder(t *testing.T) {
+	svc, db := newMemberLevelServiceForTest(t)
+	defaultLevel := createMemberLevelFixture(t, db, "default", 0, "0", true)
+	vipLevel := createMemberLevelFixture(t, db, "vip", 0, "0.01", false)
+	user := createUserFixture(t, db, "equal-sort@example.com", defaultLevel.ID)
+
+	if err := svc.OnOrderPaid(user.ID, decimal.RequireFromString("0.01")); err != nil {
+		t.Fatalf("OnOrderPaid failed: %v", err)
+	}
+
+	var updated models.User
+	if err := db.First(&updated, user.ID).Error; err != nil {
+		t.Fatalf("fetch updated user failed: %v", err)
+	}
+	if updated.MemberLevelID != vipLevel.ID {
+		t.Fatalf("expected member_level_id=%d, got %d", vipLevel.ID, updated.MemberLevelID)
+	}
+	if !updated.TotalSpent.Decimal.Equal(decimal.RequireFromString("0.01")) {
+		t.Fatalf("expected total_spent=0.01, got %s", updated.TotalSpent.Decimal.String())
+	}
+}
+
+func TestMemberLevelServiceOnOrderPaidKeepsHigherLevel(t *testing.T) {
+	svc, db := newMemberLevelServiceForTest(t)
+	highLevel := createMemberLevelFixture(t, db, "high", 100, "0", true)
+	_ = createMemberLevelFixture(t, db, "low", 10, "0.01", false)
+	user := createUserFixture(t, db, "no-downgrade@example.com", highLevel.ID)
+
+	if err := svc.OnOrderPaid(user.ID, decimal.RequireFromString("50")); err != nil {
+		t.Fatalf("OnOrderPaid failed: %v", err)
+	}
+
+	var updated models.User
+	if err := db.First(&updated, user.ID).Error; err != nil {
+		t.Fatalf("fetch updated user failed: %v", err)
+	}
+	if updated.MemberLevelID != highLevel.ID {
+		t.Fatalf("expected keep member_level_id=%d, got %d", highLevel.ID, updated.MemberLevelID)
+	}
+}
+
+func TestMemberLevelServiceOnOrderPaidUpgradesToHigherSortOrder(t *testing.T) {
+	svc, db := newMemberLevelServiceForTest(t)
+	defaultLevel := createMemberLevelFixture(t, db, "default2", 0, "0", true)
+	goldLevel := createMemberLevelFixture(t, db, "gold", 20, "0.01", false)
+	user := createUserFixture(t, db, "higher-sort@example.com", defaultLevel.ID)
+
+	if err := svc.OnOrderPaid(user.ID, decimal.RequireFromString("0.01")); err != nil {
+		t.Fatalf("OnOrderPaid failed: %v", err)
+	}
+
+	var updated models.User
+	if err := db.First(&updated, user.ID).Error; err != nil {
+		t.Fatalf("fetch updated user failed: %v", err)
+	}
+	if updated.MemberLevelID != goldLevel.ID {
+		t.Fatalf("expected member_level_id=%d, got %d", goldLevel.ID, updated.MemberLevelID)
+	}
+}


### PR DESCRIPTION
## 背景
Issue #87 反馈会员等级在达到消费阈值后未自动升级。
排查发现一个边界场景：当当前等级与目标等级的 sort_order 相同（后台默认常见为 0）时，原逻辑会直接跳过，导致即使达到阈值也不升级。

## 修改内容
- 调整升级判断：
  - 从 level.SortOrder <= currentSortOrder 改为仅过滤更低等级 level.SortOrder < currentSortOrder
  - 显式跳过当前等级自身，避免重复命中
- 活跃等级查询改为稳定排序：sort_order desc, id desc
- 补充回归测试，覆盖：
  - 相同 sort_order 下达到阈值可升级
  - 已在高等级时不会降级
  - 更高 sort_order 正常升级

## 影响范围
仅会员升级判断与查询排序逻辑，不涉及支付流程改造，不涉及前端显示逻辑。

## 验证
go test -v ./internal/service -run TestMemberLevelServiceOnOrderPaid -count=1

## 关联
- issue: #87