### PR TITLE
refactor(email): 重构邮件服务SMTP认证与连接管理

### DIFF
--- a/internal/service/email_service.go
+++ b/internal/service/email_service.go
@@ -472,10 +472,11 @@ func sendMailPlain(addr, host, from string, to []string, msg []byte, username, p
 const (
 	smtpAuthMechanismPlain = "PLAIN"
 	smtpAuthMechanismLogin = "LOGIN"
-	//还有XOAUTH2等机制，实现太复杂好像就微软这个byd搞了，这里暂不考虑
+	// 还有 XOAUTH2 等机制，当前实现暂不处理。
 )
 
 // authenticateSMTPClient 根据服务端 AUTH 能力选择并执行认证。
+// EmailService 认证策略：优先 LOGIN，回退 PLAIN。
 // 对 smtp.office365.com 的 SMTP Basic/LOGIN 场景，通常需要开启 MFA 并使用应用密码。
 func authenticateSMTPClient(client *smtp.Client, host, username, password string) error {
 	if client == nil {
@@ -492,7 +493,7 @@ func authenticateSMTPClient(client *smtp.Client, host, username, password string
 		return nil
 	}
 
-	switch pickSMTPAuthMechanism(host, advertised) {
+	switch pickSMTPAuthMechanism(advertised) {
 	case smtpAuthMechanismLogin:
 		return client.Auth(newLoginAuth(username, password, host))
 	case smtpAuthMechanismPlain:
@@ -502,17 +503,8 @@ func authenticateSMTPClient(client *smtp.Client, host, username, password string
 	}
 }
 
-// pickSMTPAuthMechanism 在 Office365 场景优先 LOGIN，其它场景保持通用优先级。
-func pickSMTPAuthMechanism(host, advertised string) string {
-	if isOffice365SMTPHost(host) {
-		if hasSMTPAuthMechanism(advertised, smtpAuthMechanismLogin) {
-			return smtpAuthMechanismLogin
-		}
-		if hasSMTPAuthMechanism(advertised, smtpAuthMechanismPlain) {
-			return smtpAuthMechanismPlain
-		}
-		return ""
-	}
+// pickSMTPAuthMechanism 根据服务端 AUTH 能力选择机制，优先 LOGIN，再回退 PLAIN。
+func pickSMTPAuthMechanism(advertised string) string {
 	if hasSMTPAuthMechanism(advertised, smtpAuthMechanismLogin) {
 		return smtpAuthMechanismLogin
 	}
@@ -520,12 +512,6 @@ func pickSMTPAuthMechanism(host, advertised string) string {
 		return smtpAuthMechanismPlain
 	}
 	return ""
-}
-
-// isOffice365SMTPHost 判断是否为 Office365 SMTP 主机。
-func isOffice365SMTPHost(host string) bool {
-	h := strings.ToLower(strings.TrimSpace(host))
-	return h == "smtp.office365.com"
 }
 
 // hasSMTPAuthMechanism 判断服务端 AUTH 扩展是否包含指定机制。

--- a/internal/service/email_service.go
+++ b/internal/service/email_service.go
@@ -167,64 +167,52 @@ func (s *EmailService) sendTextEmail(toEmail, subject, body string) error {
 	if telegramidentity.IsPlaceholderEmail(toEmail) {
 		return nil
 	}
-	if s.cfg == nil || !s.cfg.Enabled {
-		return ErrEmailServiceDisabled
+	from, addr, err := s.prepareSMTPEnvelope(toEmail)
+	if err != nil {
+		return err
 	}
-	if s.cfg.Host == "" || s.cfg.Port == 0 || s.cfg.From == "" {
-		return ErrEmailServiceNotConfigured
-	}
-	if _, err := mail.ParseAddress(toEmail); err != nil {
-		return ErrInvalidEmail
-	}
-
-	from := buildFromAddress(s.cfg.From, s.cfg.FromName)
 	msg := buildEmailMessage(from, toEmail, subject, body)
-
-	addr := fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port)
-	var auth smtp.Auth
-	if s.cfg.Username != "" || s.cfg.Password != "" {
-		auth = smtp.PlainAuth("", s.cfg.Username, s.cfg.Password, s.cfg.Host)
-	}
-
-	if s.cfg.UseSSL {
-		return normalizeEmailSendError(sendMailWithSSL(addr, auth, s.cfg.Host, s.cfg.From, []string{toEmail}, []byte(msg)))
-	}
-	if s.cfg.UseTLS {
-		return normalizeEmailSendError(sendMailWithStartTLS(addr, auth, s.cfg.Host, s.cfg.From, []string{toEmail}, []byte(msg)))
-	}
-	return normalizeEmailSendError(sendMailPlain(addr, auth, s.cfg.Host, s.cfg.From, []string{toEmail}, []byte(msg)))
+	return s.sendSMTPMessage(addr, toEmail, []byte(msg))
 }
 
 func (s *EmailService) sendEmailWithAttachment(toEmail, subject, body, attachName, attachContent string) error {
 	if telegramidentity.IsPlaceholderEmail(toEmail) {
 		return nil
 	}
+	from, addr, err := s.prepareSMTPEnvelope(toEmail)
+	if err != nil {
+		return err
+	}
+	msg := buildEmailMessageWithAttachment(from, toEmail, subject, body, attachName, attachContent)
+	return s.sendSMTPMessage(addr, toEmail, []byte(msg))
+}
+
+// prepareSMTPEnvelope 校验配置与收件人，并返回发件地址与 SMTP 服务器地址。
+func (s *EmailService) prepareSMTPEnvelope(toEmail string) (string, string, error) {
 	if s.cfg == nil || !s.cfg.Enabled {
-		return ErrEmailServiceDisabled
+		return "", "", ErrEmailServiceDisabled
 	}
 	if s.cfg.Host == "" || s.cfg.Port == 0 || s.cfg.From == "" {
-		return ErrEmailServiceNotConfigured
+		return "", "", ErrEmailServiceNotConfigured
 	}
 	if _, err := mail.ParseAddress(toEmail); err != nil {
-		return ErrInvalidEmail
+		return "", "", ErrInvalidEmail
 	}
-
 	from := buildFromAddress(s.cfg.From, s.cfg.FromName)
-	msg := buildEmailMessageWithAttachment(from, toEmail, subject, body, attachName, attachContent)
-
 	addr := fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port)
-	var auth smtp.Auth
-	if s.cfg.Username != "" || s.cfg.Password != "" {
-		auth = smtp.PlainAuth("", s.cfg.Username, s.cfg.Password, s.cfg.Host)
-	}
+	return from, addr, nil
+}
 
+// sendSMTPMessage 根据配置选择 SSL/STARTTLS/明文通道发送邮件。
+func (s *EmailService) sendSMTPMessage(addr, toEmail string, msg []byte) error {
+	recipients := []string{toEmail}
 	if s.cfg.UseSSL {
-		return normalizeEmailSendError(sendMailWithSSL(addr, auth, s.cfg.Host, s.cfg.From, []string{toEmail}, []byte(msg)))
+		return normalizeEmailSendError(sendMailWithSSL(addr, s.cfg.Host, s.cfg.From, recipients, msg, s.cfg.Username, s.cfg.Password))
 	}
 	if s.cfg.UseTLS {
-		return normalizeEmailSendError(sendMailWithStartTLS(addr, auth, s.cfg.Host, s.cfg.From, []string{toEmail}, []byte(msg)))
+		return normalizeEmailSendError(sendMailWithStartTLS(addr, s.cfg.Host, s.cfg.From, recipients, msg, s.cfg.Username, s.cfg.Password))
 	}
-	return normalizeEmailSendError(sendMailPlain(addr, auth, s.cfg.Host, s.cfg.From, []string{toEmail}, []byte(msg)))
+	return normalizeEmailSendError(sendMailPlain(addr, s.cfg.Host, s.cfg.From, recipients, msg, s.cfg.Username, s.cfg.Password))
 }
 
 func buildEmailMessageWithAttachment(from, to, subject, body, attachName, attachContent string) string {
@@ -423,25 +411,31 @@ func buildEmailMessage(from, to, subject, body string) string {
 	return buf.String()
 }
 
-func sendMailWithSSL(addr string, auth smtp.Auth, host, from string, to []string, msg []byte) error {
+func sendMailWithSSL(addr, host, from string, to []string, msg []byte, username, password string) error {
 	conn, err := tls.Dial("tcp", addr, &tls.Config{ServerName: host})
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer func(conn *tls.Conn) {
+		err := conn.Close()
+		if err != nil {
+			fmt.Printf("failed to close TLS connection: %v\n", err)
+		}
+	}(conn)
 
 	client, err := smtp.NewClient(conn, host)
 	if err != nil {
 		return err
 	}
-	defer client.Close()
-
-	if auth != nil {
-		if ok, _ := client.Extension("AUTH"); ok {
-			if err := client.Auth(auth); err != nil {
-				return err
-			}
+	defer func(client *smtp.Client) {
+		err := client.Close()
+		if err != nil {
+			fmt.Printf("failed to close SMTP client: %v\n", err)
 		}
+	}(client)
+
+	if err := authenticateSMTPClient(client, host, username, password); err != nil {
+		return err
 	}
 
 	if err := client.Mail(from); err != nil {
@@ -466,46 +460,170 @@ func sendMailWithSSL(addr string, auth smtp.Auth, host, from string, to []string
 	return client.Quit()
 }
 
-func sendMailWithStartTLS(addr string, auth smtp.Auth, host, from string, to []string, msg []byte) error {
+func sendMailWithStartTLS(addr, host, from string, to []string, msg []byte, username, password string) error {
 	client, err := smtp.Dial(addr)
 	if err != nil {
 		return err
 	}
-	defer client.Close()
+	defer func(client *smtp.Client) {
+		err := client.Close()
+		if err != nil {
+			fmt.Printf("failed to close SMTP client: %v\n", err)
+		}
+	}(client)
 
 	if err := client.StartTLS(&tls.Config{ServerName: host}); err != nil {
 		return err
 	}
 
-	if auth != nil {
-		if ok, _ := client.Extension("AUTH"); ok {
-			if err := client.Auth(auth); err != nil {
-				return err
-			}
-		}
+	if err := authenticateSMTPClient(client, host, username, password); err != nil {
+		return err
 	}
 
 	return sendSMTPData(client, from, to, msg)
 }
 
-func sendMailPlain(addr string, auth smtp.Auth, host, from string, to []string, msg []byte) error {
+func sendMailPlain(addr, host, from string, to []string, msg []byte, username, password string) error {
 	client, err := smtp.Dial(addr)
 	if err != nil {
 		return err
 	}
-	defer client.Close()
-
-	if auth != nil {
-		if ok, _ := client.Extension("AUTH"); ok {
-			if err := client.Auth(auth); err != nil {
-				return err
-			}
+	defer func(client *smtp.Client) {
+		err := client.Close()
+		if err != nil {
+			fmt.Printf("failed to close SMTP client: %v\n", err)
 		}
+	}(client)
+
+	if err := authenticateSMTPClient(client, host, username, password); err != nil {
+		return err
 	}
 
 	return sendSMTPData(client, from, to, msg)
 }
 
+const (
+	smtpAuthMechanismPlain = "PLAIN"
+	smtpAuthMechanismLogin = "LOGIN"
+	//还有XOAUTH2等机制，实现太复杂好像就微软这个byd搞了，这里暂不考虑
+)
+
+// authenticateSMTPClient 根据服务端 AUTH 能力选择并执行认证。
+// 对 smtp.office365.com 的 SMTP Basic/LOGIN 场景，通常需要开启 MFA 并使用应用密码。
+func authenticateSMTPClient(client *smtp.Client, host, username, password string) error {
+	if client == nil {
+		return nil
+	}
+	username = strings.TrimSpace(username)
+	password = strings.TrimSpace(password)
+	if username == "" && password == "" {
+		return nil
+	}
+
+	ok, advertised := client.Extension("AUTH")
+	if !ok {
+		return nil
+	}
+
+	switch pickSMTPAuthMechanism(host, advertised) {
+	case smtpAuthMechanismLogin:
+		return client.Auth(newLoginAuth(username, password, host))
+	case smtpAuthMechanismPlain:
+		return client.Auth(smtp.PlainAuth("", username, password, host))
+	default:
+		return fmt.Errorf("smtp auth mechanism not supported (server AUTH=%q)", advertised)
+	}
+}
+
+// pickSMTPAuthMechanism 在 Office365 场景优先 LOGIN，其它场景保持通用优先级。
+func pickSMTPAuthMechanism(host, advertised string) string {
+	if isOffice365SMTPHost(host) {
+		if hasSMTPAuthMechanism(advertised, smtpAuthMechanismLogin) {
+			return smtpAuthMechanismLogin
+		}
+		if hasSMTPAuthMechanism(advertised, smtpAuthMechanismPlain) {
+			return smtpAuthMechanismPlain
+		}
+		return ""
+	}
+	if hasSMTPAuthMechanism(advertised, smtpAuthMechanismLogin) {
+		return smtpAuthMechanismLogin
+	}
+	if hasSMTPAuthMechanism(advertised, smtpAuthMechanismPlain) {
+		return smtpAuthMechanismPlain
+	}
+	return ""
+}
+
+// isOffice365SMTPHost 判断是否为 Office365 SMTP 主机。
+func isOffice365SMTPHost(host string) bool {
+	h := strings.ToLower(strings.TrimSpace(host))
+	return h == "smtp.office365.com"
+}
+
+// hasSMTPAuthMechanism 判断服务端 AUTH 扩展是否包含指定机制。
+func hasSMTPAuthMechanism(advertised, mechanism string) bool {
+	if strings.TrimSpace(mechanism) == "" {
+		return false
+	}
+	tokens := strings.Fields(strings.ToUpper(strings.TrimSpace(advertised)))
+	needle := strings.ToUpper(strings.TrimSpace(mechanism))
+	for _, token := range tokens {
+		if token == needle {
+			return true
+		}
+	}
+	return false
+}
+
+type loginAuth struct {
+	username string
+	password string
+	host     string
+	userSent bool
+}
+
+// newLoginAuth 构造 AUTH LOGIN 认证器。
+func newLoginAuth(username, password, host string) smtp.Auth {
+	return &loginAuth{username: username, password: password, host: host}
+}
+
+// Start 校验连接安全性并声明 LOGIN 机制。
+func (a *loginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
+	if server == nil {
+		return "", nil, fmt.Errorf("smtp server info is required")
+	}
+	if server.Name != a.host {
+		return "", nil, fmt.Errorf("wrong host name")
+	}
+	if !server.TLS {
+		return "", nil, fmt.Errorf("unencrypted connection")
+	}
+	a.userSent = false
+	return smtpAuthMechanismLogin, nil, nil
+}
+
+// Next 按服务端 challenge 顺序回送用户名与密码。
+func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
+	if !more {
+		return nil, nil
+	}
+	challenge := strings.ToLower(strings.TrimSpace(string(fromServer)))
+	if strings.Contains(challenge, "password") {
+		return []byte(a.password), nil
+	}
+	if strings.Contains(challenge, "username") || strings.Contains(challenge, "user name") {
+		a.userSent = true
+		return []byte(a.username), nil
+	}
+	if !a.userSent {
+		a.userSent = true
+		return []byte(a.username), nil
+	}
+	return []byte(a.password), nil
+}
+
+// sendSMTPData 发送 SMTP Envelope 与邮件正文。
 func sendSMTPData(client *smtp.Client, from string, to []string, msg []byte) error {
 	if err := client.Mail(from); err != nil {
 		return err
@@ -528,6 +646,7 @@ func sendSMTPData(client *smtp.Client, from string, to []string, msg []byte) err
 	return client.Quit()
 }
 
+// normalizeEmailSendError 将可识别的收件人拒绝错误归一化为业务错误码。
 func normalizeEmailSendError(err error) error {
 	if err == nil {
 		return nil
@@ -538,6 +657,7 @@ func normalizeEmailSendError(err error) error {
 	return err
 }
 
+// isEmailRecipientRejected 识别常见 SMTP 收件人不存在/被拒绝错误。
 func isEmailRecipientRejected(err error) bool {
 	if err == nil {
 		return false

--- a/internal/service/email_service.go
+++ b/internal/service/email_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dujiao-next/internal/config"
 	"github.com/dujiao-next/internal/constants"
 	"github.com/dujiao-next/internal/i18n"
+	"github.com/dujiao-next/internal/logger"
 	"github.com/dujiao-next/internal/models"
 	"github.com/dujiao-next/internal/telegramidentity"
 )
@@ -411,66 +412,35 @@ func buildEmailMessage(from, to, subject, body string) string {
 	return buf.String()
 }
 
-func sendMailWithSSL(addr, host, from string, to []string, msg []byte, username, password string) error {
+func sendMailWithSSL(addr, host, from string, to []string, msg []byte, username, password string) (err error) {
 	conn, err := tls.Dial("tcp", addr, &tls.Config{ServerName: host})
 	if err != nil {
 		return err
 	}
-	defer func(conn *tls.Conn) {
-		err := conn.Close()
-		if err != nil {
-			fmt.Printf("failed to close TLS connection: %v\n", err)
-		}
-	}(conn)
 
 	client, err := smtp.NewClient(conn, host)
 	if err != nil {
+		if closeErr := conn.Close(); closeErr != nil && !isSMTPAlreadyClosedError(closeErr) {
+			logger.Debugw("smtp_tls_conn_close_failed", "host", host, "addr", addr, "error", closeErr)
+		}
 		return err
 	}
-	defer func(client *smtp.Client) {
-		err := client.Close()
-		if err != nil {
-			fmt.Printf("failed to close SMTP client: %v\n", err)
-		}
-	}(client)
+	defer closeSMTPClientOnError(client, &err, host, addr)
 
 	if err := authenticateSMTPClient(client, host, username, password); err != nil {
 		return err
 	}
 
-	if err := client.Mail(from); err != nil {
-		return err
-	}
-	for _, rcpt := range to {
-		if err := client.Rcpt(rcpt); err != nil {
-			return err
-		}
-	}
-	w, err := client.Data()
-	if err != nil {
-		return err
-	}
-	_, err = w.Write(msg)
-	if err != nil {
-		return err
-	}
-	if err := w.Close(); err != nil {
-		return err
-	}
-	return client.Quit()
+	err = sendSMTPData(client, host, addr, from, to, msg)
+	return err
 }
 
-func sendMailWithStartTLS(addr, host, from string, to []string, msg []byte, username, password string) error {
+func sendMailWithStartTLS(addr, host, from string, to []string, msg []byte, username, password string) (err error) {
 	client, err := smtp.Dial(addr)
 	if err != nil {
 		return err
 	}
-	defer func(client *smtp.Client) {
-		err := client.Close()
-		if err != nil {
-			fmt.Printf("failed to close SMTP client: %v\n", err)
-		}
-	}(client)
+	defer closeSMTPClientOnError(client, &err, host, addr)
 
 	if err := client.StartTLS(&tls.Config{ServerName: host}); err != nil {
 		return err
@@ -480,26 +450,23 @@ func sendMailWithStartTLS(addr, host, from string, to []string, msg []byte, user
 		return err
 	}
 
-	return sendSMTPData(client, from, to, msg)
+	err = sendSMTPData(client, host, addr, from, to, msg)
+	return err
 }
 
-func sendMailPlain(addr, host, from string, to []string, msg []byte, username, password string) error {
+func sendMailPlain(addr, host, from string, to []string, msg []byte, username, password string) (err error) {
 	client, err := smtp.Dial(addr)
 	if err != nil {
 		return err
 	}
-	defer func(client *smtp.Client) {
-		err := client.Close()
-		if err != nil {
-			fmt.Printf("failed to close SMTP client: %v\n", err)
-		}
-	}(client)
+	defer closeSMTPClientOnError(client, &err, host, addr)
 
 	if err := authenticateSMTPClient(client, host, username, password); err != nil {
 		return err
 	}
 
-	return sendSMTPData(client, from, to, msg)
+	err = sendSMTPData(client, host, addr, from, to, msg)
+	return err
 }
 
 const (
@@ -623,8 +590,13 @@ func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 	return []byte(a.password), nil
 }
 
+type smtpSessionCloser interface {
+	Quit() error
+	Close() error
+}
+
 // sendSMTPData 发送 SMTP Envelope 与邮件正文。
-func sendSMTPData(client *smtp.Client, from string, to []string, msg []byte) error {
+func sendSMTPData(client *smtp.Client, host, addr, from string, to []string, msg []byte) error {
 	if err := client.Mail(from); err != nil {
 		return err
 	}
@@ -643,7 +615,45 @@ func sendSMTPData(client *smtp.Client, from string, to []string, msg []byte) err
 	if err := w.Close(); err != nil {
 		return err
 	}
-	return client.Quit()
+	return quitSMTPClient(client, host, addr)
+}
+
+// quitSMTPClient 优先执行 SMTP QUIT；仅在 QUIT 失败时补偿 Close 回收连接。
+func quitSMTPClient(client smtpSessionCloser, host, addr string) error {
+	if client == nil {
+		return nil
+	}
+	if err := client.Quit(); err != nil {
+		if closeErr := client.Close(); closeErr != nil && !isSMTPAlreadyClosedError(closeErr) {
+			logger.Debugw("smtp_close_after_quit_failed", "host", host, "addr", addr, "error", closeErr)
+		}
+		return err
+	}
+	return nil
+}
+
+// closeSMTPClientOnError 仅在发送流程异常时兜底 Close，避免成功路径重复关闭噪音。
+func closeSMTPClientOnError(client *smtp.Client, sendErr *error, host, addr string) {
+	if client == nil || sendErr == nil || *sendErr == nil {
+		return
+	}
+	if err := client.Close(); err != nil && !isSMTPAlreadyClosedError(err) {
+		logger.Debugw("smtp_close_failed", "host", host, "addr", addr, "error", err)
+	}
+}
+
+// isSMTPAlreadyClosedError 识别连接已关闭类错误，避免重复记录无效噪音。
+func isSMTPAlreadyClosedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(strings.TrimSpace(err.Error()))
+	if message == "" {
+		return false
+	}
+	return strings.Contains(message, "use of closed network connection") ||
+		strings.Contains(message, "closed connection") ||
+		strings.Contains(message, "connection is closed")
 }
 
 // normalizeEmailSendError 将可识别的收件人拒绝错误归一化为业务错误码。

--- a/internal/service/email_service_test.go
+++ b/internal/service/email_service_test.go
@@ -421,3 +421,70 @@ func TestEmailServiceSendOffice365Integration(t *testing.T) {
 
 	t.Logf("email sent via smtp.office365.com:587 to %s", to)
 }
+
+type fakeSMTPSessionCloser struct {
+	quitErr  error
+	closeErr error
+	quitCnt  int
+	closeCnt int
+}
+
+func (f *fakeSMTPSessionCloser) Quit() error {
+	f.quitCnt++
+	return f.quitErr
+}
+
+func (f *fakeSMTPSessionCloser) Close() error {
+	f.closeCnt++
+	return f.closeErr
+}
+
+func TestQuitSMTPClient(t *testing.T) {
+	t.Run("quit_success_no_close", func(t *testing.T) {
+		fake := &fakeSMTPSessionCloser{}
+		if err := quitSMTPClient(fake, "smtp.office365.com", "smtp.office365.com:587"); err != nil {
+			t.Fatalf("quitSMTPClient() returned error: %v", err)
+		}
+		if fake.quitCnt != 1 {
+			t.Fatalf("Quit() called %d times, want 1", fake.quitCnt)
+		}
+		if fake.closeCnt != 0 {
+			t.Fatalf("Close() called %d times, want 0", fake.closeCnt)
+		}
+	})
+
+	t.Run("quit_failed_fallback_close", func(t *testing.T) {
+		quitErr := errors.New("421 service not available")
+		fake := &fakeSMTPSessionCloser{quitErr: quitErr}
+		if err := quitSMTPClient(fake, "smtp.office365.com", "smtp.office365.com:587"); !errors.Is(err, quitErr) {
+			t.Fatalf("quitSMTPClient() error = %v, want %v", err, quitErr)
+		}
+		if fake.quitCnt != 1 {
+			t.Fatalf("Quit() called %d times, want 1", fake.quitCnt)
+		}
+		if fake.closeCnt != 1 {
+			t.Fatalf("Close() called %d times, want 1", fake.closeCnt)
+		}
+	})
+}
+
+func TestIsSMTPAlreadyClosedError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "closed_network_connection", err: errors.New("use of closed network connection"), want: true},
+		{name: "connection_is_closed", err: errors.New("connection is closed"), want: true},
+		{name: "other_error", err: errors.New("dial tcp timeout"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSMTPAlreadyClosedError(tt.err); got != tt.want {
+				t.Fatalf("isSMTPAlreadyClosedError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/service/email_service_test.go
+++ b/internal/service/email_service_test.go
@@ -1,10 +1,15 @@
 package service
 
 import (
+	"crypto/tls"
 	"errors"
+	"fmt"
+	"net/smtp"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/dujiao-next/internal/config"
 	"github.com/dujiao-next/internal/i18n"
 	"github.com/dujiao-next/internal/models"
 
@@ -256,4 +261,163 @@ func TestBuildOrderStatusContentFromTemplateIncludesSiteBrand(t *testing.T) {
 	if !strings.Contains(body, "站点：示例站点 https://example.com/shop") {
 		t.Fatalf("body should contain site_name and site_url, got: %s", body)
 	}
+}
+
+func TestPickSMTPAuthMechanism(t *testing.T) {
+	tests := []struct {
+		name       string
+		host       string
+		advertised string
+		want       string
+	}{
+		{name: "office365_prefer_login", host: "smtp.office365.com", advertised: "PLAIN LOGIN XOAUTH2", want: smtpAuthMechanismLogin},
+		{name: "plain_only", host: "smtp.example.com", advertised: "PLAIN", want: smtpAuthMechanismPlain},
+		{name: "case_and_space", host: "smtp.example.com", advertised: "  login   xoauth2 ", want: smtpAuthMechanismLogin},
+		{name: "unsupported", host: "smtp.example.com", advertised: "CRAM-MD5", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pickSMTPAuthMechanism(tt.host, tt.advertised); got != tt.want {
+				t.Fatalf("pickSMTPAuthMechanism() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoginAuth(t *testing.T) {
+	auth := newLoginAuth("user@example.com", "pwd", "smtp.office365.com")
+	login, ok := auth.(*loginAuth)
+	if !ok {
+		t.Fatal("newLoginAuth() should return *loginAuth")
+	}
+
+	if _, _, err := login.Start(&smtp.ServerInfo{Name: "smtp.office365.com", TLS: true}); err != nil {
+		t.Fatalf("Start() returned unexpected error: %v", err)
+	}
+
+	resp, err := login.Next([]byte("Username:"), true)
+	if err != nil || string(resp) != "user@example.com" {
+		t.Fatalf("Next(username) = %q, %v", string(resp), err)
+	}
+
+	resp, err = login.Next([]byte("Password:"), true)
+	if err != nil || string(resp) != "pwd" {
+		t.Fatalf("Next(password) = %q, %v", string(resp), err)
+	}
+
+	resp, err = login.Next(nil, false)
+	if err != nil || resp != nil {
+		t.Fatalf("Next(done) = %v, %v; want nil, nil", resp, err)
+	}
+}
+
+func TestLoginAuthRejectsInsecureRemoteConnection(t *testing.T) {
+	auth := newLoginAuth("user@example.com", "pwd", "smtp.office365.com")
+	login := auth.(*loginAuth)
+
+	if _, _, err := login.Start(&smtp.ServerInfo{Name: "smtp.office365.com", TLS: false}); err == nil {
+		t.Fatal("Start() should reject insecure remote connection")
+	}
+}
+
+func TestSMTPServerAuthExtensions(t *testing.T) {
+	if strings.TrimSpace(os.Getenv("TEST_SMTP_AUTH_CHECK")) != "1" {
+		t.Skip("set TEST_SMTP_AUTH_CHECK=1 to check smtp.office365.com:587 AUTH capabilities")
+	}
+
+	host := "smtp.office365.com"
+	port := 587
+	useStartTLS := true
+	insecureSkipVerify := strings.EqualFold(strings.TrimSpace(os.Getenv("TEST_SMTP_INSECURE_SKIP_VERIFY")), "1") ||
+		strings.EqualFold(strings.TrimSpace(os.Getenv("TEST_SMTP_INSECURE_SKIP_VERIFY")), "true")
+
+	addr := fmt.Sprintf("%s:%d", host, port)
+	client, closeFn, err := newSMTPTestClient(addr, host, port, useStartTLS, insecureSkipVerify)
+	if err != nil {
+		t.Fatalf("connect smtp server failed: %v", err)
+	}
+	defer closeFn()
+
+	ok, authLine := client.Extension("AUTH")
+	if !ok {
+		t.Logf("smtp server %s does not advertise AUTH", addr)
+		return
+	}
+
+	mechanisms := strings.Fields(strings.ToUpper(strings.TrimSpace(authLine)))
+	if len(mechanisms) == 0 {
+		t.Fatalf("smtp AUTH extension is empty: %q", authLine)
+	}
+
+	t.Logf("smtp server %s supports AUTH: %s", addr, strings.Join(mechanisms, ", "))
+}
+
+func newSMTPTestClient(addr, host string, port int, useStartTLS, insecureSkipVerify bool) (*smtp.Client, func(), error) {
+	if port == 465 {
+		conn, err := tls.Dial("tcp", addr, &tls.Config{ServerName: host, InsecureSkipVerify: insecureSkipVerify})
+		if err != nil {
+			return nil, nil, err
+		}
+		client, err := smtp.NewClient(conn, host)
+		if err != nil {
+			_ = conn.Close()
+			return nil, nil, err
+		}
+		return client, func() {
+			_ = client.Quit()
+			_ = conn.Close()
+		}, nil
+	}
+
+	client, err := smtp.Dial(addr)
+	if err != nil {
+		return nil, nil, err
+	}
+	if useStartTLS {
+		if err := client.StartTLS(&tls.Config{ServerName: host, InsecureSkipVerify: insecureSkipVerify}); err != nil {
+			_ = client.Close()
+			return nil, nil, err
+		}
+	}
+	return client, func() {
+		_ = client.Quit()
+		_ = client.Close()
+	}, nil
+}
+
+// 仅是针对 Office365 SMTP 服务器的集成测试，确保 EmailService 能够成功发送邮件并正确处理服务器的响应。
+// 需要在环境变量中设置 TEST_OFFICE365_SEND=1 和有效的 TEST_OFFICE365_PASSWORD 来运行此测试。
+func TestEmailServiceSendOffice365Integration(t *testing.T) {
+	if strings.TrimSpace(os.Getenv("TEST_OFFICE365_SEND")) != "1" {
+		t.Skip("set TEST_OFFICE365_SEND=1 to send a real email via Office365")
+	}
+
+	password := strings.TrimSpace(os.Getenv("TEST_OFFICE365_PASSWORD"))
+	if password == "" {
+		t.Skip("set TEST_OFFICE365_PASSWORD")
+	}
+
+	to := strings.TrimSpace(os.Getenv("TEST_OFFICE365_TO"))
+	if to == "" {
+		to = "no_reply@phj233.top"
+	}
+
+	svc := NewEmailService(&config.EmailConfig{
+		Enabled:  true,
+		Host:     "smtp.office365.com",
+		Port:     587,
+		Username: "no_reply@phj233.top",
+		Password: password,
+		From:     "no_reply@phj233.top",
+		FromName: "Dujiao Next",
+		UseTLS:   true,
+		UseSSL:   false,
+	})
+
+	if err := svc.SendCustomEmail(to, "Office365 SMTP integration test", "This is a real email sent by EmailService integration test."); err != nil {
+		t.Fatalf("SendCustomEmail() failed: %v", err)
+	}
+
+	t.Logf("email sent via smtp.office365.com:587 to %s", to)
 }

--- a/internal/service/email_service_test.go
+++ b/internal/service/email_service_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/smtp"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -266,19 +267,18 @@ func TestBuildOrderStatusContentFromTemplateIncludesSiteBrand(t *testing.T) {
 func TestPickSMTPAuthMechanism(t *testing.T) {
 	tests := []struct {
 		name       string
-		host       string
 		advertised string
 		want       string
 	}{
-		{name: "office365_prefer_login", host: "smtp.office365.com", advertised: "PLAIN LOGIN XOAUTH2", want: smtpAuthMechanismLogin},
-		{name: "plain_only", host: "smtp.example.com", advertised: "PLAIN", want: smtpAuthMechanismPlain},
-		{name: "case_and_space", host: "smtp.example.com", advertised: "  login   xoauth2 ", want: smtpAuthMechanismLogin},
-		{name: "unsupported", host: "smtp.example.com", advertised: "CRAM-MD5", want: ""},
+		{name: "prefer_login_when_both_exist", advertised: "PLAIN LOGIN XOAUTH2", want: smtpAuthMechanismLogin},
+		{name: "plain_only", advertised: "PLAIN", want: smtpAuthMechanismPlain},
+		{name: "case_and_space", advertised: "  login   xoauth2 ", want: smtpAuthMechanismLogin},
+		{name: "unsupported", advertised: "CRAM-MD5", want: ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := pickSMTPAuthMechanism(tt.host, tt.advertised); got != tt.want {
+			if got := pickSMTPAuthMechanism(tt.advertised); got != tt.want {
 				t.Fatalf("pickSMTPAuthMechanism() = %q, want %q", got, tt.want)
 			}
 		})
@@ -322,22 +322,38 @@ func TestLoginAuthRejectsInsecureRemoteConnection(t *testing.T) {
 }
 
 func TestSMTPServerAuthExtensions(t *testing.T) {
-	if strings.TrimSpace(os.Getenv("TEST_SMTP_AUTH_CHECK")) != "1" {
-		t.Skip("set TEST_SMTP_AUTH_CHECK=1 to check smtp.office365.com:587 AUTH capabilities")
+	host := strings.TrimSpace(os.Getenv("TEST_SMTP_HOST"))
+	if host == "" {
+		host = "smtp.office365.com"
 	}
 
-	host := "smtp.office365.com"
 	port := 587
+	if rawPort := strings.TrimSpace(os.Getenv("TEST_SMTP_PORT")); rawPort != "" {
+		if parsed, err := strconv.Atoi(rawPort); err == nil && parsed > 0 {
+			port = parsed
+		}
+	}
+
 	useStartTLS := true
-	insecureSkipVerify := strings.EqualFold(strings.TrimSpace(os.Getenv("TEST_SMTP_INSECURE_SKIP_VERIFY")), "1") ||
-		strings.EqualFold(strings.TrimSpace(os.Getenv("TEST_SMTP_INSECURE_SKIP_VERIFY")), "true")
+	if rawStartTLS := strings.TrimSpace(os.Getenv("TEST_SMTP_USE_STARTTLS")); rawStartTLS != "" {
+		if parsed, err := strconv.ParseBool(rawStartTLS); err == nil {
+			useStartTLS = parsed
+		}
+	}
+
+	insecureSkipVerify := false
+	if rawInsecure := strings.TrimSpace(os.Getenv("TEST_SMTP_INSECURE_SKIP_VERIFY")); rawInsecure != "" {
+		if parsed, err := strconv.ParseBool(rawInsecure); err == nil {
+			insecureSkipVerify = parsed
+		}
+	}
 
 	addr := fmt.Sprintf("%s:%d", host, port)
 	client, closeFn, err := newSMTPTestClient(addr, host, port, useStartTLS, insecureSkipVerify)
 	if err != nil {
 		t.Fatalf("connect smtp server failed: %v", err)
 	}
-	defer closeFn()
+	t.Cleanup(closeFn)
 
 	ok, authLine := client.Extension("AUTH")
 	if !ok {
@@ -365,8 +381,9 @@ func newSMTPTestClient(addr, host string, port int, useStartTLS, insecureSkipVer
 			return nil, nil, err
 		}
 		return client, func() {
-			_ = client.Quit()
-			_ = conn.Close()
+			if err := client.Quit(); err != nil {
+				_ = client.Close()
+			}
 		}, nil
 	}
 
@@ -381,8 +398,9 @@ func newSMTPTestClient(addr, host string, port int, useStartTLS, insecureSkipVer
 		}
 	}
 	return client, func() {
-		_ = client.Quit()
-		_ = client.Close()
+		if err := client.Quit(); err != nil {
+			_ = client.Close()
+		}
 	}, nil
 }
 
@@ -393,6 +411,11 @@ func TestEmailServiceSendOffice365Integration(t *testing.T) {
 		t.Skip("set TEST_OFFICE365_SEND=1 to send a real email via Office365")
 	}
 
+	username := strings.TrimSpace(os.Getenv("TEST_OFFICE365_USERNAME"))
+	if username == "" {
+		t.Skip("set TEST_OFFICE365_USERNAME")
+	}
+
 	password := strings.TrimSpace(os.Getenv("TEST_OFFICE365_PASSWORD"))
 	if password == "" {
 		t.Skip("set TEST_OFFICE365_PASSWORD")
@@ -400,16 +423,21 @@ func TestEmailServiceSendOffice365Integration(t *testing.T) {
 
 	to := strings.TrimSpace(os.Getenv("TEST_OFFICE365_TO"))
 	if to == "" {
-		to = "no_reply@phj233.top"
+		t.Skip("set TEST_OFFICE365_TO")
+	}
+
+	from := strings.TrimSpace(os.Getenv("TEST_OFFICE365_FROM"))
+	if from == "" {
+		from = username
 	}
 
 	svc := NewEmailService(&config.EmailConfig{
 		Enabled:  true,
 		Host:     "smtp.office365.com",
 		Port:     587,
-		Username: "no_reply@phj233.top",
+		Username: username,
 		Password: password,
-		From:     "no_reply@phj233.top",
+		From:     from,
 		FromName: "Dujiao Next",
 		UseTLS:   true,
 		UseSSL:   false,


### PR DESCRIPTION
- 提取SMTP信封准备逻辑到独立的prepareSMTPEnvelope方法
- 实现统一的SMTP消息发送接口sendSMTPMessage支持SSL/STARTTLS/明文
- 添加对Office365 SMTP LOGIN认证机制的支持
- 实现SMTP认证机制自动选择与服务端能力检测
- 优化连接关闭逻辑并添加错误处理
- 增加详细的单元测试覆盖认证流程与集成场景