### PR TITLE
fix: keep WeChat gateway order number for payment capture

### DIFF
--- a/internal/service/payment_service_gateway_order_test.go
+++ b/internal/service/payment_service_gateway_order_test.go
@@ -11,9 +11,31 @@ import (
 
 	"github.com/dujiao-next/internal/constants"
 	"github.com/dujiao-next/internal/models"
+	"github.com/dujiao-next/internal/payment/provider"
 
 	"github.com/shopspring/decimal"
 )
+
+type emptyProviderRefProvider struct {
+	onCreate func(provider.CreateInput)
+}
+
+func (p emptyProviderRefProvider) Type() string {
+	return constants.PaymentProviderOfficial + ":" + constants.PaymentChannelTypeWechat
+}
+
+func (p emptyProviderRefProvider) ValidateConfig(models.JSON, string) error {
+	return nil
+}
+
+func (p emptyProviderRefProvider) CreatePayment(_ context.Context, _ models.JSON, input provider.CreateInput) (*provider.CreateResult, error) {
+	if p.onCreate != nil {
+		p.onCreate(input)
+	}
+	return &provider.CreateResult{
+		QRCodeURL: "weixin://wxpay/bizpayurl?pr=test",
+	}, nil
+}
 
 func TestShouldUseGatewayOrderNo(t *testing.T) {
 	tests := []struct {
@@ -106,6 +128,93 @@ func TestResolveGatewayOrderNo(t *testing.T) {
 	official := &models.PaymentChannel{ProviderType: constants.PaymentProviderOfficial}
 	if got := resolveGatewayOrderNo(official, payment); got == "" {
 		t.Fatalf("official provider should also use gateway order no")
+	}
+}
+
+func TestApplyProviderPaymentFallsBackToWechatGatewayOrderNoWhenProviderRefEmpty(t *testing.T) {
+	svc, db := setupPaymentServiceWalletTest(t)
+	now := time.Now()
+
+	order := &models.Order{
+		OrderNo:                 "DJTESTWECHAT001",
+		UserID:                  1,
+		Status:                  constants.OrderStatusPendingPayment,
+		Currency:                "CNY",
+		OriginalAmount:          models.NewMoneyFromDecimal(decimal.NewFromInt(1)),
+		DiscountAmount:          models.NewMoneyFromDecimal(decimal.Zero),
+		PromotionDiscountAmount: models.NewMoneyFromDecimal(decimal.Zero),
+		TotalAmount:             models.NewMoneyFromDecimal(decimal.NewFromInt(1)),
+		WalletPaidAmount:        models.NewMoneyFromDecimal(decimal.Zero),
+		OnlinePaidAmount:        models.NewMoneyFromDecimal(decimal.NewFromInt(1)),
+		RefundedAmount:          models.NewMoneyFromDecimal(decimal.Zero),
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}
+	if err := db.Create(order).Error; err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	channel := &models.PaymentChannel{
+		ProviderType:    constants.PaymentProviderOfficial,
+		ChannelType:     constants.PaymentChannelTypeWechat,
+		InteractionMode: constants.PaymentInteractionQR,
+		FeeRate:         models.NewMoneyFromDecimal(decimal.Zero),
+		ConfigJSON: models.JSON{
+			"notify_url": "https://api.example.com/api/v1/payments/callback",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := db.Create(channel).Error; err != nil {
+		t.Fatalf("create channel failed: %v", err)
+	}
+
+	payment := &models.Payment{
+		OrderID:         order.ID,
+		ChannelID:       channel.ID,
+		ProviderType:    channel.ProviderType,
+		ChannelType:     channel.ChannelType,
+		InteractionMode: channel.InteractionMode,
+		Amount:          models.NewMoneyFromDecimal(decimal.RequireFromString("1.00")),
+		FeeRate:         models.NewMoneyFromDecimal(decimal.Zero),
+		FeeAmount:       models.NewMoneyFromDecimal(decimal.Zero),
+		Currency:        "CNY",
+		Status:          constants.PaymentStatusInitiated,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := db.Create(payment).Error; err != nil {
+		t.Fatalf("create payment failed: %v", err)
+	}
+
+	var providerInputOrderNo string
+	svc.paymentProviderRegistry.Register(constants.PaymentProviderOfficial, constants.PaymentChannelTypeWechat, emptyProviderRefProvider{
+		onCreate: func(input provider.CreateInput) {
+			providerInputOrderNo = strings.TrimSpace(input.OrderNo)
+		},
+	})
+
+	if err := svc.applyProviderPayment(CreatePaymentInput{
+		ClientIP: "127.0.0.1",
+		Context:  context.Background(),
+	}, order, channel, payment); err != nil {
+		t.Fatalf("applyProviderPayment failed: %v", err)
+	}
+
+	if payment.GatewayOrderNo == "" {
+		t.Fatalf("payment gateway order no should not be empty")
+	}
+	if !strings.HasPrefix(payment.GatewayOrderNo, "DJP") {
+		t.Fatalf("payment gateway order no should keep DJP prefix, got %s", payment.GatewayOrderNo)
+	}
+	if providerInputOrderNo != payment.GatewayOrderNo {
+		t.Fatalf("wechat create order no = %s, want %s", providerInputOrderNo, payment.GatewayOrderNo)
+	}
+	if payment.ProviderRef != payment.GatewayOrderNo {
+		t.Fatalf("provider ref fallback = %s, want gateway order no %s", payment.ProviderRef, payment.GatewayOrderNo)
+	}
+	if payment.ProviderRef == order.OrderNo {
+		t.Fatalf("provider ref should not fall back to business order no")
 	}
 }
 

--- a/internal/service/payment_service_provider.go
+++ b/internal/service/payment_service_provider.go
@@ -90,9 +90,10 @@ func (s *PaymentService) applyProviderPayment(input CreatePaymentInput, order *m
 	if result.ProviderRef != "" {
 		payment.ProviderRef = result.ProviderRef
 	}
-	// 确保 ProviderRef 始终有值（各 adapter 可能返回空，如 wechat CreatePayment 阶段）
+	// 确保 ProviderRef 始终有值（各 adapter 可能返回空，如 wechat CreatePayment 阶段）。
+	// 主动查询必须使用实际提交到网关的订单号，而不是业务订单号。
 	if payment.ProviderRef == "" {
-		payment.ProviderRef = order.OrderNo
+		payment.ProviderRef = providerOrderNo
 	}
 	if result.Payload != nil {
 		payment.ProviderPayload = result.Payload


### PR DESCRIPTION
## Summary

- Preserve the WeChat gateway order number (`DJP...`) when provider capture needs to query payment status.
- Avoid falling back to the business order number (`DJ...`) when the provider result does not return `provider_ref`.
- Add a regression test to cover the WeChat create/capture flow.

## Why

WeChat Native payment creation uses the gateway payment order number for later status query. If `provider_ref` falls back to the business order number, active capture cannot query the paid transaction correctly.

This complements the upstream WeChat callback verification fix. That fix handles callback parsing/verification; this PR fixes the gateway order reference used by active capture.

## Test Plan

- `go test ./internal/service -run TestApplyProviderPaymentFallsBackToWechatGatewayOrderNoWhenProviderRefEmpty -count=1`
- `go test ./internal/service ./internal/payment/provider -run 'Wechat|Capture|Webhook|GatewayOrder' -count=1`
- `go test ./...`