### PR TITLE
feat: payment record: When an order expires, the payment record should also expire

### DIFF
--- a/internal/provider/container.go
+++ b/internal/provider/container.go
@@ -262,6 +262,7 @@ func (c *Container) initServices() {
 	c.OrderService = service.NewOrderService(service.OrderServiceOptions{
 		OrderRepo:             c.OrderRepo,
 		OrderRefundRecordRepo: c.OrderRefundRecordRepo,
+		PaymentRepo:           c.PaymentRepo,
 		UserRepo:              c.UserRepo,
 		ProductRepo:           c.ProductRepo,
 		ProductSKURepo:        c.ProductSKURepo,

--- a/internal/repository/payment_repository.go
+++ b/internal/repository/payment_repository.go
@@ -22,6 +22,7 @@ type PaymentRepository interface {
 	GetLatestByProviderRef(providerRef string) (*models.Payment, error)
 	ListByOrderID(orderID uint) ([]models.Payment, error)
 	GetLatestPendingByOrder(orderID uint, now time.Time) (*models.Payment, error)
+	ExpirePendingByOrderIDs(orderIDs []uint, expiredAt time.Time) (int64, error)
 	ListAdmin(filter PaymentListFilter) ([]models.Payment, int64, error)
 	Transaction(fn func(tx *gorm.DB) error) error
 	GetByIDForUpdate(id uint) (*models.Payment, error)
@@ -159,6 +160,21 @@ func (r *GormPaymentRepository) GetLatestPendingByOrderChannel(orderID uint, cha
 		return nil, nil
 	}
 	return &payment, nil
+}
+
+// ExpirePendingByOrderIDs 将指定订单的未完成支付记录标记为过期。
+func (r *GormPaymentRepository) ExpirePendingByOrderIDs(orderIDs []uint, expiredAt time.Time) (int64, error) {
+	if len(orderIDs) == 0 {
+		return 0, nil
+	}
+	result := r.db.Model(&models.Payment{}).
+		Where("order_id IN ? AND status IN ?", orderIDs, []string{constants.PaymentStatusInitiated, constants.PaymentStatusPending}).
+		Updates(map[string]interface{}{
+			"status":     constants.PaymentStatusExpired,
+			"expired_at": expiredAt,
+			"updated_at": expiredAt,
+		})
+	return result.RowsAffected, result.Error
 }
 
 // ListAdmin 管理端支付列表

--- a/internal/service/order_service.go
+++ b/internal/service/order_service.go
@@ -20,6 +20,7 @@ import (
 type OrderService struct {
 	orderRepo             repository.OrderRepository
 	orderRefundRecordRepo repository.OrderRefundRecordRepository
+	paymentRepo           repository.PaymentRepository
 	userRepo              repository.UserRepository
 	productRepo           repository.ProductRepository
 	productSKURepo        repository.ProductSKURepository
@@ -41,6 +42,7 @@ type OrderService struct {
 type OrderServiceOptions struct {
 	OrderRepo             repository.OrderRepository
 	OrderRefundRecordRepo repository.OrderRefundRecordRepository
+	PaymentRepo           repository.PaymentRepository
 	UserRepo              repository.UserRepository
 	ProductRepo           repository.ProductRepository
 	ProductSKURepo        repository.ProductSKURepository
@@ -63,6 +65,7 @@ func NewOrderService(opts OrderServiceOptions) *OrderService {
 	return &OrderService{
 		orderRepo:             opts.OrderRepo,
 		orderRefundRecordRepo: opts.OrderRefundRecordRepo,
+		paymentRepo:           opts.PaymentRepo,
 		userRepo:              opts.UserRepo,
 		productRepo:           opts.ProductRepo,
 		productSKURepo:        opts.ProductSKURepo,
@@ -567,7 +570,7 @@ func (s *OrderService) createOrder(input orderCreateParams) (*models.Order, erro
 					"error", fetchErr,
 				)
 			} else if full != nil {
-				if cancelErr := s.cancelOrderWithChildren(full, true); cancelErr != nil {
+				if cancelErr := s.cancelOrderWithChildren(full, true, false); cancelErr != nil {
 					logger.Errorw("order_timeout_rollback_cancel_failed",
 						"order_id", order.ID,
 						"order_no", order.OrderNo,

--- a/internal/service/order_service_child.go
+++ b/internal/service/order_service_child.go
@@ -14,7 +14,7 @@ import (
 )
 
 // cancelOrderWithChildren 取消父订单并级联子订单
-func (s *OrderService) cancelOrderWithChildren(order *models.Order, rollbackCoupon bool) error {
+func (s *OrderService) cancelOrderWithChildren(order *models.Order, rollbackCoupon bool, expirePendingPayments bool) error {
 	if order == nil {
 		return ErrOrderNotFound
 	}
@@ -94,6 +94,17 @@ func (s *OrderService) cancelOrderWithChildren(order *models.Order, rollbackCoup
 				return err
 			}
 		}
+		if expirePendingPayments && s.paymentRepo != nil {
+			orderIDs := []uint{order.ID}
+			for _, child := range order.Children {
+				if child.ID > 0 {
+					orderIDs = append(orderIDs, child.ID)
+				}
+			}
+			if _, err := s.paymentRepo.WithTx(tx).ExpirePendingByOrderIDs(orderIDs, now); err != nil {
+				return ErrOrderUpdateFailed
+			}
+		}
 		return nil
 	})
 	if err != nil {
@@ -122,7 +133,7 @@ func (s *OrderService) CancelOrder(orderID uint, userID uint) (*models.Order, er
 	if order.Status != constants.OrderStatusPendingPayment {
 		return nil, ErrOrderCancelNotAllowed
 	}
-	if err := s.cancelOrderWithChildren(order, false); err != nil {
+	if err := s.cancelOrderWithChildren(order, false, false); err != nil {
 		return nil, ErrOrderUpdateFailed
 	}
 	if s.affiliateSvc != nil {
@@ -168,7 +179,7 @@ func (s *OrderService) UpdateOrderStatus(orderID uint, targetStatus string) (*mo
 	if isParent {
 		switch target {
 		case constants.OrderStatusCanceled:
-			if err := s.cancelOrderWithChildren(order, true); err != nil {
+			if err := s.cancelOrderWithChildren(order, true, false); err != nil {
 				return nil, ErrOrderUpdateFailed
 			}
 			if s.affiliateSvc != nil {
@@ -526,7 +537,7 @@ func (s *OrderService) CancelExpiredOrder(orderID uint) (*models.Order, error) {
 	if order.ExpiresAt.After(now) {
 		return order, nil
 	}
-	if err := s.cancelOrderWithChildren(order, true); err != nil {
+	if err := s.cancelOrderWithChildren(order, true, true); err != nil {
 		return nil, err
 	}
 	if s.affiliateSvc != nil {

--- a/internal/service/order_service_query.go
+++ b/internal/service/order_service_query.go
@@ -85,7 +85,7 @@ func (s *OrderService) ensureOrderCanceledIfExpired(order *models.Order) error {
 	if order.ExpiresAt.After(time.Now()) {
 		return nil
 	}
-	if err := s.cancelOrderWithChildren(order, true); err != nil {
+	if err := s.cancelOrderWithChildren(order, true, true); err != nil {
 		return err
 	}
 	if s.queueClient != nil {

--- a/internal/service/order_service_test.go
+++ b/internal/service/order_service_test.go
@@ -220,6 +220,120 @@ func TestIsTransitionAllowedRefunded(t *testing.T) {
 	}
 }
 
+func TestCancelExpiredOrderExpiresPendingPayments(t *testing.T) {
+	dsn := fmt.Sprintf("file:order_service_expire_payments_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite failed: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.Order{},
+		&models.OrderItem{},
+		&models.Fulfillment{},
+		&models.Product{},
+		&models.ProductSKU{},
+		&models.Coupon{},
+		&models.CouponUsage{},
+		&models.Payment{},
+	); err != nil {
+		t.Fatalf("auto migrate failed: %v", err)
+	}
+
+	now := time.Now()
+	expiresAt := now.Add(-time.Hour)
+	order := &models.Order{
+		OrderNo:          "EXPIRE-PAYMENT-001",
+		Status:           constants.OrderStatusPendingPayment,
+		Currency:         "CNY",
+		OriginalAmount:   models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		DiscountAmount:   models.NewMoneyFromDecimal(decimal.Zero),
+		TotalAmount:      models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		WalletPaidAmount: models.NewMoneyFromDecimal(decimal.Zero),
+		OnlinePaidAmount: models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		RefundedAmount:   models.NewMoneyFromDecimal(decimal.Zero),
+		ExpiresAt:        &expiresAt,
+		CreatedAt:        now.Add(-2 * time.Hour),
+		UpdatedAt:        now.Add(-2 * time.Hour),
+	}
+	if err := db.Create(order).Error; err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	pendingPayment := &models.Payment{
+		OrderID:         order.ID,
+		ChannelID:       1,
+		ProviderType:    constants.PaymentProviderEpay,
+		ChannelType:     "alipay",
+		InteractionMode: constants.PaymentInteractionQR,
+		Amount:          models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		Currency:        "CNY",
+		Status:          constants.PaymentStatusPending,
+		CreatedAt:       now.Add(-2 * time.Hour),
+		UpdatedAt:       now.Add(-2 * time.Hour),
+	}
+	initiatedPayment := &models.Payment{
+		OrderID:         order.ID,
+		ChannelID:       1,
+		ProviderType:    constants.PaymentProviderEpay,
+		ChannelType:     "alipay",
+		InteractionMode: constants.PaymentInteractionQR,
+		Amount:          models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		Currency:        "CNY",
+		Status:          constants.PaymentStatusInitiated,
+		CreatedAt:       now.Add(-2 * time.Hour),
+		UpdatedAt:       now.Add(-2 * time.Hour),
+	}
+	successPayment := &models.Payment{
+		OrderID:         order.ID,
+		ChannelID:       1,
+		ProviderType:    constants.PaymentProviderEpay,
+		ChannelType:     "alipay",
+		InteractionMode: constants.PaymentInteractionQR,
+		Amount:          models.NewMoneyFromDecimal(decimal.NewFromInt(100)),
+		Currency:        "CNY",
+		Status:          constants.PaymentStatusSuccess,
+		CreatedAt:       now.Add(-2 * time.Hour),
+		UpdatedAt:       now.Add(-2 * time.Hour),
+		PaidAt:          &now,
+	}
+	if err := db.Create([]*models.Payment{pendingPayment, initiatedPayment, successPayment}).Error; err != nil {
+		t.Fatalf("create payments failed: %v", err)
+	}
+
+	svc := NewOrderService(OrderServiceOptions{
+		OrderRepo:       repository.NewOrderRepository(db),
+		PaymentRepo:     repository.NewPaymentRepository(db),
+		ProductRepo:     repository.NewProductRepository(db),
+		ProductSKURepo:  repository.NewProductSKURepository(db),
+		CouponRepo:      repository.NewCouponRepository(db),
+		CouponUsageRepo: repository.NewCouponUsageRepository(db),
+	})
+	updated, err := svc.CancelExpiredOrder(order.ID)
+	if err != nil {
+		t.Fatalf("cancel expired order failed: %v", err)
+	}
+	if updated == nil || updated.Status != constants.OrderStatusCanceled {
+		t.Fatalf("expected canceled order, got: %+v", updated)
+	}
+
+	var reloaded []models.Payment
+	if err := db.Order("id asc").Find(&reloaded, "order_id = ?", order.ID).Error; err != nil {
+		t.Fatalf("reload payments failed: %v", err)
+	}
+	if len(reloaded) != 3 {
+		t.Fatalf("expected 3 payments, got %d", len(reloaded))
+	}
+	if reloaded[0].Status != constants.PaymentStatusExpired || reloaded[0].ExpiredAt == nil {
+		t.Fatalf("pending payment should expire, got status=%s expired_at=%v", reloaded[0].Status, reloaded[0].ExpiredAt)
+	}
+	if reloaded[1].Status != constants.PaymentStatusExpired || reloaded[1].ExpiredAt == nil {
+		t.Fatalf("initiated payment should expire, got status=%s expired_at=%v", reloaded[1].Status, reloaded[1].ExpiredAt)
+	}
+	if reloaded[2].Status != constants.PaymentStatusSuccess || reloaded[2].ExpiredAt != nil {
+		t.Fatalf("success payment should stay success without expired_at, got status=%s expired_at=%v", reloaded[2].Status, reloaded[2].ExpiredAt)
+	}
+}
+
 func TestUpdateOrderStatusParentToPartiallyRefundedSyncsChildren(t *testing.T) {
 	dsn := fmt.Sprintf("file:order_service_parent_partial_refund_%d?mode=memory&cache=shared", time.Now().UnixNano())
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})


### PR DESCRIPTION
`CancelExpiredOrder` 实际只调用了 `cancelOrderWithChildren`，没有更新支付记录。
钱包充值有单独的过期逻辑，但普通订单支付没有，所以如果用户选了某个支付方式，一直不付钱，退回来了，订单超时后，管理端支付记录会一直显示为“已创建/处理中”。

所以，我修改为：

订单的超时任务把订单取消的同时，只要过期队列任务正常执行，就会一同把关联的 `payments` 记录从 `pending/initiated` 改成 `expired`。

逻辑：

订单超时取消时，`CancelExpiredOrder -> cancelOrderWithChildren(..., expirePendingPayments=true)` 会把关联的 `initiated/pending` 支付记录更新为 `expired`。

旧的历史记录我没动，只对新产生的充值/购买订单有效。