### PR TITLE
optimize: Optimize discount calculation logic

### DIFF
--- a/internal/dto/order.go
+++ b/internal/dto/order.go
@@ -151,7 +151,9 @@ type OrderItemResp struct {
 	SKUSnapshot              models.JSON        `json:"sku_snapshot"`
 	Tags                     models.StringArray `json:"tags"`
 	Quantity                 int                `json:"quantity"`
+	OriginalUnitPrice        models.Money       `json:"original_unit_price"`
 	UnitPrice                models.Money       `json:"unit_price"`
+	OriginalTotalPrice       models.Money       `json:"original_total_price"`
 	TotalPrice               models.Money       `json:"total_price"`
 	CouponDiscountAmount     models.Money       `json:"coupon_discount_amount"`
 	MemberDiscountAmount     models.Money       `json:"member_discount_amount"`
@@ -175,7 +177,9 @@ func newOrderItemResp(item *models.OrderItem) OrderItemResp {
 		SKUSnapshot:              item.SKUSnapshotJSON,
 		Tags:                     item.Tags,
 		Quantity:                 item.Quantity,
+		OriginalUnitPrice:        item.OriginalUnitPrice,
 		UnitPrice:                item.UnitPrice,
+		OriginalTotalPrice:       item.OriginalTotalPrice,
 		TotalPrice:               item.TotalPrice,
 		CouponDiscountAmount:     item.CouponDiscount,
 		MemberDiscountAmount:     item.MemberDiscount,

--- a/internal/dto/order_test.go
+++ b/internal/dto/order_test.go
@@ -35,16 +35,18 @@ func TestOrderDetailOmitsSensitiveFields(t *testing.T) {
 		UpdatedAt:          now,
 		Items: []models.OrderItem{
 			{
-				ID:              1,
-				OrderID:         1,
-				ProductID:       5,
-				SKUID:           10,
-				TitleJSON:       models.JSON{"zh-CN": "商品A"},
-				CostPrice:       newMoney("50.00"),
-				UnitPrice:       newMoney("100.00"),
-				TotalPrice:      newMoney("100.00"),
-				Quantity:        1,
-				FulfillmentType: "upstream",
+				ID:                 1,
+				OrderID:            1,
+				ProductID:          5,
+				SKUID:              10,
+				TitleJSON:          models.JSON{"zh-CN": "商品A"},
+				CostPrice:          newMoney("50.00"),
+				OriginalUnitPrice:  newMoney("120.00"),
+				UnitPrice:          newMoney("100.00"),
+				OriginalTotalPrice: newMoney("120.00"),
+				TotalPrice:         newMoney("100.00"),
+				Quantity:           1,
+				FulfillmentType:    "upstream",
 			},
 		},
 		Fulfillment: &models.Fulfillment{
@@ -78,7 +80,8 @@ func TestOrderDetailOmitsSensitiveFields(t *testing.T) {
 	// 公开字段应存在
 	publicFields := []string{
 		"order_no", "total_amount", "status", "currency",
-		"guest_email", "unit_price", "fulfillment_type",
+		"guest_email", "original_unit_price", "unit_price",
+		"original_total_price", "fulfillment_type",
 	}
 	for _, field := range publicFields {
 		if !strings.Contains(jsonStr, `"`+field+`"`) {

--- a/internal/http/handlers/channel/channel_order.go
+++ b/internal/http/handlers/channel/channel_order.go
@@ -710,16 +710,18 @@ func buildChannelOrderPreviewResponse(preview *service.OrderPreview, locale stri
 	items := make([]gin.H, 0, len(preview.Items))
 	for _, item := range preview.Items {
 		items = append(items, gin.H{
-			"product_id":         item.ProductID,
-			"product_title":      resolveLocalizedJSON(item.TitleJSON, locale, "zh-CN"),
-			"sku_id":             item.SKUID,
-			"sku_name":           channelLocalizedValue(item.SKUSnapshotJSON["spec_values"], locale, "zh-CN"),
-			"quantity":           item.Quantity,
-			"unit_price":         item.UnitPrice.StringFixed(2),
-			"subtotal":           item.TotalPrice.StringFixed(2),
-			"coupon_discount":    item.CouponDiscount.StringFixed(2),
-			"promotion_discount": item.PromotionDiscount.StringFixed(2),
-			"fulfillment_type":   item.FulfillmentType,
+			"product_id":           item.ProductID,
+			"product_title":        resolveLocalizedJSON(item.TitleJSON, locale, "zh-CN"),
+			"sku_id":               item.SKUID,
+			"sku_name":             channelLocalizedValue(item.SKUSnapshotJSON["spec_values"], locale, "zh-CN"),
+			"quantity":             item.Quantity,
+			"original_unit_price":  item.OriginalUnitPrice.StringFixed(2),
+			"unit_price":           item.UnitPrice.StringFixed(2),
+			"original_total_price": item.OriginalTotalPrice.StringFixed(2),
+			"subtotal":             item.TotalPrice.StringFixed(2),
+			"coupon_discount":      item.CouponDiscount.StringFixed(2),
+			"promotion_discount":   item.PromotionDiscount.StringFixed(2),
+			"fulfillment_type":     item.FulfillmentType,
 		})
 	}
 	return gin.H{
@@ -787,17 +789,19 @@ func buildChannelOrderDetailResponse(order *models.Order, locale string) gin.H {
 			instructions = resolveLocalizedJSON(item.InstructionsJSON, locale, "zh-CN")
 		}
 		items = append(items, gin.H{
-			"product_id":         item.ProductID,
-			"product_title":      resolveLocalizedJSON(item.TitleJSON, locale, "zh-CN"),
-			"sku_id":             item.SKUID,
-			"sku_name":           channelLocalizedValue(item.SKUSnapshotJSON["spec_values"], locale, "zh-CN"),
-			"quantity":           item.Quantity,
-			"unit_price":         item.UnitPrice.StringFixed(2),
-			"subtotal":           item.TotalPrice.StringFixed(2),
-			"coupon_discount":    item.CouponDiscount.StringFixed(2),
-			"promotion_discount": item.PromotionDiscount.StringFixed(2),
-			"fulfillment_type":   item.FulfillmentType,
-			"instructions":       instructions,
+			"product_id":           item.ProductID,
+			"product_title":        resolveLocalizedJSON(item.TitleJSON, locale, "zh-CN"),
+			"sku_id":               item.SKUID,
+			"sku_name":             channelLocalizedValue(item.SKUSnapshotJSON["spec_values"], locale, "zh-CN"),
+			"quantity":             item.Quantity,
+			"original_unit_price":  item.OriginalUnitPrice.StringFixed(2),
+			"unit_price":           item.UnitPrice.StringFixed(2),
+			"original_total_price": item.OriginalTotalPrice.StringFixed(2),
+			"subtotal":             item.TotalPrice.StringFixed(2),
+			"coupon_discount":      item.CouponDiscount.StringFixed(2),
+			"promotion_discount":   item.PromotionDiscount.StringFixed(2),
+			"fulfillment_type":     item.FulfillmentType,
+			"instructions":         instructions,
 		})
 	}
 	resp["items"] = items

--- a/internal/http/handlers/channel/channel_order_test.go
+++ b/internal/http/handlers/channel/channel_order_test.go
@@ -19,16 +19,18 @@ func TestBuildChannelOrderPreviewResponseIncludesTelegramFriendlyFields(t *testi
 		PromotionDiscountAmount: models.NewMoneyFromDecimal(decimal.RequireFromString("10.00")),
 		TotalAmount:             models.NewMoneyFromDecimal(decimal.RequireFromString("90.00")),
 		Items: []service.OrderPreviewItem{{
-			ProductID:         12,
-			SKUID:             34,
-			TitleJSON:         models.JSON{"zh-CN": "会员订阅"},
-			SKUSnapshotJSON:   models.JSON{"spec_values": models.JSON{"zh-CN": "季度版"}},
-			Quantity:          2,
-			UnitPrice:         models.NewMoneyFromDecimal(decimal.RequireFromString("54.00")),
-			TotalPrice:        models.NewMoneyFromDecimal(decimal.RequireFromString("108.00")),
-			CouponDiscount:    models.NewMoneyFromDecimal(decimal.RequireFromString("8.00")),
-			PromotionDiscount: models.NewMoneyFromDecimal(decimal.RequireFromString("10.00")),
-			FulfillmentType:   "manual",
+			ProductID:          12,
+			SKUID:              34,
+			TitleJSON:          models.JSON{"zh-CN": "会员订阅"},
+			SKUSnapshotJSON:    models.JSON{"spec_values": models.JSON{"zh-CN": "季度版"}},
+			Quantity:           2,
+			OriginalUnitPrice:  models.NewMoneyFromDecimal(decimal.RequireFromString("60.00")),
+			UnitPrice:          models.NewMoneyFromDecimal(decimal.RequireFromString("54.00")),
+			OriginalTotalPrice: models.NewMoneyFromDecimal(decimal.RequireFromString("120.00")),
+			TotalPrice:         models.NewMoneyFromDecimal(decimal.RequireFromString("108.00")),
+			CouponDiscount:     models.NewMoneyFromDecimal(decimal.RequireFromString("8.00")),
+			PromotionDiscount:  models.NewMoneyFromDecimal(decimal.RequireFromString("10.00")),
+			FulfillmentType:    "manual",
 		}},
 	}, "zh-CN")
 
@@ -44,6 +46,12 @@ func TestBuildChannelOrderPreviewResponseIncludesTelegramFriendlyFields(t *testi
 	}
 	if got := items[0]["coupon_discount"]; got != "8.00" {
 		t.Fatalf("expected coupon_discount=8.00, got=%v", got)
+	}
+	if got := items[0]["original_unit_price"]; got != "60.00" {
+		t.Fatalf("expected original_unit_price=60.00, got=%v", got)
+	}
+	if got := items[0]["original_total_price"]; got != "120.00" {
+		t.Fatalf("expected original_total_price=120.00, got=%v", got)
 	}
 	if got := items[0]["promotion_discount"]; got != "10.00" {
 		t.Fatalf("expected promotion_discount=10.00, got=%v", got)
@@ -72,16 +80,18 @@ func TestBuildChannelOrderDetailResponseUsesTotalPaidAmount(t *testing.T) {
 		UpdatedAt:               now,
 		PaidAt:                  &now,
 		Items: []models.OrderItem{{
-			ProductID:         1,
-			SKUID:             2,
-			TitleJSON:         models.JSON{"zh-CN": "测试商品"},
-			SKUSnapshotJSON:   models.JSON{"spec_values": models.JSON{"zh-CN": "标准版"}},
-			Quantity:          1,
-			UnitPrice:         models.NewMoneyFromDecimal(decimal.RequireFromString("80.00")),
-			TotalPrice:        models.NewMoneyFromDecimal(decimal.RequireFromString("80.00")),
-			CouponDiscount:    models.NewMoneyFromDecimal(decimal.RequireFromString("5.00")),
-			PromotionDiscount: models.NewMoneyFromDecimal(decimal.RequireFromString("15.00")),
-			FulfillmentType:   "manual",
+			ProductID:          1,
+			SKUID:              2,
+			TitleJSON:          models.JSON{"zh-CN": "测试商品"},
+			SKUSnapshotJSON:    models.JSON{"spec_values": models.JSON{"zh-CN": "标准版"}},
+			Quantity:           1,
+			OriginalUnitPrice:  models.NewMoneyFromDecimal(decimal.RequireFromString("100.00")),
+			UnitPrice:          models.NewMoneyFromDecimal(decimal.RequireFromString("80.00")),
+			OriginalTotalPrice: models.NewMoneyFromDecimal(decimal.RequireFromString("100.00")),
+			TotalPrice:         models.NewMoneyFromDecimal(decimal.RequireFromString("80.00")),
+			CouponDiscount:     models.NewMoneyFromDecimal(decimal.RequireFromString("5.00")),
+			PromotionDiscount:  models.NewMoneyFromDecimal(decimal.RequireFromString("15.00")),
+			FulfillmentType:    "manual",
 		}},
 		Children: []models.Order{{
 			ID:      8,
@@ -117,6 +127,12 @@ func TestBuildChannelOrderDetailResponseUsesTotalPaidAmount(t *testing.T) {
 	}
 	if got := items[0]["coupon_discount"]; got != "5.00" {
 		t.Fatalf("expected coupon_discount=5.00, got=%v", got)
+	}
+	if got := items[0]["original_unit_price"]; got != "100.00" {
+		t.Fatalf("expected original_unit_price=100.00, got=%v", got)
+	}
+	if got := items[0]["original_total_price"]; got != "100.00" {
+		t.Fatalf("expected original_total_price=100.00, got=%v", got)
 	}
 	if got := items[0]["promotion_discount"]; got != "15.00" {
 		t.Fatalf("expected promotion_discount=15.00, got=%v", got)

--- a/internal/http/handlers/upstream/upstream_handler.go
+++ b/internal/http/handlers/upstream/upstream_handler.go
@@ -584,13 +584,15 @@ func (h *Handler) GetOrder(c *gin.Context) {
 		items := make([]gin.H, 0, len(order.Items))
 		for _, item := range order.Items {
 			items = append(items, gin.H{
-				"product_id":       item.ProductID,
-				"sku_id":           item.SKUID,
-				"title":            item.TitleJSON,
-				"quantity":         item.Quantity,
-				"unit_price":       item.UnitPrice.StringFixed(2),
-				"total_price":      item.TotalPrice.StringFixed(2),
-				"fulfillment_type": item.FulfillmentType,
+				"product_id":           item.ProductID,
+				"sku_id":               item.SKUID,
+				"title":                item.TitleJSON,
+				"quantity":             item.Quantity,
+				"original_unit_price":  item.OriginalUnitPrice.StringFixed(2),
+				"unit_price":           item.UnitPrice.StringFixed(2),
+				"original_total_price": item.OriginalTotalPrice.StringFixed(2),
+				"total_price":          item.TotalPrice.StringFixed(2),
+				"fulfillment_type":     item.FulfillmentType,
 			})
 		}
 		resp["items"] = items

--- a/internal/models/db.go
+++ b/internal/models/db.go
@@ -19,6 +19,7 @@ const (
 	skuMigrationSettingKey                          = "migration/product_sku_v1"
 	categoryParentMigrationSettingKey               = "migration/category_parent_v1"
 	paymentProviderBepusdtRenameMigrationSettingKey = "migration/payment_provider_bepusdt_rename_v1"
+	orderItemOriginalPriceMigrationKey              = "migration/order_item_original_price_v1"
 	manualStockUnlimitedValue                       = -1
 )
 
@@ -169,6 +170,9 @@ func AutoMigrate() error {
 		return err
 	}
 	if err := ensurePaymentProviderBepusdtRenameMigration(); err != nil {
+		return err
+	}
+	if err := ensureOrderItemOriginalPriceMigration(); err != nil {
 		return err
 	}
 

--- a/internal/models/migrations.go
+++ b/internal/models/migrations.go
@@ -64,6 +64,47 @@ func migrationDone(value JSON) bool {
 	return ok && flag
 }
 
+// ensureOrderItemOriginalPriceMigration 为历史订单项回填原价快照。
+// 历史数据没有真实原价，只能以当时已记录的 unit_price/total_price 作为兼容回填。
+func ensureOrderItemOriginalPriceMigration() error {
+	if DB == nil {
+		return errors.New("database is not initialized")
+	}
+
+	var marker Setting
+	if err := DB.First(&marker, "key = ?", orderItemOriginalPriceMigrationKey).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+	} else if migrationDone(marker.ValueJSON) {
+		return nil
+	}
+
+	return DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&OrderItem{}).
+			Where("original_unit_price = 0").
+			Update("original_unit_price", gorm.Expr("unit_price")).
+			Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&OrderItem{}).
+			Where("original_total_price = 0").
+			Update("original_total_price", gorm.Expr("total_price")).
+			Error; err != nil {
+			return err
+		}
+
+		marker := Setting{
+			Key: orderItemOriginalPriceMigrationKey,
+			ValueJSON: JSON{
+				"done":        true,
+				"migrated_at": time.Now().UTC().Format(time.RFC3339),
+			},
+		}
+		return tx.Save(&marker).Error
+	})
+}
+
 // migrateCartSKUUniqueIndex 迁移购物车唯一索引为 user_id + product_id + sku_id 维度。
 func migrateCartSKUUniqueIndex() error {
 	migrator := DB.Migrator()

--- a/internal/models/order_item.go
+++ b/internal/models/order_item.go
@@ -15,9 +15,11 @@ type OrderItem struct {
 	TitleJSON                    JSON           `gorm:"type:json;not null" json:"title"`                                        // 商品标题快照
 	SKUSnapshotJSON              JSON           `gorm:"type:json" json:"sku_snapshot"`                                          // SKU 快照（编码/规格）
 	Tags                         StringArray    `gorm:"type:json" json:"tags"`                                                  // 标签快照
+	OriginalUnitPrice            Money          `gorm:"type:decimal(20,2);not null;default:0" json:"original_unit_price"`       // 原始单价快照
 	UnitPrice                    Money          `gorm:"type:decimal(20,2);not null;default:0" json:"unit_price"`                // 单价
 	CostPrice                    Money          `gorm:"type:decimal(20,2);not null;default:0" json:"cost_price"`                // 成本价快照
 	Quantity                     int            `gorm:"not null" json:"quantity"`                                               // 数量
+	OriginalTotalPrice           Money          `gorm:"type:decimal(20,2);not null;default:0" json:"original_total_price"`      // 原始小计快照
 	TotalPrice                   Money          `gorm:"type:decimal(20,2);not null;default:0" json:"total_price"`               // 小计
 	CouponDiscount               Money          `gorm:"type:decimal(20,2);not null;default:0" json:"coupon_discount_amount"`    // 优惠券分摊金额
 	MemberDiscount               Money          `gorm:"type:decimal(20,2);not null;default:0" json:"member_discount_amount"`    // 会员优惠分摊金额

--- a/internal/service/order_service.go
+++ b/internal/service/order_service.go
@@ -222,6 +222,7 @@ type orderCreateParams struct {
 	ClientIP            string
 	IsGuest             bool
 	ManualFormData      map[string]models.JSON
+	SkipManualFormCheck bool
 	SkipRiskControl     bool
 	SkipIPRiskControl   bool
 }
@@ -239,18 +240,20 @@ type OrderPreview struct {
 
 // OrderPreviewItem 订单项金额预览
 type OrderPreviewItem struct {
-	ProductID         uint               `json:"product_id"`
-	SKUID             uint               `json:"sku_id"`
-	TitleJSON         models.JSON        `json:"title"`
-	SKUSnapshotJSON   models.JSON        `json:"sku_snapshot"`
-	Tags              models.StringArray `json:"tags"`
-	UnitPrice         models.Money       `json:"unit_price"`
-	Quantity          int                `json:"quantity"`
-	TotalPrice        models.Money       `json:"total_price"`
-	MemberDiscount    models.Money       `json:"member_discount_amount"`
-	CouponDiscount    models.Money       `json:"coupon_discount_amount"`
-	PromotionDiscount models.Money       `json:"promotion_discount_amount"`
-	FulfillmentType   string             `json:"fulfillment_type"`
+	ProductID          uint               `json:"product_id"`
+	SKUID              uint               `json:"sku_id"`
+	TitleJSON          models.JSON        `json:"title"`
+	SKUSnapshotJSON    models.JSON        `json:"sku_snapshot"`
+	Tags               models.StringArray `json:"tags"`
+	OriginalUnitPrice  models.Money       `json:"original_unit_price"`
+	UnitPrice          models.Money       `json:"unit_price"`
+	Quantity           int                `json:"quantity"`
+	OriginalTotalPrice models.Money       `json:"original_total_price"`
+	TotalPrice         models.Money       `json:"total_price"`
+	MemberDiscount     models.Money       `json:"member_discount_amount"`
+	CouponDiscount     models.Money       `json:"coupon_discount_amount"`
+	PromotionDiscount  models.Money       `json:"promotion_discount_amount"`
+	FulfillmentType    string             `json:"fulfillment_type"`
 }
 
 type orderBuildResult struct {
@@ -280,6 +283,7 @@ func (s *OrderService) PreviewOrder(input CreateOrderInput) (*OrderPreview, erro
 		AffiliateVisitorKey: input.AffiliateVisitorKey,
 		ClientIP:            input.ClientIP,
 		ManualFormData:      input.ManualFormData,
+		SkipManualFormCheck: true,
 	})
 }
 
@@ -296,6 +300,7 @@ func (s *OrderService) PreviewGuestOrder(input CreateGuestOrderInput) (*OrderPre
 		ClientIP:            input.ClientIP,
 		IsGuest:             true,
 		ManualFormData:      input.ManualFormData,
+		SkipManualFormCheck: true,
 	})
 }
 
@@ -308,18 +313,20 @@ func (s *OrderService) previewOrder(input orderCreateParams) (*OrderPreview, err
 	for _, plan := range result.Plans {
 		item := plan.Item
 		items = append(items, OrderPreviewItem{
-			ProductID:         item.ProductID,
-			SKUID:             item.SKUID,
-			TitleJSON:         item.TitleJSON,
-			SKUSnapshotJSON:   item.SKUSnapshotJSON,
-			Tags:              item.Tags,
-			UnitPrice:         item.UnitPrice,
-			Quantity:          item.Quantity,
-			TotalPrice:        item.TotalPrice,
-			MemberDiscount:    item.MemberDiscount,
-			CouponDiscount:    item.CouponDiscount,
-			PromotionDiscount: item.PromotionDiscount,
-			FulfillmentType:   item.FulfillmentType,
+			ProductID:          item.ProductID,
+			SKUID:              item.SKUID,
+			TitleJSON:          item.TitleJSON,
+			SKUSnapshotJSON:    item.SKUSnapshotJSON,
+			Tags:               item.Tags,
+			OriginalUnitPrice:  item.OriginalUnitPrice,
+			UnitPrice:          item.UnitPrice,
+			Quantity:           item.Quantity,
+			OriginalTotalPrice: item.OriginalTotalPrice,
+			TotalPrice:         item.TotalPrice,
+			MemberDiscount:     item.MemberDiscount,
+			CouponDiscount:     item.CouponDiscount,
+			PromotionDiscount:  item.PromotionDiscount,
+			FulfillmentType:    item.FulfillmentType,
 		})
 	}
 	return &OrderPreview{

--- a/internal/service/order_service_test.go
+++ b/internal/service/order_service_test.go
@@ -451,6 +451,288 @@ func TestBuildOrderResultRejectsZeroPromotionPrice(t *testing.T) {
 	}
 }
 
+func TestPreviewOrderAppliesMemberDiscountForManualProductBeforeFormCompleted(t *testing.T) {
+	dsn := fmt.Sprintf("file:order_service_manual_member_preview_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite failed: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.Category{},
+		&models.Product{},
+		&models.ProductSKU{},
+		&models.Promotion{},
+		&models.User{},
+		&models.MemberLevel{},
+		&models.MemberLevelPrice{},
+	); err != nil {
+		t.Fatalf("auto migrate failed: %v", err)
+	}
+
+	now := time.Now()
+	category := models.Category{
+		Slug:      "manual-member-preview-category",
+		NameJSON:  models.JSON{"zh-CN": "测试分类"},
+		SortOrder: 0,
+		CreatedAt: now,
+	}
+	if err := db.Create(&category).Error; err != nil {
+		t.Fatalf("create category failed: %v", err)
+	}
+	level := models.MemberLevel{
+		NameJSON:     models.JSON{"zh-CN": "金牌会员"},
+		Slug:         "gold",
+		DiscountRate: models.NewMoneyFromDecimal(decimal.NewFromInt(80)),
+		IsActive:     true,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := db.Create(&level).Error; err != nil {
+		t.Fatalf("create member level failed: %v", err)
+	}
+	user := models.User{
+		Email:         "manual-preview@example.com",
+		PasswordHash:  "hash",
+		Status:        "active",
+		MemberLevelID: level.ID,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create user failed: %v", err)
+	}
+
+	product := models.Product{
+		CategoryID:      category.ID,
+		Slug:            "manual-member-preview-product",
+		TitleJSON:       models.JSON{"zh-CN": "人工发货商品"},
+		PriceAmount:     models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		PurchaseType:    constants.ProductPurchaseMember,
+		FulfillmentType: constants.FulfillmentTypeManual,
+		ManualFormSchemaJSON: models.JSON{
+			"fields": []interface{}{
+				map[string]interface{}{
+					"key":      "account",
+					"type":     "text",
+					"required": true,
+					"label":    map[string]interface{}{"zh-CN": "账号"},
+				},
+			},
+		},
+		IsActive:  true,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := db.Create(&product).Error; err != nil {
+		t.Fatalf("create product failed: %v", err)
+	}
+
+	sku := models.ProductSKU{
+		ProductID:         product.ID,
+		SKUCode:           models.DefaultSKUCode,
+		PriceAmount:       models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		IsActive:          true,
+		ManualStockTotal:  constants.ManualStockUnlimited,
+		ManualStockLocked: 0,
+		ManualStockSold:   0,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	if err := db.Create(&sku).Error; err != nil {
+		t.Fatalf("create sku failed: %v", err)
+	}
+
+	levelRepo := repository.NewMemberLevelRepository(db)
+	priceRepo := repository.NewMemberLevelPriceRepository(db)
+	userRepo := repository.NewUserRepository(db)
+	svc := NewOrderService(OrderServiceOptions{
+		UserRepo:           userRepo,
+		ProductRepo:        repository.NewProductRepository(db),
+		ProductSKURepo:     repository.NewProductSKURepository(db),
+		PromotionRepo:      repository.NewPromotionRepository(db),
+		MemberLevelService: NewMemberLevelService(levelRepo, priceRepo, userRepo),
+		ExpireMinutes:      15,
+	})
+
+	preview, err := svc.PreviewOrder(CreateOrderInput{
+		UserID: user.ID,
+		Items: []CreateOrderItem{
+			{
+				ProductID: product.ID,
+				SKUID:     sku.ID,
+				Quantity:  2,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("preview order failed: %v", err)
+	}
+
+	expectedOriginal := decimal.NewFromInt(200)
+	expectedMemberDiscount := decimal.NewFromInt(40)
+	expectedTotal := decimal.NewFromInt(160)
+	if !preview.OriginalAmount.Decimal.Equal(expectedOriginal) {
+		t.Fatalf("expected original amount %s, got: %s", expectedOriginal.String(), preview.OriginalAmount.String())
+	}
+	if !preview.MemberDiscountAmount.Decimal.Equal(expectedMemberDiscount) {
+		t.Fatalf("expected member discount amount %s, got: %s", expectedMemberDiscount.String(), preview.MemberDiscountAmount.String())
+	}
+	if !preview.TotalAmount.Decimal.Equal(expectedTotal) {
+		t.Fatalf("expected total amount %s, got: %s", expectedTotal.String(), preview.TotalAmount.String())
+	}
+}
+
+func TestBuildOrderResultStacksPromotionAndMemberDiscount(t *testing.T) {
+	dsn := fmt.Sprintf("file:order_service_stack_promo_member_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite failed: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.Category{},
+		&models.Product{},
+		&models.ProductSKU{},
+		&models.Promotion{},
+		&models.User{},
+		&models.MemberLevel{},
+		&models.MemberLevelPrice{},
+	); err != nil {
+		t.Fatalf("auto migrate failed: %v", err)
+	}
+
+	now := time.Now()
+	category := models.Category{
+		Slug:      "stack-promo-member-category",
+		NameJSON:  models.JSON{"zh-CN": "测试分类"},
+		SortOrder: 0,
+		CreatedAt: now,
+	}
+	if err := db.Create(&category).Error; err != nil {
+		t.Fatalf("create category failed: %v", err)
+	}
+	level := models.MemberLevel{
+		NameJSON:     models.JSON{"zh-CN": "金牌会员"},
+		Slug:         "stack-gold",
+		DiscountRate: models.NewMoneyFromDecimal(decimal.NewFromInt(80)),
+		IsActive:     true,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := db.Create(&level).Error; err != nil {
+		t.Fatalf("create member level failed: %v", err)
+	}
+	user := models.User{
+		Email:         "stack-promo-member@example.com",
+		PasswordHash:  "hash",
+		Status:        "active",
+		MemberLevelID: level.ID,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create user failed: %v", err)
+	}
+
+	product := models.Product{
+		CategoryID:      category.ID,
+		Slug:            "stack-promo-member-product",
+		TitleJSON:       models.JSON{"zh-CN": "叠加优惠商品"},
+		PriceAmount:     models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		PurchaseType:    constants.ProductPurchaseMember,
+		FulfillmentType: constants.FulfillmentTypeAuto,
+		IsActive:        true,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := db.Create(&product).Error; err != nil {
+		t.Fatalf("create product failed: %v", err)
+	}
+	sku := models.ProductSKU{
+		ProductID:   product.ID,
+		SKUCode:     models.DefaultSKUCode,
+		PriceAmount: models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		IsActive:    true,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := db.Create(&sku).Error; err != nil {
+		t.Fatalf("create sku failed: %v", err)
+	}
+	promotion := models.Promotion{
+		Name:       "test-10-percent",
+		ScopeType:  constants.ScopeTypeProduct,
+		ScopeRefID: product.ID,
+		Type:       constants.PromotionTypePercent,
+		Value:      models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+		MinAmount:  models.NewMoneyFromDecimal(decimal.Zero),
+		IsActive:   true,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := db.Create(&promotion).Error; err != nil {
+		t.Fatalf("create promotion failed: %v", err)
+	}
+
+	levelRepo := repository.NewMemberLevelRepository(db)
+	priceRepo := repository.NewMemberLevelPriceRepository(db)
+	userRepo := repository.NewUserRepository(db)
+	svc := NewOrderService(OrderServiceOptions{
+		UserRepo:           userRepo,
+		ProductRepo:        repository.NewProductRepository(db),
+		ProductSKURepo:     repository.NewProductSKURepository(db),
+		PromotionRepo:      repository.NewPromotionRepository(db),
+		MemberLevelService: NewMemberLevelService(levelRepo, priceRepo, userRepo),
+		ExpireMinutes:      15,
+	})
+
+	result, err := svc.buildOrderResult(orderCreateParams{
+		UserID: user.ID,
+		Items: []CreateOrderItem{
+			{
+				ProductID: product.ID,
+				SKUID:     sku.ID,
+				Quantity:  2,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildOrderResult failed: %v", err)
+	}
+
+	expectedOriginal := decimal.NewFromInt(200)
+	expectedPromotion := decimal.NewFromInt(20)
+	expectedMemberDiscount := decimal.NewFromInt(36)
+	expectedTotal := decimal.NewFromInt(144)
+	if !result.OriginalAmount.Equal(expectedOriginal) {
+		t.Fatalf("expected original amount %s, got: %s", expectedOriginal.String(), result.OriginalAmount.String())
+	}
+	if !result.PromotionDiscountAmount.Equal(expectedPromotion) {
+		t.Fatalf("expected promotion discount amount %s, got: %s", expectedPromotion.String(), result.PromotionDiscountAmount.String())
+	}
+	if !result.MemberDiscountAmount.Equal(expectedMemberDiscount) {
+		t.Fatalf("expected member discount amount %s, got: %s", expectedMemberDiscount.String(), result.MemberDiscountAmount.String())
+	}
+	if !result.TotalAmount.Equal(expectedTotal) {
+		t.Fatalf("expected total amount %s, got: %s", expectedTotal.String(), result.TotalAmount.String())
+	}
+	if len(result.Plans) != 1 {
+		t.Fatalf("expected one plan, got %d", len(result.Plans))
+	}
+	item := result.Plans[0].Item
+	if item.OriginalUnitPrice.String() != "100.00" {
+		t.Fatalf("expected original unit price 100.00, got %s", item.OriginalUnitPrice.String())
+	}
+	if item.OriginalTotalPrice.String() != "200.00" {
+		t.Fatalf("expected original total price 200.00, got %s", item.OriginalTotalPrice.String())
+	}
+	if item.UnitPrice.String() != "72.00" {
+		t.Fatalf("expected final unit price 72.00, got %s", item.UnitPrice.String())
+	}
+	if item.TotalPrice.String() != "144.00" {
+		t.Fatalf("expected final total price 144.00, got %s", item.TotalPrice.String())
+	}
+}
+
 func TestBuildOrderResultRejectsProductMaxPurchaseQuantityExceeded(t *testing.T) {
 	dsn := fmt.Sprintf("file:order_service_purchase_limit_%d?mode=memory&cache=shared", time.Now().UnixNano())
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})

--- a/internal/service/order_service_validate.go
+++ b/internal/service/order_service_validate.go
@@ -99,30 +99,31 @@ func (s *OrderService) buildOrderResult(input orderCreateParams) (*orderBuildRes
 		}
 		promoUnitPriceAmount := promoUnitPrice.Decimal.Round(2)
 
-		// 2. 计算会员价
-		memberUnitPrice := basePrice
-		itemMemberDiscount := decimal.Zero
-		if userMemberLevelID > 0 && s.memberLevelService != nil {
-			memberUnitPrice, _ = s.memberLevelService.ResolveMemberPrice(userMemberLevelID, product.ID, sku.ID, basePrice)
-		}
-
-		// 3. 取最低价（会员价 vs 活动价）
+		// 2. 先应用活动价，再在活动价基础上应用会员价
 		unitPriceAmount := promoUnitPriceAmount
 		promotionDiscount := decimal.Zero
-		if memberUnitPrice.LessThan(promoUnitPriceAmount) {
-			// 会员价更低，使用会员价
-			unitPriceAmount = memberUnitPrice
-			itemMemberDiscount = basePrice.Sub(memberUnitPrice).
-				Mul(decimal.NewFromInt(int64(item.Quantity))).
-				Round(2)
-			memberDiscountAmount = memberDiscountAmount.Add(itemMemberDiscount).Round(2)
-			promotion = nil // 不使用活动价
-		} else if promotion != nil && basePrice.GreaterThan(promoUnitPriceAmount) {
-			// 活动价更低或相等，使用活动价
+		if promotion != nil && basePrice.GreaterThan(promoUnitPriceAmount) {
 			promotionDiscount = basePrice.Sub(promoUnitPriceAmount).
 				Mul(decimal.NewFromInt(int64(item.Quantity))).
 				Round(2)
 			promotionDiscountAmount = promotionDiscountAmount.Add(promotionDiscount).Round(2)
+		}
+
+		itemMemberDiscount := decimal.Zero
+		if userMemberLevelID > 0 && s.memberLevelService != nil {
+			memberUnitPrice, _ := s.memberLevelService.ResolveMemberPrice(userMemberLevelID, product.ID, sku.ID, unitPriceAmount)
+			if memberUnitPrice.LessThan(unitPriceAmount) {
+				itemMemberDiscount = unitPriceAmount.Sub(memberUnitPrice).
+					Mul(decimal.NewFromInt(int64(item.Quantity))).
+					Round(2)
+				memberDiscountAmount = memberDiscountAmount.Add(itemMemberDiscount).Round(2)
+				unitPriceAmount = memberUnitPrice
+			}
+		}
+
+		// 3. 兼容活动规则命中但未形成实际优惠的情况
+		if promotion != nil && promotionDiscount.IsZero() && !basePrice.GreaterThan(promoUnitPriceAmount) {
+			promotion = nil
 		}
 
 		if unitPriceAmount.LessThanOrEqual(decimal.Zero) || productCurrency == "" {
@@ -147,8 +148,8 @@ func (s *OrderService) buildOrderResult(input orderCreateParams) (*orderBuildRes
 
 		manualSchemaSnapshot := models.JSON{}
 		manualSubmission := models.JSON{}
-		if fulfillmentType == constants.FulfillmentTypeManual ||
-			(fulfillmentType == constants.FulfillmentTypeUpstream && len(product.ManualFormSchemaJSON) > 0) {
+		if !input.SkipManualFormCheck && (fulfillmentType == constants.FulfillmentTypeManual ||
+			(fulfillmentType == constants.FulfillmentTypeUpstream && len(product.ManualFormSchemaJSON) > 0)) {
 			submission := resolveManualFormSubmission(manualFormData, product.ID, sku.ID)
 			normalizedSchema, normalizedSubmission, err := validateAndNormalizeManualForm(product.ManualFormSchemaJSON, submission)
 			if err != nil {
@@ -183,9 +184,11 @@ func (s *OrderService) buildOrderResult(input orderCreateParams) (*orderBuildRes
 				"image":       firstProductImage(product.Images),
 			},
 			Tags:                         product.Tags,
+			OriginalUnitPrice:            models.NewMoneyFromDecimal(basePrice),
 			UnitPrice:                    models.NewMoneyFromDecimal(unitPriceAmount),
 			CostPrice:                    sku.CostPriceAmount, // 成本价快照
 			Quantity:                     item.Quantity,
+			OriginalTotalPrice:           models.NewMoneyFromDecimal(baseTotal),
 			TotalPrice:                   models.NewMoneyFromDecimal(total),
 			MemberDiscount:               models.NewMoneyFromDecimal(itemMemberDiscount),
 			CouponDiscount:               models.NewMoneyFromDecimal(decimal.Zero),


### PR DESCRIPTION

后端：
1. 预览不检查自定义表单输入，用户不填自定义表单时，也可直接输出结果以方便用户查看优惠
2. 新增字段：订单接口，新增 original_unit_price original_total_price 两个字段，方便前端计算原始金额
该值需要加入快照，老订单由于没有原始订单价格值，所以老订单由原“unit_price”、“total_price”两个字段迁移。
3. 会员折扣逻辑变更：如果开启了会员折扣，会员可在当前活动价基础上，享受折上折，而不是二选一（原逻辑是活动价和会员折扣，取最大优惠）。

user 前端：
1. 购物车页面，应付金额改为“小计”，避免歧义
2. 优惠券、活动价、会员优惠等，非0值，应显示为负数方便客户理解

3. 订单结算页面：
- 不拦截自定义表单输入项
- 订单商品-子商品：“应付金额”砍掉，因为左右显示，在移动端，商品名较长的商品，会挤压很难看
- 订单商品-子商品：自动交付、游客可购等 badge 砍掉，保持界面干净，避免影响客户对价格的判断
- 订单商品-子商品：正确显示优惠价后的价格，并显示原价，如无优惠则显示原价

4. 订单详情页面：
- “优惠金额”改成“礼券金额”，避免产生歧义
- 子订单明细：单价、小计均为原始价格，方便客户判断原价
- 子订单明细：增加“共减”条目，显示所有优惠加起来的数值，方便客户判断省了多少钱
- 子订单明细：增加“实付金额”，该字段为客户实际为该项子商品花费的金额

admin 前端：
1. “优惠金额”改成“礼券金额”，避免产生歧义
2. 订单详情弹窗：
- 子订单明细：显示“共减”与“实付金额”，单价、小计均为原始价格（跟随 user 前端）

关联 admin 前端 PR: https://github.com/dujiao-next/admin/pull/38
关联 user 前端 PR: https://github.com/dujiao-next/user/pull/23

图片预览：

购物车页：
<img width="2319" height="673" alt="screenshot_2026-05-09_20-17-22" src="https://github.com/user-attachments/assets/6067dbb5-e3ea-4ef6-a1f5-8b9d5b3eddb1" />

订单结算页：
<img width="2369" height="708" alt="screenshot_2026-05-09_20-14-10" src="https://github.com/user-attachments/assets/176b98c3-4b68-4ebb-a0d9-63cb23363bc4" />

用户订单详情页：
<img width="2385" height="1649" alt="screenshot_2026-05-09_20-16-42" src="https://github.com/user-attachments/assets/4c0ebb6d-a2b1-4556-8154-291d0775ad5f" />

后台订单详情弹窗页：
<img width="1485" height="930" alt="screenshot_2026-05-09_20-56-31" src="https://github.com/user-attachments/assets/e5d5bd94-008b-44d8-a92d-cfb484daeee7" />


