### PR TITLE
feat: adminuser: Admin can unbind user's telegram

### DIFF
--- a/internal/authz/bootstrap.go
+++ b/internal/authz/bootstrap.go
@@ -96,6 +96,7 @@ func BuiltinRoleSeeds() []RoleSeed {
 				{Object: "/admin/users/:id/wallet/transactions", Action: "GET"},
 				{Object: "/admin/users/:id/wallet/adjust", Action: "POST"},
 				{Object: "/admin/users/:id/member-level", Action: "PUT"},
+				{Object: "/admin/users/:id/oauth/telegram", Action: "DELETE"},
 				{Object: "/admin/users/:id/2fa", Action: "DELETE"}, // 客服协助用户重置丢失 TOTP+恢复码 的 2FA
 				{Object: "/admin/user-login-logs", Action: "GET"},
 				{Object: "/admin/wallet/recharges", Action: "GET"},

--- a/internal/http/handlers/admin/admin_user.go
+++ b/internal/http/handlers/admin/admin_user.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -313,6 +314,34 @@ func (h *Handler) UpdateAdminUser(c *gin.Context) {
 	_ = cache.SetUserAuthState(c.Request.Context(), cache.BuildUserAuthState(user))
 
 	response.Success(c, user)
+}
+
+// UnbindAdminUserTelegram 管理员解除目标用户的 Telegram 绑定。
+// DELETE /admin/users/:id/oauth/telegram
+func (h *Handler) UnbindAdminUserTelegram(c *gin.Context) {
+	userID, err := shared.ParseParamUint(c, "id")
+	if err != nil {
+		shared.RespondError(c, response.CodeBadRequest, "error.user_id_invalid", nil)
+		return
+	}
+
+	if err := h.UserAuthService.UnbindTelegram(userID); err != nil {
+		switch {
+		case errors.Is(err, service.ErrNotFound):
+			shared.RespondError(c, response.CodeNotFound, "error.user_not_found", nil)
+		case errors.Is(err, service.ErrUserDisabled):
+			shared.RespondError(c, response.CodeBadRequest, "error.user_disabled", nil)
+		case errors.Is(err, service.ErrUserOAuthNotBound):
+			shared.RespondError(c, response.CodeBadRequest, "error.telegram_not_bound", nil)
+		case errors.Is(err, service.ErrTelegramUnbindRequiresEmail):
+			shared.RespondError(c, response.CodeBadRequest, "error.telegram_unbind_requires_email", nil)
+		default:
+			shared.RespondError(c, response.CodeInternal, "error.user_update_failed", err)
+		}
+		return
+	}
+
+	response.Success(c, gin.H{"unbound": true})
 }
 
 // GetAdminUserCouponUsages 获取用户优惠券使用记录

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -431,6 +431,7 @@ func SetupRouter(cfg *config.Config, c *provider.Container) *gin.Engine {
 				authorized.GET("/users", adminHandler.GetAdminUsers)
 				authorized.GET("/user-login-logs", adminHandler.GetUserLoginLogs)
 				authorized.PUT("/users/batch-status", adminHandler.BatchUpdateUserStatus)
+				authorized.DELETE("/users/:id/oauth/telegram", adminHandler.UnbindAdminUserTelegram)
 				authorized.GET("/users/:id", adminHandler.GetAdminUser)
 				authorized.PUT("/users/:id", adminHandler.UpdateAdminUser)
 				authorized.GET("/users/:id/coupon-usages", adminHandler.GetAdminUserCouponUsages)


### PR DESCRIPTION
管理员可以直接删除用户绑定的电报账号。

关联 Admin 前端 PR: https://github.com/dujiao-next/admin/pull/41

图：

<img width="1053" height="313" alt="screenshot_2026-05-18_22-55-43" src="https://github.com/user-attachments/assets/01fec2bc-e4b3-4961-8401-feaae24d1ab2" />
