### PR TITLE
fix: prevent activating upstream products without valid categories

### DIFF
--- a/internal/http/handlers/admin/admin_product.go
+++ b/internal/http/handlers/admin/admin_product.go
@@ -340,6 +340,10 @@ func (h *Handler) QuickUpdateProduct(c *gin.Context) {
 			shared.RespondError(c, response.CodeNotFound, "error.product_not_found", nil)
 			return
 		}
+		if errors.Is(err, service.ErrProductCategoryInvalid) {
+			shared.RespondError(c, response.CodeBadRequest, "error.product_category_invalid", nil)
+			return
+		}
 		shared.RespondError(c, response.CodeInternal, "error.product_update_failed", err)
 		return
 	}
@@ -451,6 +455,29 @@ type BatchProductCategoryRequest struct {
 	CategoryID uint   `json:"category_id"`
 }
 
+type batchProductFailureItem struct {
+	ID        uint   `json:"id"`
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func productBatchFailureFromError(id uint, err error) batchProductFailureItem {
+	item := batchProductFailureItem{
+		ID:        id,
+		ErrorCode: "product_update_failed",
+		Message:   "product update failed",
+	}
+	switch {
+	case errors.Is(err, service.ErrProductCategoryInvalid):
+		item.ErrorCode = "product_category_invalid"
+		item.Message = "Please select a valid category before activating this product."
+	case errors.Is(err, service.ErrNotFound):
+		item.ErrorCode = "product_not_found"
+		item.Message = "Product not found."
+	}
+	return item
+}
+
 // BatchUpdateProductStatus 批量上架/下架
 func (h *Handler) BatchUpdateProductStatus(c *gin.Context) {
 	var req BatchProductStatusRequest
@@ -459,13 +486,16 @@ func (h *Handler) BatchUpdateProductStatus(c *gin.Context) {
 		return
 	}
 	successCount := 0
+	failedItems := make([]batchProductFailureItem, 0)
 	for _, id := range req.IDs {
 		_, err := h.ProductService.QuickUpdate(strconv.FormatUint(uint64(id), 10), map[string]interface{}{"is_active": req.IsActive})
 		if err == nil {
 			successCount++
+		} else {
+			failedItems = append(failedItems, productBatchFailureFromError(id, err))
 		}
 	}
-	response.Success(c, gin.H{"total": len(req.IDs), "success_count": successCount})
+	response.Success(c, gin.H{"total": len(req.IDs), "success_count": successCount, "failed_items": failedItems})
 }
 
 // BatchUpdateProductCategory 批量修改分类

--- a/internal/http/handlers/admin/admin_product_mapping.go
+++ b/internal/http/handlers/admin/admin_product_mapping.go
@@ -69,10 +69,11 @@ func (h *Handler) GetProductMapping(c *gin.Context) {
 
 // ImportUpstreamProductRequest 导入上游商品请求
 type ImportUpstreamProductRequest struct {
-	ConnectionID      uint   `json:"connection_id" binding:"required"`
-	UpstreamProductID uint   `json:"upstream_product_id" binding:"required"`
-	CategoryID        uint   `json:"category_id"`
-	Slug              string `json:"slug"`
+	ConnectionID       uint   `json:"connection_id" binding:"required"`
+	UpstreamProductID  uint   `json:"upstream_product_id" binding:"required"`
+	CategoryID         uint   `json:"category_id"`
+	Slug               string `json:"slug"`
+	AutoCreateCategory bool   `json:"auto_create_category"`
 }
 
 // ImportUpstreamProduct 导入上游商品
@@ -83,11 +84,12 @@ func (h *Handler) ImportUpstreamProduct(c *gin.Context) {
 		return
 	}
 
-	mapping, err := h.ProductMappingService.ImportUpstreamProduct(
+	mapping, err := h.ProductMappingService.ImportUpstreamProductWithAutoCategory(
 		req.ConnectionID,
 		req.UpstreamProductID,
 		req.CategoryID,
 		req.Slug,
+		req.AutoCreateCategory,
 	)
 	if err != nil {
 		if errors.Is(err, service.ErrMappingAlreadyExists) {
@@ -122,6 +124,7 @@ type BatchImportUpstreamProductRequest struct {
 	ConnectionID       uint   `json:"connection_id" binding:"required"`
 	UpstreamProductIDs []uint `json:"upstream_product_ids" binding:"required,min=1"`
 	CategoryID         uint   `json:"category_id"`
+	AutoCreateCategory bool   `json:"auto_create_category"`
 }
 
 // BatchImportUpstreamProductResult 单个商品导入结果
@@ -146,11 +149,12 @@ func (h *Handler) BatchImportUpstreamProducts(c *gin.Context) {
 		result := BatchImportUpstreamProductResult{
 			UpstreamProductID: upstreamProductID,
 		}
-		_, err := h.ProductMappingService.ImportUpstreamProduct(
+		_, err := h.ProductMappingService.ImportUpstreamProductWithAutoCategory(
 			req.ConnectionID,
 			upstreamProductID,
 			req.CategoryID,
 			"", // auto-generate slug
+			req.AutoCreateCategory,
 		)
 		if err != nil {
 			result.Error = err.Error()

--- a/internal/http/handlers/admin/admin_product_mapping_test.go
+++ b/internal/http/handlers/admin/admin_product_mapping_test.go
@@ -1,0 +1,215 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dujiao-next/internal/constants"
+	"github.com/dujiao-next/internal/models"
+	"github.com/dujiao-next/internal/provider"
+	"github.com/dujiao-next/internal/repository"
+	"github.com/dujiao-next/internal/service"
+	"github.com/dujiao-next/internal/upstream"
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupAdminProductMappingHandlerTest(t *testing.T, upstreamHandler http.HandlerFunc) (*Handler, *gorm.DB, uint, func()) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	dsn := fmt.Sprintf("file:admin_product_mapping_handler_test_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite failed: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.Category{},
+		&models.Product{},
+		&models.ProductSKU{},
+		&models.SiteConnection{},
+		&models.ProductMapping{},
+		&models.SKUMapping{},
+	); err != nil {
+		t.Fatalf("auto migrate failed: %v", err)
+	}
+
+	server := httptest.NewServer(upstreamHandler)
+	categoryRepo := repository.NewCategoryRepository(db)
+	categoryService := service.NewCategoryService(categoryRepo)
+	connService := service.NewSiteConnectionService(repository.NewSiteConnectionRepository(db), "test-secret-key", t.TempDir())
+	conn, err := connService.Create(service.CreateConnectionInput{
+		Name:      "upstream",
+		BaseURL:   server.URL,
+		ApiKey:    "test-key",
+		ApiSecret: "test-secret",
+		Protocol:  constants.ConnectionProtocolDujiaoNext,
+	})
+	if err != nil {
+		t.Fatalf("create connection failed: %v", err)
+	}
+
+	mappingService := service.NewProductMappingService(
+		repository.NewProductMappingRepository(db),
+		repository.NewSKUMappingRepository(db),
+		repository.NewProductRepository(db),
+		repository.NewProductSKURepository(db),
+		categoryRepo,
+		connService,
+	)
+	mappingService.SetCategoryService(categoryService)
+
+	h := &Handler{Container: &provider.Container{
+		CategoryService:       categoryService,
+		ProductMappingService: mappingService,
+	}}
+	return h, db, conn.ID, server.Close
+}
+
+func TestBatchImportUpstreamProductsAutoCreatesCategory(t *testing.T) {
+	h, db, connID, cleanup := setupAdminProductMappingHandlerTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/upstream/categories":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"categories": []upstream.UpstreamCategory{
+					{ID: 9, Slug: "upstream-streaming", Name: models.JSON{"zh-CN": "流媒体"}},
+				},
+			})
+		case "/api/v1/upstream/products/101":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"product": upstream.UpstreamProduct{
+					ID:              101,
+					CategoryID:      9,
+					Title:           models.JSON{"zh-CN": "上游商品"},
+					Description:     models.JSON{"zh-CN": "描述"},
+					Content:         models.JSON{"zh-CN": "内容"},
+					Images:          []string{},
+					Tags:            []string{},
+					PriceAmount:     "10.00",
+					Currency:        "CNY",
+					FulfillmentType: constants.FulfillmentTypeAuto,
+					IsActive:        true,
+					SKUs: []upstream.UpstreamSKU{
+						{ID: 201, SKUCode: "SKU-A", SpecValues: models.JSON{"name": "A"}, PriceAmount: "10.00", IsActive: true},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+
+	body := fmt.Sprintf(`{"connection_id":%d,"upstream_product_ids":[101],"auto_create_category":true}`, connID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/product-mappings/batch-import", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.BatchImportUpstreamProducts(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var imported models.Product
+	if err := db.First(&imported).Error; err != nil {
+		t.Fatalf("load imported product failed: %v", err)
+	}
+	if imported.CategoryID == 0 {
+		t.Fatalf("expected imported product to be assigned to auto-created category")
+	}
+
+	var category models.Category
+	if err := db.First(&category, imported.CategoryID).Error; err != nil {
+		t.Fatalf("load auto-created category failed: %v", err)
+	}
+	if category.Slug != "upstream-streaming" {
+		t.Fatalf("expected auto-created category slug upstream-streaming, got %q", category.Slug)
+	}
+}
+
+func TestBatchImportUpstreamProductsRestoresSoftDeletedAutoCategory(t *testing.T) {
+	h, db, connID, cleanup := setupAdminProductMappingHandlerTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/upstream/categories":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"categories": []upstream.UpstreamCategory{
+					{ID: 9, Slug: "upstream-streaming", Name: models.JSON{"zh-CN": "流媒体"}},
+				},
+			})
+		case "/api/v1/upstream/products/101":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"product": upstream.UpstreamProduct{
+					ID:              101,
+					CategoryID:      9,
+					Title:           models.JSON{"zh-CN": "上游商品"},
+					PriceAmount:     "10.00",
+					Currency:        "CNY",
+					FulfillmentType: constants.FulfillmentTypeAuto,
+					IsActive:        true,
+					SKUs: []upstream.UpstreamSKU{
+						{ID: 201, SKUCode: "SKU-A", SpecValues: models.JSON{"name": "A"}, PriceAmount: "10.00", IsActive: true},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+
+	deletedCategory := models.Category{
+		Slug:     "upstream-streaming",
+		NameJSON: models.JSON{"zh-CN": "已删除分类"},
+		IsActive: true,
+	}
+	if err := db.Create(&deletedCategory).Error; err != nil {
+		t.Fatalf("create soft-delete target category failed: %v", err)
+	}
+	if err := db.Delete(&deletedCategory).Error; err != nil {
+		t.Fatalf("soft delete category failed: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"connection_id":%d,"upstream_product_ids":[101],"auto_create_category":true}`, connID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/product-mappings/batch-import", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.BatchImportUpstreamProducts(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var imported models.Product
+	if err := db.First(&imported).Error; err != nil {
+		t.Fatalf("load imported product failed: %v", err)
+	}
+	if imported.CategoryID != deletedCategory.ID {
+		t.Fatalf("expected imported product category %d, got %d", deletedCategory.ID, imported.CategoryID)
+	}
+
+	var restored models.Category
+	if err := db.First(&restored, deletedCategory.ID).Error; err != nil {
+		t.Fatalf("expected category to be restored, got %v", err)
+	}
+	if restored.NameJSON["zh-CN"] != "流媒体" {
+		t.Fatalf("expected restored category name to be refreshed, got %+v", restored.NameJSON)
+	}
+}

--- a/internal/http/handlers/admin/admin_product_test.go
+++ b/internal/http/handlers/admin/admin_product_test.go
@@ -1,0 +1,120 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dujiao-next/internal/constants"
+	"github.com/dujiao-next/internal/models"
+	"github.com/dujiao-next/internal/provider"
+	"github.com/dujiao-next/internal/repository"
+	"github.com/dujiao-next/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+func setupAdminProductHandlerTest(t *testing.T) (*Handler, *gorm.DB) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	dsn := fmt.Sprintf("file:admin_product_handler_test_%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite failed: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.Category{},
+		&models.Product{},
+		&models.ProductSKU{},
+		&models.CardSecret{},
+		&models.CardSecretBatch{},
+		&models.MemberLevelPrice{},
+		&models.CartItem{},
+		&models.ProductMapping{},
+		&models.SKUMapping{},
+		&models.Order{},
+		&models.OrderItem{},
+	); err != nil {
+		t.Fatalf("auto migrate failed: %v", err)
+	}
+
+	productService := service.NewProductService(
+		repository.NewProductRepository(db),
+		repository.NewProductSKURepository(db),
+		repository.NewCardSecretRepository(db),
+		repository.NewCardSecretBatchRepository(db),
+		repository.NewCategoryRepository(db),
+		repository.NewMemberLevelPriceRepository(db),
+		repository.NewCartRepository(db),
+		repository.NewProductMappingRepository(db),
+		repository.NewOrderRepository(db),
+	)
+
+	h := &Handler{Container: &provider.Container{
+		ProductService: productService,
+	}}
+	return h, db
+}
+
+func TestBatchUpdateProductStatusReturnsFailureReasons(t *testing.T) {
+	h, db := setupAdminProductHandlerTest(t)
+
+	product := models.Product{
+		CategoryID:      0,
+		Slug:            "batch-uncategorized-product",
+		TitleJSON:       models.JSON{"zh-CN": "batch-uncategorized-product"},
+		PriceAmount:     models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+		FulfillmentType: constants.FulfillmentTypeUpstream,
+		IsMapped:        true,
+		IsActive:        false,
+	}
+	if err := db.Create(&product).Error; err != nil {
+		t.Fatalf("create uncategorized product failed: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"ids":[%d],"is_active":true}`, product.ID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/products/batch-status", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.BatchUpdateProductStatus(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Data struct {
+			Total        int `json:"total"`
+			SuccessCount int `json:"success_count"`
+			FailedItems  []struct {
+				ID        uint   `json:"id"`
+				ErrorCode string `json:"error_code"`
+				Message   string `json:"message"`
+			} `json:"failed_items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response failed: %v body=%s", err, w.Body.String())
+	}
+	if resp.Data.Total != 1 || resp.Data.SuccessCount != 0 {
+		t.Fatalf("unexpected counts: total=%d success=%d", resp.Data.Total, resp.Data.SuccessCount)
+	}
+	if len(resp.Data.FailedItems) != 1 {
+		t.Fatalf("expected one failed item, got %+v", resp.Data.FailedItems)
+	}
+	if resp.Data.FailedItems[0].ID != product.ID {
+		t.Fatalf("expected failed product id %d, got %d", product.ID, resp.Data.FailedItems[0].ID)
+	}
+	if resp.Data.FailedItems[0].ErrorCode != "product_category_invalid" {
+		t.Fatalf("expected product_category_invalid, got %q", resp.Data.FailedItems[0].ErrorCode)
+	}
+}

--- a/internal/repository/category_repository.go
+++ b/internal/repository/category_repository.go
@@ -22,6 +22,8 @@ type CategoryRepository interface {
 	CountProducts(categoryID string) (int64, error)
 	CountActiveProducts(categoryID string) (int64, error)
 	GetBySlug(slug string) (*models.Category, error)
+	GetBySlugUnscoped(slug string) (*models.Category, error)
+	Restore(category *models.Category) error
 }
 
 // GormCategoryRepository GORM 实现
@@ -125,6 +127,30 @@ func (r *GormCategoryRepository) GetBySlug(slug string) (*models.Category, error
 		return nil, err
 	}
 	return &category, nil
+}
+
+// GetBySlugUnscoped 根据 slug 获取分类，包含软删除记录。
+func (r *GormCategoryRepository) GetBySlugUnscoped(slug string) (*models.Category, error) {
+	var category models.Category
+	if err := r.db.Unscoped().Where("slug = ?", slug).First(&category).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &category, nil
+}
+
+// Restore 恢复软删除分类并刷新展示信息。
+func (r *GormCategoryRepository) Restore(category *models.Category) error {
+	return r.db.Unscoped().Model(&models.Category{}).Where("id = ?", category.ID).Updates(map[string]interface{}{
+		"parent_id":  category.ParentID,
+		"name_json":  category.NameJSON,
+		"icon":       category.Icon,
+		"sort_order": category.SortOrder,
+		"is_active":  category.IsActive,
+		"deleted_at": nil,
+	}).Error
 }
 
 // CountActiveProducts 统计某分类下已上架商品数

--- a/internal/service/product_mapping_batch_import.go
+++ b/internal/service/product_mapping_batch_import.go
@@ -162,6 +162,20 @@ func (s *ProductMappingService) findOrCreateLocalCategory(slug string, nameJSON 
 		return existing, nil
 	}
 
+	deleted, err := s.categoryRepo.GetBySlugUnscoped(slug)
+	if err != nil {
+		return nil, err
+	}
+	if deleted != nil {
+		deleted.ParentID = parentID
+		deleted.NameJSON = nameJSON
+		deleted.IsActive = true
+		if err := s.categoryRepo.Restore(deleted); err != nil {
+			return nil, err
+		}
+		return deleted, nil
+	}
+
 	// 不存在，创建新分类
 	if s.categoryService == nil {
 		return nil, fmt.Errorf("category service not available")

--- a/internal/service/product_mapping_import.go
+++ b/internal/service/product_mapping_import.go
@@ -20,10 +20,15 @@ import (
 
 // ImportUpstreamProduct 从上游导入商品（克隆为本地商品 + 建立映射）
 func (s *ProductMappingService) ImportUpstreamProduct(connectionID uint, upstreamProductID uint, categoryID uint, slug string) (*models.ProductMapping, error) {
-	if err := validateProductCategoryAssignment(s.categoryRepo, categoryID, 0); err != nil {
-		return nil, err
-	}
+	return s.importUpstreamProduct(connectionID, upstreamProductID, categoryID, slug, false)
+}
 
+// ImportUpstreamProductWithAutoCategory 从上游导入商品，并按上游分类自动创建/匹配本地分类。
+func (s *ProductMappingService) ImportUpstreamProductWithAutoCategory(connectionID uint, upstreamProductID uint, categoryID uint, slug string, autoCreateCategory bool) (*models.ProductMapping, error) {
+	return s.importUpstreamProduct(connectionID, upstreamProductID, categoryID, slug, autoCreateCategory)
+}
+
+func (s *ProductMappingService) importUpstreamProduct(connectionID uint, upstreamProductID uint, categoryID uint, slug string, autoCreateCategory bool) (*models.ProductMapping, error) {
 	// 检查是否已存在映射
 	existing, err := s.mappingRepo.GetByConnectionAndUpstreamID(connectionID, upstreamProductID)
 	if err != nil {
@@ -66,6 +71,17 @@ func (s *ProductMappingService) ImportUpstreamProduct(connectionID uint, upstrea
 	// 新版上游对下架商品返回 200 + is_active=false → 同样禁止导入
 	if !upProduct.IsActive {
 		return nil, ErrUpstreamProductNotFound
+	}
+
+	if autoCreateCategory && categoryID == 0 && upProduct.CategoryID > 0 {
+		category, createErr := s.resolveLocalCategoryFromUpstream(ctx, adapter, upProduct.CategoryID)
+		if createErr != nil {
+			return nil, fmt.Errorf("auto create category: %w", createErr)
+		}
+		categoryID = category.ID
+	}
+	if err := validateProductCategoryAssignment(s.categoryRepo, categoryID, 0); err != nil {
+		return nil, err
 	}
 
 	// 下载图片到本地
@@ -214,6 +230,18 @@ func (s *ProductMappingService) ImportUpstreamProduct(connectionID uint, upstrea
 	}
 
 	return mapping, nil
+}
+
+func (s *ProductMappingService) resolveLocalCategoryFromUpstream(ctx context.Context, adapter upstream.Adapter, upstreamCategoryID uint) (*models.Category, error) {
+	catResult, err := adapter.ListCategories(ctx)
+	if err != nil {
+		return nil, err
+	}
+	catMap := make(map[uint]upstream.UpstreamCategory, len(catResult.Categories))
+	for _, c := range catResult.Categories {
+		catMap[c.ID] = c
+	}
+	return s.findOrCreateCategoryFromUpstream(upstreamCategoryID, catMap)
 }
 
 func createSKUMappingsWithRepo(

--- a/internal/service/product_service.go
+++ b/internal/service/product_service.go
@@ -969,10 +969,77 @@ func (s *ProductService) QuickUpdate(id string, fields map[string]interface{}) (
 	if product == nil {
 		return nil, ErrNotFound
 	}
+	if isQuickUpdateActivatingProduct(fields) {
+		categoryID := product.CategoryID
+		if rawCategoryID, ok := fields["category_id"]; ok {
+			parsedCategoryID, parseErr := quickUpdateCategoryID(rawCategoryID)
+			if parseErr != nil {
+				return nil, ErrProductCategoryInvalid
+			}
+			categoryID = parsedCategoryID
+		}
+		if err := validateProductActivationCategory(s.categoryRepo, categoryID); err != nil {
+			return nil, err
+		}
+	}
 	if err := s.repo.QuickUpdate(id, fields); err != nil {
 		return nil, err
 	}
 	return s.repo.GetByID(id)
+}
+
+func isQuickUpdateActivatingProduct(fields map[string]interface{}) bool {
+	raw, ok := fields["is_active"]
+	if !ok {
+		return false
+	}
+	value, ok := raw.(bool)
+	return ok && value
+}
+
+func quickUpdateCategoryID(value interface{}) (uint, error) {
+	switch v := value.(type) {
+	case uint:
+		return v, nil
+	case uint64:
+		return uint(v), nil
+	case int:
+		if v < 0 {
+			return 0, ErrProductCategoryInvalid
+		}
+		return uint(v), nil
+	case float64:
+		if v < 0 || v != float64(uint(v)) {
+			return 0, ErrProductCategoryInvalid
+		}
+		return uint(v), nil
+	default:
+		return 0, ErrProductCategoryInvalid
+	}
+}
+
+func validateProductActivationCategory(categoryRepo repository.CategoryRepository, categoryID uint) error {
+	if categoryID == 0 || categoryRepo == nil {
+		return ErrProductCategoryInvalid
+	}
+
+	categoryIDText := strconv.FormatUint(uint64(categoryID), 10)
+	category, err := categoryRepo.GetByID(categoryIDText)
+	if err != nil {
+		return err
+	}
+	if category == nil || !category.IsActive {
+		return ErrProductCategoryInvalid
+	}
+
+	childCount, err := categoryRepo.CountChildren(categoryIDText)
+	if err != nil {
+		return err
+	}
+	if childCount > 0 {
+		return ErrProductCategoryInvalid
+	}
+	return nil
 }
 
 // ApplyAutoStockCounts 聚合卡密自动发货库存信息并填充到商品中

--- a/internal/service/product_service_test.go
+++ b/internal/service/product_service_test.go
@@ -380,6 +380,36 @@ func TestProductServiceCreateRejectsParentCategoryWithChildren(t *testing.T) {
 	}
 }
 
+func TestProductServiceQuickUpdateRejectsActivationWithoutCategory(t *testing.T) {
+	svc, db := newProductServiceForTest(t)
+
+	product := models.Product{
+		CategoryID:      0,
+		Slug:            "uncategorized-imported-product",
+		TitleJSON:       models.JSON{"zh-CN": "uncategorized-imported-product"},
+		PriceAmount:     models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+		FulfillmentType: constants.FulfillmentTypeUpstream,
+		IsMapped:        true,
+		IsActive:        false,
+	}
+	if err := db.Create(&product).Error; err != nil {
+		t.Fatalf("create uncategorized product failed: %v", err)
+	}
+
+	_, err := svc.QuickUpdate(strconv.FormatUint(uint64(product.ID), 10), map[string]interface{}{"is_active": true})
+	if err != ErrProductCategoryInvalid {
+		t.Fatalf("expected ErrProductCategoryInvalid, got %v", err)
+	}
+
+	var got models.Product
+	if err := db.First(&got, product.ID).Error; err != nil {
+		t.Fatalf("reload product failed: %v", err)
+	}
+	if got.IsActive {
+		t.Fatalf("expected product to remain inactive")
+	}
+}
+
 func TestProductServiceListPublicSortOrderDescending(t *testing.T) {
 	svc, db := newProductServiceForTest(t)
 


### PR DESCRIPTION
## Summary

- Reject product activation when the product does not have a valid category.
- Return per-item failure details for batch product status updates instead of silently reporting `0/1` updated.
- Preserve `auto_create_category` when importing selected upstream products, so single/batch import can create the matching local category.
- Restore soft-deleted categories with the same slug before creating a new category, avoiding duplicate slug constraint errors.

## Why

Upstream product import could create or activate products without selecting a valid local category, while manually created local products require a category before listing. This made the validation behavior inconsistent.

Batch activation also returned a neutral success-style message such as `updated 0/1`, which did not clearly explain that activation failed because the category was missing or invalid.

## Test Plan

- `gofmt` on changed Go files
- `go test ./...`
- `git diff --cached --check`
- `gitleaks protect --staged --redact`
- Manual linked test:
  - import upstream product with auto-create category enabled
  - batch activate product without category
  - verify failed item reason is returned
  - verify soft-deleted category slug can be restored instead of causing UNIQUE constraint failure