### PR TITLE
新增：站点图标配置字段

### DIFF
--- a/internal/service/setting_normalize.go
+++ b/internal/service/setting_normalize.go
@@ -174,6 +174,7 @@ func normalizeSiteBrand(raw interface{}) map[string]interface{} {
 	result := map[string]interface{}{
 		"site_name":        "",
 		"site_url":         "",
+		"site_icon":        "",
 		"site_description": normalizeSiteLocalizedField(nil),
 	}
 	brandMap, ok := raw.(map[string]interface{})
@@ -182,6 +183,7 @@ func normalizeSiteBrand(raw interface{}) map[string]interface{} {
 	}
 	result["site_name"] = normalizeSettingText(brandMap["site_name"])
 	result["site_url"] = strings.TrimRight(normalizeSettingText(brandMap["site_url"]), "/")
+	result["site_icon"] = normalizeSettingText(brandMap["site_icon"])
 	result["site_description"] = normalizeSiteLocalizedField(brandMap["site_description"])
 	return result
 }

--- a/internal/service/setting_normalize_test.go
+++ b/internal/service/setting_normalize_test.go
@@ -72,6 +72,7 @@ func TestUpdateSiteSettingNormalized(t *testing.T) {
 		"brand": map[string]interface{}{
 			"site_name": 123,
 			"site_url":  "  https://example.com/path/  ",
+			"site_icon": "  /uploads/site/icon.png  ",
 		},
 		"contact": map[string]interface{}{
 			"telegram": "  https://t.me/demo  ",
@@ -167,6 +168,9 @@ func TestUpdateSiteSettingNormalized(t *testing.T) {
 	}
 	if brand["site_url"] != "https://example.com/path" {
 		t.Fatalf("unexpected brand.site_url: %v", brand["site_url"])
+	}
+	if brand["site_icon"] != "/uploads/site/icon.png" {
+		t.Fatalf("unexpected brand.site_icon: %v", brand["site_icon"])
 	}
 
 	contact, ok := result["contact"].(map[string]interface{})
@@ -328,6 +332,9 @@ func TestUpdateSiteSettingNormalizedDefaultAbout(t *testing.T) {
 		t.Fatalf("unexpected default brand payload: %+v", brand)
 	}
 	if brand["site_url"] != "" {
+		t.Fatalf("unexpected default brand payload: %+v", brand)
+	}
+	if brand["site_icon"] != "" {
 		t.Fatalf("unexpected default brand payload: %+v", brand)
 	}
 	scripts, ok := result["scripts"].([]interface{})


### PR DESCRIPTION
新增 site_config.brand.site_icon 配置字段，用于保存自定义网站图标地址。

关联：
- admin: https://github.com/dujiao-next/admin/pull/34
- user: https://github.com/dujiao-next/user/pull/21

测试：
- go test ./internal/service ./internal/web