### PR TITLE
fix: Urgent: Fix Telegram OIDC tgid identity error

### DIFF
--- a/internal/service/telegram_auth_service.go
+++ b/internal/service/telegram_auth_service.go
@@ -34,13 +34,14 @@ type TelegramLoginPayload struct {
 
 // TelegramIdentityVerified Telegram 身份校验结果
 type TelegramIdentityVerified struct {
-	Provider       string
-	ProviderUserID string
-	Username       string
-	AvatarURL      string
-	FirstName      string
-	LastName       string
-	AuthAt         time.Time
+	Provider              string
+	ProviderUserID        string
+	ProviderUserIDAliases []string
+	Username              string
+	AvatarURL             string
+	FirstName             string
+	LastName              string
+	AuthAt                time.Time
 }
 
 type telegramReplaySetNXFunc func(ctx context.Context, key string, value interface{}, ttl time.Duration) (bool, error)

--- a/internal/service/telegram_oidc.go
+++ b/internal/service/telegram_oidc.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -311,12 +312,14 @@ func (s *TelegramAuthService) CompleteOIDCLogin(ctx context.Context, code, state
 		return nil, "", 0, fmt.Errorf("%w: %v", ErrTelegramOIDCIDTokenInvalid, err)
 	}
 
-	providerUserID := strings.TrimSpace(claims.Subject)
-	if providerUserID == "" {
-		providerUserID = strings.TrimSpace(claims.ID.String())
-	}
-	if providerUserID == "" || providerUserID == "0" {
+	providerUserID, idNum, err := telegramOIDCProviderUserID(claims)
+	if err != nil {
 		return nil, "", 0, ErrTelegramOIDCIDTokenInvalid
+	}
+	subject := strings.TrimSpace(claims.Subject)
+	var providerUserIDAliases []string
+	if subject != "" && subject != providerUserID {
+		providerUserIDAliases = append(providerUserIDAliases, subject)
 	}
 	firstName, lastName := splitTelegramName(claims.Name)
 	authAt := time.Now()
@@ -324,24 +327,30 @@ func (s *TelegramAuthService) CompleteOIDCLogin(ctx context.Context, code, state
 		authAt = claims.IssuedAt.Time
 	}
 
-	idNum := int64(0)
-	if n, perr := claims.ID.Int64(); perr == nil {
-		idNum = n
-	}
 	fp := sha256.Sum256([]byte(tokResp.IDToken))
 	if err := s.markTelegramReplay(ctx, idNum, hex.EncodeToString(fp[:8]), cfg.ReplayTTLSeconds); err != nil {
 		return nil, "", 0, err
 	}
 
 	return &TelegramIdentityVerified{
-		Provider:       constants.UserOAuthProviderTelegram,
-		ProviderUserID: providerUserID,
-		Username:       strings.TrimSpace(claims.PreferredUsername),
-		AvatarURL:      strings.TrimSpace(claims.Picture),
-		FirstName:      firstName,
-		LastName:       lastName,
-		AuthAt:         authAt,
+		Provider:              constants.UserOAuthProviderTelegram,
+		ProviderUserID:        providerUserID,
+		ProviderUserIDAliases: providerUserIDAliases,
+		Username:              strings.TrimSpace(claims.PreferredUsername),
+		AvatarURL:             strings.TrimSpace(claims.Picture),
+		FirstName:             firstName,
+		LastName:              lastName,
+		AuthAt:                authAt,
 	}, st.Intent, st.UserID, nil
+}
+
+// telegramOIDCProviderUserID 从 Telegram OIDC claims 中提取标准 Telegram 数字用户 ID。
+func telegramOIDCProviderUserID(claims telegramOIDCIDClaims) (string, int64, error) {
+	idNum, err := claims.ID.Int64()
+	if err != nil || idNum <= 0 {
+		return "", 0, ErrTelegramOIDCIDTokenInvalid
+	}
+	return strconv.FormatInt(idNum, 10), idNum, nil
 }
 
 func splitTelegramName(name string) (string, string) {

--- a/internal/service/telegram_oidc_test.go
+++ b/internal/service/telegram_oidc_test.go
@@ -121,7 +121,7 @@ func TestCompleteOIDCLoginHappyPath(t *testing.T) {
 	claims := jwt.MapClaims{
 		"iss":                "https://oauth.telegram.org",
 		"aud":                clientID,
-		"sub":                "987654321",
+		"sub":                "1234123412341234123",
 		"iat":                now.Unix(),
 		"exp":                now.Add(time.Hour).Unix(),
 		"id":                 float64(987654321),
@@ -183,6 +183,9 @@ func TestCompleteOIDCLoginHappyPath(t *testing.T) {
 	}
 	if verified.ProviderUserID != "987654321" {
 		t.Fatalf("provider_user_id %q", verified.ProviderUserID)
+	}
+	if len(verified.ProviderUserIDAliases) != 1 || verified.ProviderUserIDAliases[0] != "1234123412341234123" {
+		t.Fatalf("provider_user_id aliases %#v", verified.ProviderUserIDAliases)
 	}
 	if verified.Username != "johndoe" {
 		t.Fatalf("username %q", verified.Username)

--- a/internal/service/user_auth_service_oauth.go
+++ b/internal/service/user_auth_service_oauth.go
@@ -168,7 +168,7 @@ func (s *UserAuthService) BindTelegramOIDC(input BindTelegramOIDCInput) (*models
 }
 
 func (s *UserAuthService) loginWithVerifiedTelegram(verified *TelegramIdentityVerified) (*UserLoginResult, error) {
-	identity, err := s.userOAuthIdentityRepo.GetByProviderUserID(verified.Provider, verified.ProviderUserID)
+	identity, err := s.getTelegramIdentityByVerifiedID(verified)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,11 @@ func (s *UserAuthService) loginWithVerifiedTelegram(verified *TelegramIdentityVe
 		if err != nil {
 			return nil, err
 		}
-		identityChanged := applyTelegramIdentity(verified, identity)
+		identityChanged, err := s.canonicalizeTelegramProviderUserID(verified, identity)
+		if err != nil {
+			return nil, err
+		}
+		identityChanged = applyTelegramIdentity(verified, identity) || identityChanged
 		if identityChanged {
 			identity.UpdatedAt = time.Now()
 			if err := s.userOAuthIdentityRepo.Update(identity); err != nil {
@@ -295,7 +299,7 @@ func (s *UserAuthService) bindVerifiedTelegram(userID uint, verified *TelegramId
 		return nil, err
 	}
 
-	occupied, err := s.userOAuthIdentityRepo.GetByProviderUserID(verified.Provider, verified.ProviderUserID)
+	occupied, err := s.getTelegramIdentityByVerifiedID(verified)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +311,7 @@ func (s *UserAuthService) bindVerifiedTelegram(userID uint, verified *TelegramId
 	if err != nil {
 		return nil, err
 	}
-	if current != nil && current.ProviderUserID != verified.ProviderUserID {
+	if current != nil && !telegramProviderUserIDMatchesVerified(current.ProviderUserID, verified) {
 		return nil, ErrUserOAuthAlreadyBound
 	}
 	if current == nil {
@@ -327,7 +331,11 @@ func (s *UserAuthService) bindVerifiedTelegram(userID uint, verified *TelegramId
 		return current, nil
 	}
 
-	if applyTelegramIdentity(verified, current) {
+	identityChanged, err := s.canonicalizeTelegramProviderUserID(verified, current)
+	if err != nil {
+		return nil, err
+	}
+	if applyTelegramIdentity(verified, current) || identityChanged {
 		current.UpdatedAt = time.Now()
 		if err := s.userOAuthIdentityRepo.Update(current); err != nil {
 			return nil, err
@@ -661,6 +669,61 @@ func (s *UserAuthService) findOrCreateTelegramUser(verified *TelegramIdentityVer
 		_ = s.memberLevelSvc.AssignDefaultLevel(user.ID)
 	}
 	return user, nil
+}
+
+// getTelegramIdentityByVerifiedID 按 Telegram 数字 ID 查询绑定，未命中时兼容历史 OIDC subject 绑定。
+func (s *UserAuthService) getTelegramIdentityByVerifiedID(verified *TelegramIdentityVerified) (*models.UserOAuthIdentity, error) {
+	if verified == nil || s.userOAuthIdentityRepo == nil {
+		return nil, ErrTelegramAuthConfigInvalid
+	}
+	identity, err := s.userOAuthIdentityRepo.GetByProviderUserID(verified.Provider, verified.ProviderUserID)
+	if err != nil || identity != nil {
+		return identity, err
+	}
+	for _, alias := range verified.ProviderUserIDAliases {
+		alias = strings.TrimSpace(alias)
+		if alias == "" || alias == verified.ProviderUserID {
+			continue
+		}
+		identity, err = s.userOAuthIdentityRepo.GetByProviderUserID(verified.Provider, alias)
+		if err != nil || identity != nil {
+			return identity, err
+		}
+	}
+	return nil, nil
+}
+
+// canonicalizeTelegramProviderUserID 将历史 OIDC subject 绑定迁移为 Telegram 数字用户 ID。
+func (s *UserAuthService) canonicalizeTelegramProviderUserID(verified *TelegramIdentityVerified, identity *models.UserOAuthIdentity) (bool, error) {
+	if verified == nil || identity == nil || identity.ProviderUserID == verified.ProviderUserID {
+		return false, nil
+	}
+	occupied, err := s.userOAuthIdentityRepo.GetByProviderUserID(verified.Provider, verified.ProviderUserID)
+	if err != nil {
+		return false, err
+	}
+	if occupied != nil && occupied.ID != identity.ID {
+		return false, ErrUserOAuthIdentityExists
+	}
+	identity.ProviderUserID = verified.ProviderUserID
+	return true, nil
+}
+
+// telegramProviderUserIDMatchesVerified 判断绑定 ID 是否匹配当前 Telegram 身份或其历史别名。
+func telegramProviderUserIDMatchesVerified(providerUserID string, verified *TelegramIdentityVerified) bool {
+	providerUserID = strings.TrimSpace(providerUserID)
+	if verified == nil || providerUserID == "" {
+		return false
+	}
+	if providerUserID == verified.ProviderUserID {
+		return true
+	}
+	for _, alias := range verified.ProviderUserIDAliases {
+		if providerUserID == strings.TrimSpace(alias) {
+			return true
+		}
+	}
+	return false
 }
 
 func applyTelegramIdentity(verified *TelegramIdentityVerified, identity *models.UserOAuthIdentity) bool {

--- a/internal/service/user_auth_service_oauth_test.go
+++ b/internal/service/user_auth_service_oauth_test.go
@@ -129,6 +129,60 @@ func TestLoginWithTelegramAllowsExistingIdentityWhenRegistrationDisabled(t *test
 	}
 }
 
+func TestLoginWithTelegramMigratesOIDCSubjectIdentityToTelegramID(t *testing.T) {
+	svc, db := setupTelegramOAuthTestService(t)
+
+	now := time.Now()
+	user := &models.User{
+		Email:        telegramidentity.BuildPlaceholderEmail("1234123412341234123"),
+		PasswordHash: "telegram-auto",
+		DisplayName:  "OIDC Existing",
+		Status:       constants.UserStatusActive,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := db.Create(user).Error; err != nil {
+		t.Fatalf("create user failed: %v", err)
+	}
+	identity := &models.UserOAuthIdentity{
+		UserID:         user.ID,
+		Provider:       constants.UserOAuthProviderTelegram,
+		ProviderUserID: "1234123412341234123",
+		Username:       "old_oidc",
+		AuthAt:         &now,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := db.Create(identity).Error; err != nil {
+		t.Fatalf("create identity failed: %v", err)
+	}
+
+	res, err := svc.loginWithVerifiedTelegram(&TelegramIdentityVerified{
+		Provider:              constants.UserOAuthProviderTelegram,
+		ProviderUserID:        "987654321",
+		ProviderUserIDAliases: []string{"1234123412341234123"},
+		Username:              "new_oidc",
+		AuthAt:                time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("loginWithVerifiedTelegram returned error: %v", err)
+	}
+	if res.User == nil || res.User.ID != user.ID {
+		t.Fatalf("expected existing user %d, got %+v", user.ID, res.User)
+	}
+
+	var migrated models.UserOAuthIdentity
+	if err := db.First(&migrated, identity.ID).Error; err != nil {
+		t.Fatalf("load migrated identity failed: %v", err)
+	}
+	if migrated.ProviderUserID != "987654321" {
+		t.Fatalf("provider user id not migrated: %q", migrated.ProviderUserID)
+	}
+	if migrated.Username != "new_oidc" {
+		t.Fatalf("username not updated: %q", migrated.Username)
+	}
+}
+
 func TestTelegramMiniAppLoginReturnsRegistrationDisabledWhenCreatingNewUser(t *testing.T) {
 	svc, _ := setupTelegramOAuthTestService(t)
 	telegramSvc := NewTelegramAuthService(config.TelegramAuthConfig{


### PR DESCRIPTION
紧急修正 Telegram Widget 登录和 OIDC 登录，代码前后逻辑不一致，导致电报老用户登录身份识别错误问题

详情：
9dadd18feb097de9446aa9fede89f007ea50ce21 OIDC 提交，错误的将 OIDC sub 作为了用户 ID（第三方ID），导致电报老用户无法登录到他之前创建的账号。
请求开发者尽快合并该提交。

OIDC sub 格式: 17272877123451234123
Telegram 数字 ID 格式: 1012323123


修复后的逻辑：

1. **早期已经注册过的账号（已有正确 Telegram 数字 ID）：**
   - 早期账号：`provider_user_id = Telegram数字ID`
   - bug 期间账号：`provider_user_id = OIDC sub`
   - 修复后同一个 Telegram 用户再登录时，会先按 Telegram 数字 ID 命中早期账号。
   - bug 期间注册的账号不会被自动登录到，也不会自动迁移。

2. **只有 bug 期间账号，没有早期账号**
   - 修复后会通过 `sub` alias 找到这个历史绑定。
   - 然后把它的 `provider_user_id` 自动迁移成 Telegram 数字 ID。

3. **在 bug 期间，这个老用户又注册了一个账号**
   - 两个账号都存在，不会自动合并。
   - 因为两个账号可能各自有订单、余额、钱包流水、邮箱、会员等级等数据，自动合并风险比较高。
   - 当前行为逻辑是：该用户 Telegram 登录回到正确的老账号，bug 期间账号作为独立账号保留，让店家自行处理在 bug 期间注册的账号。

修复以后，跟随老的 Widget 登录方式，第三方ID 那里，将会正确显示 Telegram 的用户 ID。