### PR TITLE
feat: Admin user email verification control

### DIFF
--- a/internal/http/handlers/admin/admin_user.go
+++ b/internal/http/handlers/admin/admin_user.go
@@ -22,12 +22,13 @@ import (
 
 // UpdateAdminUserRequest 管理员更新用户请求
 type UpdateAdminUserRequest struct {
-	Nickname  *string `json:"nickname"`
-	Locale    *string `json:"locale"`
-	Status    *string `json:"status"`
-	Email     *string `json:"email"`
-	Password  *string `json:"password"`
-	AdminNote *string `json:"admin_note"`
+	Nickname      *string `json:"nickname"`
+	Locale        *string `json:"locale"`
+	Status        *string `json:"status"`
+	Email         *string `json:"email"`
+	Password      *string `json:"password"`
+	AdminNote     *string `json:"admin_note"`
+	EmailVerified *bool   `json:"email_verified"`
 }
 
 // BatchUpdateUserStatusRequest 批量更新用户状态请求
@@ -294,6 +295,19 @@ func (h *Handler) UpdateAdminUser(c *gin.Context) {
 	if req.AdminNote != nil {
 		user.AdminNote = *req.AdminNote
 		updated = true
+	}
+
+	if req.EmailVerified != nil {
+		if *req.EmailVerified {
+			if user.EmailVerifiedAt == nil {
+				now := time.Now()
+				user.EmailVerifiedAt = &now
+				updated = true
+			}
+		} else if user.EmailVerifiedAt != nil {
+			user.EmailVerifiedAt = nil
+			updated = true
+		}
 	}
 
 	if !updated {


### PR DESCRIPTION
管理员可以控制用户邮箱验证状态。

为什么要这个？
这不得不说，有用户电报号没了，但是上面有钱，想联系管理员解绑并换绑，但是，解绑要先填真实邮箱，但是即使填上真实邮箱，用户也登不上，因为开启了邮箱必须验证才能登录，这陷入死循环了。

加上这个以后，管理员可先填邮箱，然后正常解绑电报账号，让用户自己更换电报账号。

还有一点要提的是，如果不强制电报用户绑定邮箱，那么用户自主绑定邮箱的概率为个位数。

关联 admin 前端 PR: https://github.com/dujiao-next/admin/pull/42

图：

用户详情两个状态 badge：
<img width="909" height="212" alt="screenshot_2026-05-20_19-45-35" src="https://github.com/user-attachments/assets/73dad150-970c-4ed2-98a7-6608d768ea03" />
<img width="910" height="194" alt="screenshot_2026-05-20_19-47-50" src="https://github.com/user-attachments/assets/35c800d5-ebd5-4e0d-b17f-d7f9d12edac0" />

编辑用户：
<img width="845" height="1006" alt="screenshot_2026-05-20_19-46-24" src="https://github.com/user-attachments/assets/d69a2dd2-c409-43ea-a8d9-714dc720fff6" />
