### PR TITLE
feat: 易用性相关调整

### DIFF
--- a/internal/http/handlers/admin/admin_payment.go
+++ b/internal/http/handlers/admin/admin_payment.go
@@ -21,6 +21,7 @@ import (
 type AdminPaymentItem struct {
 	models.Payment
 	ChannelName    string `json:"channel_name"`
+	OrderNo        string `json:"order_no,omitempty"`
 	RechargeNo     string `json:"recharge_no,omitempty"`
 	RechargeStatus string `json:"recharge_status,omitempty"`
 	RechargeUserID uint   `json:"recharge_user_id,omitempty"`
@@ -57,6 +58,11 @@ func (h *Handler) GetAdminPayments(c *gin.Context) {
 		shared.RespondError(c, response.CodeInternal, "error.payment_fetch_failed", err)
 		return
 	}
+	orderNoMap, err := h.resolvePaymentOrderNos(payments)
+	if err != nil {
+		shared.RespondError(c, response.CodeInternal, "error.payment_fetch_failed", err)
+		return
+	}
 
 	items := make([]AdminPaymentItem, 0, len(payments))
 	for _, payment := range payments {
@@ -64,6 +70,7 @@ func (h *Handler) GetAdminPayments(c *gin.Context) {
 		items = append(items, AdminPaymentItem{
 			Payment:        payment,
 			ChannelName:    channelNameMap[payment.ChannelID],
+			OrderNo:        orderNoMap[payment.OrderID],
 			RechargeNo:     rechargeMeta.RechargeNo,
 			RechargeStatus: rechargeMeta.Status,
 			RechargeUserID: rechargeMeta.UserID,
@@ -170,10 +177,16 @@ func (h *Handler) GetAdminPayment(c *gin.Context) {
 		shared.RespondError(c, response.CodeInternal, "error.payment_fetch_failed", err)
 		return
 	}
+	orderNoMap, err := h.resolvePaymentOrderNos([]models.Payment{*payment})
+	if err != nil {
+		shared.RespondError(c, response.CodeInternal, "error.payment_fetch_failed", err)
+		return
+	}
 	rechargeMeta := rechargeMetaMap[payment.ID]
 	response.Success(c, AdminPaymentItem{
 		Payment:        *payment,
 		ChannelName:    channelNameMap[payment.ChannelID],
+		OrderNo:        orderNoMap[payment.OrderID],
 		RechargeNo:     rechargeMeta.RechargeNo,
 		RechargeStatus: rechargeMeta.Status,
 		RechargeUserID: rechargeMeta.UserID,
@@ -277,6 +290,33 @@ func (h *Handler) resolvePaymentChannelNames(payments []models.Payment) (map[uin
 	}
 	for _, channel := range channels {
 		result[channel.ID] = channel.Name
+	}
+	return result, nil
+}
+
+func (h *Handler) resolvePaymentOrderNos(payments []models.Payment) (map[uint]string, error) {
+	orderIDs := make([]uint, 0, len(payments))
+	seen := make(map[uint]struct{})
+	for _, payment := range payments {
+		if payment.OrderID == 0 {
+			continue
+		}
+		if _, ok := seen[payment.OrderID]; ok {
+			continue
+		}
+		seen[payment.OrderID] = struct{}{}
+		orderIDs = append(orderIDs, payment.OrderID)
+	}
+	result := make(map[uint]string)
+	if len(orderIDs) == 0 || h.OrderRepo == nil {
+		return result, nil
+	}
+	orders, err := h.OrderRepo.GetByIDs(orderIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, order := range orders {
+		result[order.ID] = strings.TrimSpace(order.OrderNo)
 	}
 	return result, nil
 }

--- a/internal/http/handlers/admin/admin_payment_test.go
+++ b/internal/http/handlers/admin/admin_payment_test.go
@@ -27,6 +27,7 @@ type adminPaymentFixture struct {
 	User1ID              uint
 	User2ID              uint
 	OrderPaymentID       uint
+	OrderNo              string
 	RechargePaymentUser1 uint
 	RechargePaymentUser2 uint
 	RechargeNoUser1      string
@@ -54,6 +55,7 @@ func setupAdminPaymentHandlerTest(t *testing.T) (*Handler, *gorm.DB) {
 
 	paymentRepo := repository.NewPaymentRepository(db)
 	paymentChannelRepo := repository.NewPaymentChannelRepository(db)
+	orderRepo := repository.NewOrderRepository(db)
 	walletRepo := repository.NewWalletRepository(db)
 	paymentService := service.NewPaymentService(service.PaymentServiceOptions{
 		PaymentRepo:   paymentRepo,
@@ -65,6 +67,7 @@ func setupAdminPaymentHandlerTest(t *testing.T) (*Handler, *gorm.DB) {
 	h := &Handler{Container: &provider.Container{
 		PaymentService:     paymentService,
 		PaymentChannelRepo: paymentChannelRepo,
+		OrderRepo:          orderRepo,
 		WalletRepo:         walletRepo,
 	}}
 	return h, db
@@ -246,6 +249,7 @@ func seedAdminPaymentData(t *testing.T, db *gorm.DB) adminPaymentFixture {
 		User1ID:              user1.ID,
 		User2ID:              user2.ID,
 		OrderPaymentID:       orderPayment.ID,
+		OrderNo:              order.OrderNo,
 		RechargePaymentUser1: rechargePaymentUser1.ID,
 		RechargePaymentUser2: rechargePaymentUser2.ID,
 		RechargeNoUser1:      rechargeNoUser1,
@@ -303,7 +307,11 @@ func TestGetAdminPaymentsFiltersByUserID(t *testing.T) {
 		if !ok {
 			t.Fatalf("row id missing or invalid: %+v", row)
 		}
-		gotIDs[uint(idRaw)] = struct{}{}
+		id := uint(idRaw)
+		gotIDs[id] = struct{}{}
+		if id == fixture.OrderPaymentID && row["order_no"] != fixture.OrderNo {
+			t.Fatalf("order payment order_no want %q got %+v", fixture.OrderNo, row["order_no"])
+		}
 	}
 	if _, ok := gotIDs[fixture.OrderPaymentID]; !ok {
 		t.Fatalf("missing order payment id %d", fixture.OrderPaymentID)

--- a/internal/http/handlers/admin/admin_user.go
+++ b/internal/http/handlers/admin/admin_user.go
@@ -84,6 +84,11 @@ func (h *Handler) GetAdminUsers(c *gin.Context) {
 	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
 	page, pageSize = shared.NormalizePagination(page, pageSize)
 
+	userID, err := shared.ParseQueryUint(c.Query("user_id"), true)
+	if err != nil {
+		shared.RespondError(c, response.CodeBadRequest, "error.user_id_invalid", err)
+		return
+	}
 	keyword := strings.TrimSpace(c.Query("keyword"))
 	status := strings.TrimSpace(c.Query("status"))
 	createdFromRaw := strings.TrimSpace(c.Query("created_from"))
@@ -115,6 +120,7 @@ func (h *Handler) GetAdminUsers(c *gin.Context) {
 	users, total, err := h.UserRepo.List(repository.UserListFilter{
 		Page:          page,
 		PageSize:      pageSize,
+		UserID:        userID,
 		Keyword:       keyword,
 		Status:        status,
 		CreatedFrom:   createdFrom,

--- a/internal/repository/admin_search_repository_test.go
+++ b/internal/repository/admin_search_repository_test.go
@@ -58,6 +58,14 @@ func TestUserRepositoryListSupportsOAuthKeyword(t *testing.T) {
 	if total != 1 || len(users) != 1 || users[0].ID != user1.ID {
 		t.Fatalf("unexpected result by provider user id: total=%d users=%+v", total, users)
 	}
+
+	users, total, err = userRepo.List(UserListFilter{Page: 1, PageSize: 20, UserID: user2.ID})
+	if err != nil {
+		t.Fatalf("list by user id failed: %v", err)
+	}
+	if total != 1 || len(users) != 1 || users[0].ID != user2.ID {
+		t.Fatalf("unexpected result by user id: total=%d users=%+v", total, users)
+	}
 }
 
 func TestOrderRepositoryListAdminSupportsUserKeyword(t *testing.T) {

--- a/internal/repository/types.go
+++ b/internal/repository/types.go
@@ -113,6 +113,7 @@ type CouponUsageListFilter struct {
 type UserListFilter struct {
 	Page          int
 	PageSize      int
+	UserID        uint
 	Keyword       string
 	Status        string
 	CreatedFrom   *time.Time

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -89,6 +89,9 @@ func (r *GormUserRepository) Update(user *models.User) error {
 func (r *GormUserRepository) List(filter UserListFilter) ([]models.User, int64, error) {
 	query := r.db.Model(&models.User{})
 
+	if filter.UserID != 0 {
+		query = query.Where("users.id = ?", filter.UserID)
+	}
 	if filter.Keyword != "" {
 		like := "%" + filter.Keyword + "%"
 		query = query.Where(


### PR DESCRIPTION
后端相关调整：
admin_payment 处理器添加订单号字段。
admin_user 处理器添加用户 ID 过滤方式。

admin 前端相关调整：
1. 支付记录-支付详情弹窗，如果是充值订单，订单ID卡片中，例如：“充值用户：`#100`”这个 `#100` 改成链接，可以点进去，方便为掉单用户手动补单。
2. 订单退款页面：用户列例如 `#100` 是一个链接，可以点进去，方便查看用户详情。
3. 返利用户、佣金记录、提现审核：用户列例如 `#100` 是一个链接，可以点进去。
4. API 凭证管理：用户列 "ID: 100" 是一个链接，可以点进去。
5. 用户详情页面：订单记录标签页：订单号是一个链接，可以点进去，并添加了复制按钮。
6. 用户详情页面：支付记录标签页，如果是充值订单，例如 WR202605...，是一个链接，加上了复制按钮，点击后打开对应的支付详情弹窗。
7. 用户详情页面：支付记录标签页，订单ID `#111` 改成显示订单号，而不是订单 ID，加上了复制按钮。
8. 用户详情页面：支付记录标签页，将 订单ID 列，文案改成“订单号”。
9. 用户管理页面：新增一个 用户ID 搜索框，允许用用户 ID 查找。
10. 支付记录：支付详情弹窗：订单ID卡片，改文案为“订单号”，该卡片显示订单号，加上了复制按钮。

关联 admin 前端 PR: https://github.com/dujiao-next/admin/pull/39