### PR TITLE
feat: notification center: Split Order Alert Settings

### DIFF
--- a/internal/repository/dashboard_repository.go
+++ b/internal/repository/dashboard_repository.go
@@ -16,6 +16,7 @@ import (
 // 说明：仅聚合统计数据，不承载业务规则。
 type DashboardRepository interface {
 	GetOverview(startAt, endAt time.Time) (DashboardOverviewRow, error)
+	GetPaymentOrderAlertCounts(startAt, endAt time.Time) (DashboardPaymentOrderAlertCountsRow, error)
 	GetOrderTrends(startAt, endAt time.Time) ([]DashboardOrderTrendRow, error)
 	GetPaymentTrends(startAt, endAt time.Time) ([]DashboardPaymentTrendRow, error)
 	GetProfitOverview(startAt, endAt time.Time) (DashboardProfitOverviewRow, error)
@@ -41,6 +42,12 @@ type DashboardOverviewRow struct {
 	NewUsers             int64
 	ActiveProducts       int64
 	Currency             string
+}
+
+// DashboardPaymentOrderAlertCountsRow 支付订单告警计数
+type DashboardPaymentOrderAlertCountsRow struct {
+	PendingPaymentOrders int64
+	PaymentsFailed       int64
 }
 
 // DashboardProfitOverviewRow 利润总览原始统计结果
@@ -264,6 +271,25 @@ func (r *GormDashboardRepository) GetOverview(startAt, endAt time.Time) (Dashboa
 			Order("id DESC").
 			Limit(1).
 			Pluck("currency", &result.Currency).Error
+	}
+
+	return result, nil
+}
+
+// GetPaymentOrderAlertCounts 获取支付订单告警计数
+func (r *GormDashboardRepository) GetPaymentOrderAlertCounts(startAt, endAt time.Time) (DashboardPaymentOrderAlertCountsRow, error) {
+	result := DashboardPaymentOrderAlertCountsRow{}
+
+	if err := r.db.Model(&models.Order{}).
+		Where("parent_id IS NULL AND status = ? AND created_at >= ? AND created_at < ?", constants.OrderStatusPendingPayment, startAt, endAt).
+		Count(&result.PendingPaymentOrders).Error; err != nil {
+		return result, err
+	}
+
+	if err := onlinePaymentBase(r.db, startAt, endAt).
+		Where("status = ?", constants.PaymentStatusFailed).
+		Count(&result.PaymentsFailed).Error; err != nil {
+		return result, err
 	}
 
 	return result, nil

--- a/internal/repository/dashboard_repository_test.go
+++ b/internal/repository/dashboard_repository_test.go
@@ -335,6 +335,86 @@ func TestPaymentStatsExcludeWalletProvider(t *testing.T) {
 	}
 }
 
+func TestGetPaymentOrderAlertCountsExcludesChildOrdersAndWalletPayments(t *testing.T) {
+	repo, db := setupDashboardRepositoryTest(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	parentOrder := &models.Order{
+		OrderNo:        "DJ-PENDING-001",
+		Status:         constants.OrderStatusPendingPayment,
+		Currency:       "CNY",
+		OriginalAmount: models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		DiscountAmount: models.NewMoneyFromDecimal(decimal.Zero),
+		TotalAmount:    models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := db.Create(parentOrder).Error; err != nil {
+		t.Fatalf("create parent pending order failed: %v", err)
+	}
+
+	childOrder := &models.Order{
+		OrderNo:        "DJ-PENDING-001-01",
+		ParentID:       &parentOrder.ID,
+		Status:         constants.OrderStatusPendingPayment,
+		Currency:       "CNY",
+		OriginalAmount: models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		DiscountAmount: models.NewMoneyFromDecimal(decimal.Zero),
+		TotalAmount:    models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := db.Create(childOrder).Error; err != nil {
+		t.Fatalf("create child pending order failed: %v", err)
+	}
+
+	onlineFailed := &models.Payment{
+		OrderID:         parentOrder.ID,
+		ChannelID:       1,
+		ProviderType:    constants.PaymentProviderOfficial,
+		ChannelType:     constants.PaymentChannelTypeAlipay,
+		InteractionMode: constants.PaymentInteractionRedirect,
+		Amount:          models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		FeeRate:         models.NewMoneyFromDecimal(decimal.Zero),
+		FeeAmount:       models.NewMoneyFromDecimal(decimal.Zero),
+		Currency:        "CNY",
+		Status:          constants.PaymentStatusFailed,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := db.Create(onlineFailed).Error; err != nil {
+		t.Fatalf("create online failed payment failed: %v", err)
+	}
+
+	walletFailed := &models.Payment{
+		OrderID:         parentOrder.ID,
+		ProviderType:    constants.PaymentProviderWallet,
+		ChannelType:     constants.PaymentChannelTypeBalance,
+		InteractionMode: constants.PaymentInteractionBalance,
+		Amount:          models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		FeeRate:         models.NewMoneyFromDecimal(decimal.Zero),
+		FeeAmount:       models.NewMoneyFromDecimal(decimal.Zero),
+		Currency:        "CNY",
+		Status:          constants.PaymentStatusFailed,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := db.Create(walletFailed).Error; err != nil {
+		t.Fatalf("create wallet failed payment failed: %v", err)
+	}
+
+	counts, err := repo.GetPaymentOrderAlertCounts(now.Add(-time.Hour), now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("get payment order alert counts failed: %v", err)
+	}
+	if counts.PendingPaymentOrders != 1 {
+		t.Fatalf("pending payment orders want 1 got %d", counts.PendingPaymentOrders)
+	}
+	if counts.PaymentsFailed != 1 {
+		t.Fatalf("payments failed want 1 got %d", counts.PaymentsFailed)
+	}
+}
+
 func TestGetStockStatsUsesActiveManualSKUs(t *testing.T) {
 	repo, db := setupDashboardRepositoryTest(t)
 	category := createDashboardCategory(t, db, "dashboard-manual-stock")

--- a/internal/service/dashboard_service.go
+++ b/internal/service/dashboard_service.go
@@ -284,6 +284,14 @@ func (s *DashboardService) GetInventoryAlertItems(_ context.Context, lowStockThr
 	return s.repo.GetInventoryAlertItems(lowStockThreshold)
 }
 
+// GetPaymentOrderAlertCounts 获取支付订单告警计数
+func (s *DashboardService) GetPaymentOrderAlertCounts(_ context.Context, startAt, endAt time.Time) (repository.DashboardPaymentOrderAlertCountsRow, error) {
+	if s == nil || s.repo == nil {
+		return repository.DashboardPaymentOrderAlertCountsRow{}, nil
+	}
+	return s.repo.GetPaymentOrderAlertCounts(startAt, endAt)
+}
+
 // GetTrends 获取仪表盘趋势
 func (s *DashboardService) GetTrends(ctx context.Context, input DashboardQueryInput) (*DashboardTrendResponse, error) {
 	if s == nil || s.repo == nil {

--- a/internal/service/dashboard_service_test.go
+++ b/internal/service/dashboard_service_test.go
@@ -17,6 +17,10 @@ func (s dashboardServiceRepoStub) GetOverview(startAt, endAt time.Time) (reposit
 	return s.overview, nil
 }
 
+func (s dashboardServiceRepoStub) GetPaymentOrderAlertCounts(startAt, endAt time.Time) (repository.DashboardPaymentOrderAlertCountsRow, error) {
+	return repository.DashboardPaymentOrderAlertCountsRow{}, nil
+}
+
 func (s dashboardServiceRepoStub) GetOrderTrends(startAt, endAt time.Time) ([]repository.DashboardOrderTrendRow, error) {
 	return []repository.DashboardOrderTrendRow{}, nil
 }

--- a/internal/service/notification_center_setting.go
+++ b/internal/service/notification_center_setting.go
@@ -22,6 +22,13 @@ const (
 	notificationInventoryAlertIntervalDefaultSeconds = 1800
 	notificationInventoryAlertIntervalMinSeconds     = 60
 	notificationInventoryAlertIntervalMaxSeconds     = 604800
+
+	notificationPaymentOrderAlertIntervalDefaultSeconds = 1800
+	notificationPaymentOrderAlertIntervalMinSeconds     = 60
+	notificationPaymentOrderAlertIntervalMaxSeconds     = 604800
+	notificationPaymentOrderAlertCheckDefaultSeconds    = 86400
+	notificationPaymentOrderAlertCheckMinSeconds        = 60
+	notificationPaymentOrderAlertCheckMaxSeconds        = 604800
 )
 
 // NotificationChannelSetting 通知渠道配置
@@ -67,24 +74,28 @@ type NotificationTemplatesSetting struct {
 
 // NotificationCenterSetting 通知中心配置
 type NotificationCenterSetting struct {
-	DefaultLocale                 string                       `json:"default_locale"`
-	Channels                      NotificationChannelsSetting  `json:"channels"`
-	Scenes                        NotificationSceneSetting     `json:"scenes"`
-	Templates                     NotificationTemplatesSetting `json:"templates"`
-	DedupeTTLSeconds              int                          `json:"dedupe_ttl_seconds"`
-	InventoryAlertIntervalSeconds int                          `json:"inventory_alert_interval_seconds"`
-	IgnoredProductIDs             []uint                       `json:"ignored_product_ids"`
+	DefaultLocale                    string                       `json:"default_locale"`
+	Channels                         NotificationChannelsSetting  `json:"channels"`
+	Scenes                           NotificationSceneSetting     `json:"scenes"`
+	Templates                        NotificationTemplatesSetting `json:"templates"`
+	DedupeTTLSeconds                 int                          `json:"dedupe_ttl_seconds"`
+	InventoryAlertIntervalSeconds    int                          `json:"inventory_alert_interval_seconds"`
+	PaymentOrderAlertIntervalSeconds int                          `json:"payment_order_alert_interval_seconds"`
+	PaymentOrderAlertCheckSeconds    int                          `json:"payment_order_alert_check_interval_seconds"`
+	IgnoredProductIDs                []uint                       `json:"ignored_product_ids"`
 }
 
 // NotificationCenterSettingPatch 通知中心配置补丁
 type NotificationCenterSettingPatch struct {
-	DefaultLocale                 *string                     `json:"default_locale"`
-	Channels                      *NotificationChannelsPatch  `json:"channels"`
-	Scenes                        *NotificationScenePatch     `json:"scenes"`
-	Templates                     *NotificationTemplatesPatch `json:"templates"`
-	DedupeTTLSeconds              *int                        `json:"dedupe_ttl_seconds"`
-	InventoryAlertIntervalSeconds *int                        `json:"inventory_alert_interval_seconds"`
-	IgnoredProductIDs             *[]uint                     `json:"ignored_product_ids"`
+	DefaultLocale                    *string                     `json:"default_locale"`
+	Channels                         *NotificationChannelsPatch  `json:"channels"`
+	Scenes                           *NotificationScenePatch     `json:"scenes"`
+	Templates                        *NotificationTemplatesPatch `json:"templates"`
+	DedupeTTLSeconds                 *int                        `json:"dedupe_ttl_seconds"`
+	InventoryAlertIntervalSeconds    *int                        `json:"inventory_alert_interval_seconds"`
+	PaymentOrderAlertIntervalSeconds *int                        `json:"payment_order_alert_interval_seconds"`
+	PaymentOrderAlertCheckSeconds    *int                        `json:"payment_order_alert_check_interval_seconds"`
+	IgnoredProductIDs                *[]uint                     `json:"ignored_product_ids"`
 }
 
 // NotificationChannelsPatch 通知渠道补丁
@@ -206,9 +217,11 @@ func NotificationCenterDefaultSetting() NotificationCenterSetting {
 				},
 			},
 		},
-		DedupeTTLSeconds:              300,
-		InventoryAlertIntervalSeconds: notificationInventoryAlertIntervalDefaultSeconds,
-		IgnoredProductIDs:             []uint{},
+		DedupeTTLSeconds:                 300,
+		InventoryAlertIntervalSeconds:    notificationInventoryAlertIntervalDefaultSeconds,
+		PaymentOrderAlertIntervalSeconds: notificationPaymentOrderAlertIntervalDefaultSeconds,
+		PaymentOrderAlertCheckSeconds:    notificationPaymentOrderAlertCheckDefaultSeconds,
+		IgnoredProductIDs:                []uint{},
 	})
 }
 
@@ -219,6 +232,8 @@ func NormalizeNotificationCenterSetting(setting NotificationCenterSetting) Notif
 	setting.Channels.Telegram.Recipients = normalizeTelegramRecipients(setting.Channels.Telegram.Recipients)
 	setting.DedupeTTLSeconds = normalizeNotificationDedupeTTL(setting.DedupeTTLSeconds)
 	setting.InventoryAlertIntervalSeconds = normalizeNotificationInventoryAlertInterval(setting.InventoryAlertIntervalSeconds)
+	setting.PaymentOrderAlertIntervalSeconds = normalizeNotificationPaymentOrderAlertInterval(setting.PaymentOrderAlertIntervalSeconds)
+	setting.PaymentOrderAlertCheckSeconds = normalizeNotificationPaymentOrderAlertCheck(setting.PaymentOrderAlertCheckSeconds)
 	setting.IgnoredProductIDs = normalizeNotificationIgnoredProductIDs(setting.IgnoredProductIDs)
 	setting.Templates = normalizeNotificationTemplates(setting.Templates)
 	return setting
@@ -258,6 +273,12 @@ func ValidateNotificationCenterSetting(setting NotificationCenterSetting) error 
 	if normalized.InventoryAlertIntervalSeconds < notificationInventoryAlertIntervalMinSeconds || normalized.InventoryAlertIntervalSeconds > notificationInventoryAlertIntervalMaxSeconds {
 		return fmt.Errorf("%w: 库存告警频率需在 60-604800 秒之间", ErrNotificationConfigInvalid)
 	}
+	if normalized.PaymentOrderAlertIntervalSeconds < notificationPaymentOrderAlertIntervalMinSeconds || normalized.PaymentOrderAlertIntervalSeconds > notificationPaymentOrderAlertIntervalMaxSeconds {
+		return fmt.Errorf("%w: 支付订单告警频率需在 60-604800 秒之间", ErrNotificationConfigInvalid)
+	}
+	if normalized.PaymentOrderAlertCheckSeconds < notificationPaymentOrderAlertCheckMinSeconds || normalized.PaymentOrderAlertCheckSeconds > notificationPaymentOrderAlertCheckMaxSeconds {
+		return fmt.Errorf("%w: 支付订单告警检查区间需在 60-604800 秒之间", ErrNotificationConfigInvalid)
+	}
 	return nil
 }
 
@@ -288,9 +309,11 @@ func NotificationCenterSettingToMap(setting NotificationCenterSetting) map[strin
 			"manual_fulfillment_pending": notificationSceneTemplateToMap(normalized.Templates.ManualFulfillmentPending),
 			"exception_alert":            notificationSceneTemplateToMap(normalized.Templates.ExceptionAlert),
 		},
-		"dedupe_ttl_seconds":               normalized.DedupeTTLSeconds,
-		"inventory_alert_interval_seconds": normalized.InventoryAlertIntervalSeconds,
-		"ignored_product_ids":              cloneUintSlice(normalized.IgnoredProductIDs),
+		"dedupe_ttl_seconds":                         normalized.DedupeTTLSeconds,
+		"inventory_alert_interval_seconds":           normalized.InventoryAlertIntervalSeconds,
+		"payment_order_alert_interval_seconds":       normalized.PaymentOrderAlertIntervalSeconds,
+		"payment_order_alert_check_interval_seconds": normalized.PaymentOrderAlertCheckSeconds,
+		"ignored_product_ids":                        cloneUintSlice(normalized.IgnoredProductIDs),
 	}
 }
 
@@ -330,6 +353,12 @@ func (s *SettingService) PatchNotificationCenterSetting(patch NotificationCenter
 	}
 	if patch.InventoryAlertIntervalSeconds != nil {
 		next.InventoryAlertIntervalSeconds = *patch.InventoryAlertIntervalSeconds
+	}
+	if patch.PaymentOrderAlertIntervalSeconds != nil {
+		next.PaymentOrderAlertIntervalSeconds = *patch.PaymentOrderAlertIntervalSeconds
+	}
+	if patch.PaymentOrderAlertCheckSeconds != nil {
+		next.PaymentOrderAlertCheckSeconds = *patch.PaymentOrderAlertCheckSeconds
 	}
 	if patch.IgnoredProductIDs != nil {
 		next.IgnoredProductIDs = cloneUintSlice(*patch.IgnoredProductIDs)
@@ -445,6 +474,8 @@ func notificationCenterSettingFromJSON(raw models.JSON, fallback NotificationCen
 	next.DefaultLocale = readString(raw, "default_locale", next.DefaultLocale)
 	next.DedupeTTLSeconds = readInt(raw, "dedupe_ttl_seconds", next.DedupeTTLSeconds)
 	next.InventoryAlertIntervalSeconds = readInt(raw, "inventory_alert_interval_seconds", next.InventoryAlertIntervalSeconds)
+	next.PaymentOrderAlertIntervalSeconds = readInt(raw, "payment_order_alert_interval_seconds", readInt(raw, "payment_failed_alert_interval_seconds", next.PaymentOrderAlertIntervalSeconds))
+	next.PaymentOrderAlertCheckSeconds = readInt(raw, "payment_order_alert_check_interval_seconds", next.PaymentOrderAlertCheckSeconds)
 	next.IgnoredProductIDs = readUintList(raw, "ignored_product_ids", next.IgnoredProductIDs)
 
 	if channelsMap := toStringAnyMap(raw["channels"]); channelsMap != nil {
@@ -566,6 +597,22 @@ func normalizeNotificationInventoryAlertInterval(ttl int) int {
 		return notificationInventoryAlertIntervalDefaultSeconds
 	}
 	return ttl
+}
+
+// normalizeNotificationPaymentOrderAlertInterval 归一化支付订单告警发送间隔
+func normalizeNotificationPaymentOrderAlertInterval(ttl int) int {
+	if ttl < notificationPaymentOrderAlertIntervalMinSeconds || ttl > notificationPaymentOrderAlertIntervalMaxSeconds {
+		return notificationPaymentOrderAlertIntervalDefaultSeconds
+	}
+	return ttl
+}
+
+// normalizeNotificationPaymentOrderAlertCheck 归一化支付订单告警检查区间
+func normalizeNotificationPaymentOrderAlertCheck(seconds int) int {
+	if seconds < notificationPaymentOrderAlertCheckMinSeconds || seconds > notificationPaymentOrderAlertCheckMaxSeconds {
+		return notificationPaymentOrderAlertCheckDefaultSeconds
+	}
+	return seconds
 }
 
 func normalizeEmailRecipients(items []string) []string {

--- a/internal/service/notification_service.go
+++ b/internal/service/notification_service.go
@@ -220,40 +220,21 @@ func (s *NotificationService) dispatchExceptionAlertCheck(ctx context.Context, s
 		}
 	}
 
-	overview, err := s.dashboardSvc.GetOverview(ctx, DashboardQueryInput{
-		Range:        "today",
-		Timezone:     time.Local.String(),
-		ForceRefresh: true,
-	})
+	paymentOrderAlertNow := time.Now()
+	paymentOrderAlertStart := paymentOrderAlertNow.Add(-time.Duration(setting.PaymentOrderAlertCheckSeconds) * time.Second)
+	paymentOrderCounts, err := s.dashboardSvc.GetPaymentOrderAlertCounts(ctx, paymentOrderAlertStart, paymentOrderAlertNow)
 	if err != nil {
 		return err
 	}
-	if overview == nil || len(overview.Alerts) == 0 {
-		return firstErr
-	}
 
-	alertLocale := resolveNotificationLocale(payload.Locale, setting.DefaultLocale)
-	for _, alert := range overview.Alerts {
-		if isInventoryAlertType(alert.Type) {
+	for _, itemPayload := range buildPaymentOrderAlertDispatchPayloads(setting, dashboardSetting, payload, paymentOrderCounts) {
+		allowed, intervalErr := acquirePaymentOrderAlertInterval(ctx, setting.PaymentOrderAlertIntervalSeconds, itemPayload)
+		if intervalErr != nil {
+			logger.Warnw("notification_payment_order_alert_interval_failed", "error", intervalErr)
+		}
+		if intervalErr == nil && !allowed {
 			continue
 		}
-		data := cloneNotificationVariables(payload.Data)
-		if data == nil {
-			data = map[string]interface{}{}
-		}
-		alertType := strings.TrimSpace(alert.Type)
-		data["alert_type"] = alertTypeLabelByType(alertLocale, alertType)
-		data["alert_type_label"] = data["alert_type"]
-		data["alert_type_key"] = alertType
-		data["alert_level"] = strings.TrimSpace(alert.Level)
-		data["alert_value"] = fmt.Sprintf("%d", alert.Value)
-		data["alert_threshold"] = fmt.Sprintf("%d", thresholdValueByAlertType(dashboardSetting.Alert, alertType))
-		data["message"] = thresholdMessageByAlertType(alertType)
-
-		itemPayload := payload
-		itemPayload.EventType = constants.NotificationEventExceptionAlert
-		itemPayload.BizType = constants.NotificationBizTypeDashboardAlert
-		itemPayload.Data = data
 		if err := s.dispatchSingleEvent(ctx, setting, itemPayload); err != nil && firstErr == nil {
 			firstErr = err
 		}
@@ -600,6 +581,43 @@ func acquireInventoryAlertInterval(ctx context.Context, intervalSeconds int, pay
 	return cache.SetNX(ctx, key, "1", time.Duration(intervalSeconds)*time.Second)
 }
 
+// isPaymentOrderAlertType 判断是否为支付订单类告警
+func isPaymentOrderAlertType(alertType string) bool {
+	switch strings.ToLower(strings.TrimSpace(alertType)) {
+	case constants.NotificationAlertTypePendingOrders, constants.NotificationAlertTypePaymentsFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+// acquirePaymentOrderAlertInterval 获取支付订单告警发送间隔锁
+func acquirePaymentOrderAlertInterval(ctx context.Context, intervalSeconds int, payload queue.NotificationDispatchPayload) (bool, error) {
+	alertType := resolvePaymentOrderAlertTypeKey(payload.Data)
+	if !isPaymentOrderAlertType(alertType) {
+		return true, nil
+	}
+	intervalSeconds = normalizeNotificationPaymentOrderAlertInterval(intervalSeconds)
+	key := "notification:payment_order_interval:" + alertType
+	return cache.SetNX(ctx, key, "1", time.Duration(intervalSeconds)*time.Second)
+}
+
+// resolvePaymentOrderAlertTypeKey 解析支付订单告警类型键
+func resolvePaymentOrderAlertTypeKey(data map[string]interface{}) string {
+	if len(data) == 0 {
+		return ""
+	}
+	normalized := strings.ToLower(strings.TrimSpace(fmt.Sprintf("%v", data["alert_type_key"])))
+	if isPaymentOrderAlertType(normalized) {
+		return normalized
+	}
+	normalized = strings.ToLower(strings.TrimSpace(fmt.Sprintf("%v", data["alert_type"])))
+	if isPaymentOrderAlertType(normalized) {
+		return normalized
+	}
+	return ""
+}
+
 func resolveInventoryAlertTypeKey(data map[string]interface{}) string {
 	if len(data) == 0 {
 		return ""
@@ -738,6 +756,103 @@ func inventoryAlertLevel(alertType string) string {
 		return "error"
 	default:
 		return "warning"
+	}
+}
+
+// buildPaymentOrderAlertDispatchPayloads 构建支付订单告警通知载荷
+func buildPaymentOrderAlertDispatchPayloads(
+	setting NotificationCenterSetting,
+	dashboardSetting DashboardSetting,
+	payload queue.NotificationDispatchPayload,
+	counts repository.DashboardPaymentOrderAlertCountsRow,
+) []queue.NotificationDispatchPayload {
+	result := make([]queue.NotificationDispatchPayload, 0, 2)
+	if itemPayload, ok := buildPaymentOrderAlertDispatchPayload(
+		setting,
+		payload,
+		constants.NotificationAlertTypePendingOrders,
+		counts.PendingPaymentOrders,
+		dashboardSetting.Alert.PendingPaymentOrdersThreshold,
+	); ok {
+		result = append(result, itemPayload)
+	}
+	if itemPayload, ok := buildPaymentOrderAlertDispatchPayload(
+		setting,
+		payload,
+		constants.NotificationAlertTypePaymentsFailed,
+		counts.PaymentsFailed,
+		dashboardSetting.Alert.PaymentsFailedThreshold,
+	); ok {
+		result = append(result, itemPayload)
+	}
+	return result
+}
+
+// buildPaymentOrderAlertDispatchPayload 构建单个支付订单告警通知载荷
+func buildPaymentOrderAlertDispatchPayload(
+	setting NotificationCenterSetting,
+	payload queue.NotificationDispatchPayload,
+	alertType string,
+	value int64,
+	threshold int64,
+) (queue.NotificationDispatchPayload, bool) {
+	if value < threshold {
+		return queue.NotificationDispatchPayload{}, false
+	}
+
+	locale := resolveNotificationLocale(payload.Locale, setting.DefaultLocale)
+	data := cloneNotificationVariables(payload.Data)
+	if data == nil {
+		data = map[string]interface{}{}
+	}
+	data["alert_type"] = alertTypeLabelByType(locale, alertType)
+	data["alert_type_label"] = data["alert_type"]
+	data["alert_type_key"] = alertType
+	data["alert_level"] = "warning"
+	data["alert_value"] = fmt.Sprintf("%d", value)
+	data["alert_threshold"] = fmt.Sprintf("%d", threshold)
+	data["message"] = buildPaymentOrderAlertMessage(locale, alertType, value, threshold, setting.PaymentOrderAlertIntervalSeconds)
+
+	itemPayload := payload
+	itemPayload.EventType = constants.NotificationEventExceptionAlert
+	itemPayload.BizType = constants.NotificationBizTypeDashboardAlert
+	itemPayload.Data = data
+	return itemPayload, true
+}
+
+// buildPaymentOrderAlertMessage 构建支付订单告警消息内容
+func buildPaymentOrderAlertMessage(locale string, alertType string, value, threshold int64, intervalSeconds int) string {
+	intervalText := formatPaymentOrderAlertInterval(locale, intervalSeconds)
+	switch strings.ToLower(strings.TrimSpace(alertType)) {
+	case constants.NotificationAlertTypePendingOrders:
+		return localizedNotificationText(
+			locale,
+			fmt.Sprintf("当前统计周期内待支付订单 %d 笔，已达到告警阈值 %d 笔；本类告警最短 %s 发送一次。", value, threshold, intervalText),
+			fmt.Sprintf("目前統計週期內待支付訂單 %d 筆，已達到告警門檻 %d 筆；本類告警最短 %s 發送一次。", value, threshold, intervalText),
+			fmt.Sprintf("Pending payment orders reached %d in the current alert window, meeting the threshold of %d; this alert is sent at most once every %s.", value, threshold, intervalText),
+		)
+	default:
+		return localizedNotificationText(
+			locale,
+			fmt.Sprintf("当前统计周期内支付失败 %d 笔，已达到告警阈值 %d 笔；本类告警最短 %s 发送一次。", value, threshold, intervalText),
+			fmt.Sprintf("目前統計週期內支付失敗 %d 筆，已達到告警門檻 %d 筆；本類告警最短 %s 發送一次。", value, threshold, intervalText),
+			fmt.Sprintf("Payment failures reached %d in the current alert window, meeting the threshold of %d; this alert is sent at most once every %s.", value, threshold, intervalText),
+		)
+	}
+}
+
+// formatPaymentOrderAlertInterval 格式化支付订单告警发送间隔
+func formatPaymentOrderAlertInterval(locale string, seconds int) string {
+	seconds = normalizeNotificationPaymentOrderAlertInterval(seconds)
+	switch {
+	case seconds%3600 == 0:
+		hours := seconds / 3600
+		return localizedNotificationText(locale, fmt.Sprintf("%d 小时", hours), fmt.Sprintf("%d 小時", hours), fmt.Sprintf("%d hours", hours))
+	case seconds%60 == 0:
+		minutes := seconds / 60
+		return localizedNotificationText(locale, fmt.Sprintf("%d 分钟", minutes), fmt.Sprintf("%d 分鐘", minutes), fmt.Sprintf("%d minutes", minutes))
+	default:
+		return localizedNotificationText(locale, fmt.Sprintf("%d 秒", seconds), fmt.Sprintf("%d 秒", seconds), fmt.Sprintf("%d seconds", seconds))
 	}
 }
 

--- a/internal/service/payment_notification_payload_test.go
+++ b/internal/service/payment_notification_payload_test.go
@@ -314,6 +314,116 @@ func TestPatchNotificationCenterSettingPersistsInventoryAlertConfig(t *testing.T
 	}
 }
 
+func TestPatchNotificationCenterSettingPersistsPaymentOrderAlertConfig(t *testing.T) {
+	repo := newMockSettingRepo()
+	svc := NewSettingService(repo)
+	interval := 900
+	checkInterval := 7200
+
+	setting, err := svc.PatchNotificationCenterSetting(NotificationCenterSettingPatch{
+		PaymentOrderAlertIntervalSeconds: &interval,
+		PaymentOrderAlertCheckSeconds:    &checkInterval,
+	})
+	if err != nil {
+		t.Fatalf("patch notification center setting failed: %v", err)
+	}
+
+	if setting.PaymentOrderAlertIntervalSeconds != interval {
+		t.Fatalf("expected payment order interval %d, got %d", interval, setting.PaymentOrderAlertIntervalSeconds)
+	}
+	if setting.PaymentOrderAlertCheckSeconds != checkInterval {
+		t.Fatalf("expected payment order check interval %d, got %d", checkInterval, setting.PaymentOrderAlertCheckSeconds)
+	}
+
+	stored, err := svc.GetNotificationCenterSetting()
+	if err != nil {
+		t.Fatalf("get notification center setting failed: %v", err)
+	}
+	if stored.PaymentOrderAlertIntervalSeconds != interval {
+		t.Fatalf("stored payment order interval want %d got %d", interval, stored.PaymentOrderAlertIntervalSeconds)
+	}
+	if stored.PaymentOrderAlertCheckSeconds != checkInterval {
+		t.Fatalf("stored payment order check interval want %d got %d", checkInterval, stored.PaymentOrderAlertCheckSeconds)
+	}
+}
+
+func TestBuildPaymentOrderAlertDispatchPayloadsUseDashboardThresholds(t *testing.T) {
+	setting := NotificationCenterDefaultSetting()
+	setting.DefaultLocale = constants.LocaleZhCN
+	setting.PaymentOrderAlertIntervalSeconds = 600
+
+	payloads := buildPaymentOrderAlertDispatchPayloads(
+		setting,
+		DashboardSetting{
+			Alert: DashboardAlertSetting{
+				PendingPaymentOrdersThreshold: 5,
+				PaymentsFailedThreshold:       3,
+			},
+		},
+		queue.NotificationDispatchPayload{
+			EventType: constants.NotificationEventExceptionAlertCheck,
+			BizType:   constants.NotificationBizTypeDashboardAlert,
+			Data: map[string]interface{}{
+				"source": "scheduler",
+			},
+		},
+		repository.DashboardPaymentOrderAlertCountsRow{
+			PendingPaymentOrders: 6,
+			PaymentsFailed:       4,
+		},
+	)
+	if len(payloads) != 2 {
+		t.Fatalf("expected 2 payment order alert payloads, got %d", len(payloads))
+	}
+
+	byType := make(map[string]queue.NotificationDispatchPayload, len(payloads))
+	for _, payload := range payloads {
+		if payload.EventType != constants.NotificationEventExceptionAlert {
+			t.Fatalf("event type want exception_alert got %s", payload.EventType)
+		}
+		byType[fmt.Sprintf("%v", payload.Data["alert_type_key"])] = payload
+	}
+
+	pendingPayload, ok := byType[constants.NotificationAlertTypePendingOrders]
+	if !ok {
+		t.Fatal("expected pending payment alert payload")
+	}
+	if pendingPayload.Data["alert_value"] != "6" || pendingPayload.Data["alert_threshold"] != "5" {
+		t.Fatalf("pending alert value/threshold mismatch: %#v", pendingPayload.Data)
+	}
+	pendingMessage := fmt.Sprintf("%v", pendingPayload.Data["message"])
+	if !strings.Contains(pendingMessage, "待支付订单 6 笔") || !strings.Contains(pendingMessage, "10 分钟") {
+		t.Fatalf("unexpected pending payment message: %s", pendingMessage)
+	}
+
+	failedPayload, ok := byType[constants.NotificationAlertTypePaymentsFailed]
+	if !ok {
+		t.Fatal("expected payment failed alert payload")
+	}
+	if failedPayload.Data["alert_value"] != "4" || failedPayload.Data["alert_threshold"] != "3" {
+		t.Fatalf("payment failed alert value/threshold mismatch: %#v", failedPayload.Data)
+	}
+	failedMessage := fmt.Sprintf("%v", failedPayload.Data["message"])
+	if !strings.Contains(failedMessage, "支付失败 4 笔") || !strings.Contains(failedMessage, "10 分钟") {
+		t.Fatalf("unexpected payment failed message: %s", failedMessage)
+	}
+
+	payloads = buildPaymentOrderAlertDispatchPayloads(
+		setting,
+		DashboardSetting{
+			Alert: DashboardAlertSetting{
+				PendingPaymentOrdersThreshold: 5,
+				PaymentsFailedThreshold:       3,
+			},
+		},
+		queue.NotificationDispatchPayload{EventType: constants.NotificationEventExceptionAlertCheck},
+		repository.DashboardPaymentOrderAlertCountsRow{PendingPaymentOrders: 4, PaymentsFailed: 2},
+	)
+	if len(payloads) != 0 {
+		t.Fatalf("expected no payload below dashboard thresholds, got %d", len(payloads))
+	}
+}
+
 func TestBuildInventoryAlertDispatchPayloadsIncludesSummaryAndIgnoreRules(t *testing.T) {
 	setting := NotificationCenterDefaultSetting()
 	setting.DefaultLocale = constants.LocaleEnUS
@@ -437,7 +547,7 @@ func TestResolveInventoryAlertTypeKey(t *testing.T) {
 			name: "use code directly",
 			data: map[string]interface{}{
 				"alert_type_key": constants.NotificationAlertTypeLowStockProducts,
-				"alert_type":      "低库存商品",
+				"alert_type":     "低库存商品",
 			},
 			want: constants.NotificationAlertTypeLowStockProducts,
 		},


### PR DESCRIPTION
付款失败、待付款订单，不跟随仪表盘，而是独立化设置。

为什么要这样：
付款接口某天炸了，用户会反复进行尝试，就会失败或者出现待付款；
而付款失败/待付款巡检阈值是按天算的，不能满足需要。
这两个告警也没有设置项，因为它不是库存告警，会使用默认值5分钟。
巡检按天算，也就是说，这个告警会以5分钟的频率，通知骚扰你一天。
加了这项设置：
我可以轻松设置为一小时或者半天检查一次，没有出问题的话不会高频骚扰。

ps：仪表盘那边的“异常告警”卡片我没有变动，因为我发现如果改那边比较麻烦，要设计独立接口，所以那边仍然是按默认7天算的。

关联 admin 前端 PR: https://github.com/dujiao-next/admin/pull/35