### PR TITLE
Allow PayPal configs without webhook ID

### DIFF
--- a/internal/payment/paypal/paypal.go
+++ b/internal/payment/paypal/paypal.go
@@ -144,9 +144,6 @@ func ValidateConfig(cfg *Config) error {
 	if _, err := url.ParseRequestURI(strings.TrimSpace(cfg.CancelURL)); err != nil {
 		return fmt.Errorf("%w: cancel_url is invalid", ErrConfigInvalid)
 	}
-	if strings.TrimSpace(cfg.WebhookID) == "" {
-		return fmt.Errorf("%w: webhook_id is required", ErrConfigInvalid)
-	}
 	return nil
 }
 

--- a/internal/payment/paypal/paypal_test.go
+++ b/internal/payment/paypal/paypal_test.go
@@ -1,6 +1,9 @@
 package paypal
 
 import (
+	"context"
+	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/dujiao-next/internal/constants"
@@ -20,7 +23,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 }
 
-func TestValidateConfigWebhookIDRequired(t *testing.T) {
+func TestValidateConfigAllowsMissingWebhookID(t *testing.T) {
 	cfg := &Config{
 		ClientID:     "cid",
 		ClientSecret: "secret",
@@ -28,8 +31,23 @@ func TestValidateConfigWebhookIDRequired(t *testing.T) {
 		ReturnURL:    "https://example.com/payment?order_id=1",
 		CancelURL:    "https://example.com/payment?order_id=1",
 	}
-	if err := ValidateConfig(cfg); err == nil {
-		t.Fatalf("ValidateConfig should fail when webhook_id is empty")
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig should allow missing webhook_id, got: %v", err)
+	}
+}
+
+func TestVerifyWebhookSignatureRequiresWebhookID(t *testing.T) {
+	cfg := &Config{
+		ClientID:     "cid",
+		ClientSecret: "secret",
+		BaseURL:      "https://api-m.sandbox.paypal.com",
+		ReturnURL:    "https://example.com/payment?order_id=1",
+		CancelURL:    "https://example.com/payment?order_id=1",
+	}
+
+	err := VerifyWebhookSignature(context.Background(), cfg, http.Header{}, map[string]interface{}{})
+	if !errors.Is(err, ErrConfigInvalid) {
+		t.Fatalf("VerifyWebhookSignature should require webhook_id, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Allow PayPal payment channel configs to be saved without `webhook_id`.
- Keep `webhook_id` required when verifying PayPal webhook signatures.
- Add regression coverage for both config validation and webhook signature verification behavior.

## Paired Admin PR

This backend change is paired with the admin copy update:

- Admin PR: https://github.com/dujiao-next/admin/pull/44

Together they make `webhook_id` optional during channel setup while clearly explaining that PayPal async notifications cannot be processed without it.

## Verification

- `go test ./internal/payment/paypal -run 'TestValidateConfigAllowsMissingWebhookID|TestVerifyWebhookSignatureRequiresWebhookID' -count=1`
- `go test ./internal/payment/paypal ./internal/payment/provider ./internal/service -count=1`
- `go test ./... -count=1`
- `gitleaks protect --staged --redact`
