### PR TITLE
fix: ignore stale product payment channel restrictions

### DIFF
--- a/internal/http/handlers/admin/admin_product_test.go
+++ b/internal/http/handlers/admin/admin_product_test.go
@@ -55,6 +55,7 @@ func setupAdminProductHandlerTest(t *testing.T) (*Handler, *gorm.DB) {
 		repository.NewCartRepository(db),
 		repository.NewProductMappingRepository(db),
 		repository.NewOrderRepository(db),
+		repository.NewPaymentChannelRepository(db),
 	)
 
 	h := &Handler{Container: &provider.Container{

--- a/internal/provider/container.go
+++ b/internal/provider/container.go
@@ -252,7 +252,7 @@ func (c *Container) initServices() {
 	c.UserAuthService = service.NewUserAuthService(c.Config, c.UserRepo, c.UserOAuthIdentityRepo, c.EmailVerifyCodeRepo, c.SettingService, c.EmailService, c.TelegramAuthService)
 	c.UploadService = service.NewUploadService(c.Config)
 	c.AffiliateService = service.NewAffiliateService(c.AffiliateRepo, c.UserRepo, c.OrderRepo, c.ProductRepo, c.SettingService)
-	c.ProductService = service.NewProductService(c.ProductRepo, c.ProductSKURepo, c.CardSecretRepo, c.CardSecretBatchRepo, c.CategoryRepo, c.MemberLevelPriceRepo, c.CartRepo, c.ProductMappingRepo, c.OrderRepo)
+	c.ProductService = service.NewProductService(c.ProductRepo, c.ProductSKURepo, c.CardSecretRepo, c.CardSecretBatchRepo, c.CategoryRepo, c.MemberLevelPriceRepo, c.CartRepo, c.ProductMappingRepo, c.OrderRepo, c.PaymentChannelRepo)
 	c.PostService = service.NewPostService(c.PostRepo)
 	c.CategoryService = service.NewCategoryService(c.CategoryRepo)
 	c.SitemapService = service.NewSitemapService(c.ProductRepo, c.CategoryRepo, c.PostRepo)

--- a/internal/service/product_service.go
+++ b/internal/service/product_service.go
@@ -24,6 +24,7 @@ type ProductService struct {
 	cartRepo             repository.CartRepository
 	productMappingRepo   repository.ProductMappingRepository
 	orderRepo            repository.OrderRepository
+	paymentChannelRepo   repository.PaymentChannelRepository
 }
 
 // NewProductService 创建商品服务
@@ -37,6 +38,7 @@ func NewProductService(
 	cartRepo repository.CartRepository,
 	productMappingRepo repository.ProductMappingRepository,
 	orderRepo repository.OrderRepository,
+	paymentChannelRepo repository.PaymentChannelRepository,
 ) *ProductService {
 	return &ProductService{
 		repo:                 repo,
@@ -48,7 +50,55 @@ func NewProductService(
 		cartRepo:             cartRepo,
 		productMappingRepo:   productMappingRepo,
 		orderRepo:            orderRepo,
+		paymentChannelRepo:   paymentChannelRepo,
 	}
+}
+
+func (s *ProductService) filterAvailablePaymentChannelIDs(ids []uint) ([]uint, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	uniqueIDs := make([]uint, 0, len(ids))
+	seen := make(map[uint]struct{}, len(ids))
+	for _, id := range ids {
+		if id == 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		uniqueIDs = append(uniqueIDs, id)
+	}
+	if len(uniqueIDs) == 0 {
+		return nil, nil
+	}
+	if s.paymentChannelRepo == nil {
+		return uniqueIDs, nil
+	}
+
+	channels, err := s.paymentChannelRepo.ListByIDs(uniqueIDs)
+	if err != nil {
+		return nil, err
+	}
+	activeIDs := make(map[uint]struct{}, len(channels))
+	for _, channel := range channels {
+		if channel.IsActive {
+			activeIDs[channel.ID] = struct{}{}
+		}
+	}
+
+	filtered := make([]uint, 0, len(uniqueIDs))
+	for _, id := range uniqueIDs {
+		if _, ok := activeIDs[id]; ok {
+			filtered = append(filtered, id)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, nil
+	}
+	return filtered, nil
 }
 
 // CreateProductInput 创建/更新商品输入
@@ -241,6 +291,10 @@ func (s *ProductService) Create(input CreateProductInput) (*models.Product, erro
 		}
 		costPriceAmount = minActiveCostPrice(normalizedSKUs)
 	}
+	paymentChannelIDs, err := s.filterAvailablePaymentChannelIDs(input.PaymentChannelIDs)
+	if err != nil {
+		return nil, err
+	}
 
 	product := models.Product{
 		CategoryID:           input.CategoryID,
@@ -262,7 +316,7 @@ func (s *ProductService) Create(input CreateProductInput) (*models.Product, erro
 		ManualStockTotal:     manualStockTotal,
 		ManualStockLocked:    0,
 		ManualStockSold:      0,
-		PaymentChannelIDs:    EncodeChannelIDs(input.PaymentChannelIDs),
+		PaymentChannelIDs:    EncodeChannelIDs(paymentChannelIDs),
 		IsAffiliateEnabled:   isAffiliateEnabled,
 		IsActive:             isActive,
 		SortOrder:            input.SortOrder,
@@ -336,7 +390,11 @@ func (s *ProductService) Update(id string, input CreateProductInput) (*models.Pr
 	product.SortOrder = input.SortOrder
 	product.Images = models.StringArray(input.Images)
 	product.Tags = models.StringArray(input.Tags)
-	product.PaymentChannelIDs = EncodeChannelIDs(input.PaymentChannelIDs)
+	paymentChannelIDs, err := s.filterAvailablePaymentChannelIDs(input.PaymentChannelIDs)
+	if err != nil {
+		return nil, err
+	}
+	product.PaymentChannelIDs = EncodeChannelIDs(paymentChannelIDs)
 	if input.IsActive != nil {
 		product.IsActive = *input.IsActive
 	}

--- a/internal/service/product_service_test.go
+++ b/internal/service/product_service_test.go
@@ -273,7 +273,7 @@ func newAutoStockProductService(t *testing.T) (*ProductService, *gorm.DB) {
 		t.Fatalf("auto migrate card secret failed: %v", err)
 	}
 	secretRepo := repository.NewCardSecretRepository(db)
-	return NewProductService(nil, nil, secretRepo, nil, nil, nil, nil, nil, nil), db
+	return NewProductService(nil, nil, secretRepo, nil, nil, nil, nil, nil, nil, nil), db
 }
 
 func insertCardSecrets(t *testing.T, db *gorm.DB, productID, skuID uint, status string, count int) {
@@ -650,6 +650,91 @@ func TestProductServiceUpdateKeepsMappedProductFulfillmentUpstream(t *testing.T)
 	}
 }
 
+func TestProductServiceCreateFiltersUnavailablePaymentChannels(t *testing.T) {
+	svc, db := newProductServiceForTest(t)
+
+	category := models.Category{
+		Slug:     "payment-channel-category",
+		NameJSON: models.JSON{"zh-CN": "payment-channel-category"},
+	}
+	if err := db.Create(&category).Error; err != nil {
+		t.Fatalf("create category failed: %v", err)
+	}
+
+	activeChannel := createProductTestPaymentChannel(t, db, "Active", true, false)
+	inactiveChannel := createProductTestPaymentChannel(t, db, "Inactive", false, false)
+	deletedChannel := createProductTestPaymentChannel(t, db, "Deleted", true, true)
+
+	product, err := svc.Create(CreateProductInput{
+		CategoryID:        category.ID,
+		Slug:              "payment-channel-create",
+		TitleJSON:         map[string]interface{}{"zh-CN": "payment-channel-create"},
+		PriceAmount:       decimal.NewFromInt(10),
+		PurchaseType:      constants.ProductPurchaseMember,
+		FulfillmentType:   constants.FulfillmentTypeAuto,
+		PaymentChannelIDs: []uint{deletedChannel.ID, inactiveChannel.ID, activeChannel.ID},
+		IsActive: func() *bool {
+			value := true
+			return &value
+		}(),
+	})
+	if err != nil {
+		t.Fatalf("create product failed: %v", err)
+	}
+
+	got := DecodeChannelIDs(product.PaymentChannelIDs)
+	if len(got) != 1 || got[0] != activeChannel.ID {
+		t.Fatalf("expected only active payment channel %d, got %v", activeChannel.ID, got)
+	}
+}
+
+func TestProductServiceUpdateFiltersUnavailablePaymentChannels(t *testing.T) {
+	svc, db := newProductServiceForTest(t)
+
+	category := models.Category{
+		Slug:     "payment-channel-update-category",
+		NameJSON: models.JSON{"zh-CN": "payment-channel-update-category"},
+	}
+	if err := db.Create(&category).Error; err != nil {
+		t.Fatalf("create category failed: %v", err)
+	}
+
+	deletedChannel := createProductTestPaymentChannel(t, db, "Deleted", true, true)
+	product := models.Product{
+		CategoryID:        category.ID,
+		Slug:              "payment-channel-update",
+		TitleJSON:         models.JSON{"zh-CN": "payment-channel-update"},
+		PriceAmount:       models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+		PurchaseType:      constants.ProductPurchaseMember,
+		FulfillmentType:   constants.FulfillmentTypeAuto,
+		PaymentChannelIDs: EncodeChannelIDs([]uint{deletedChannel.ID}),
+		IsActive:          true,
+	}
+	if err := db.Create(&product).Error; err != nil {
+		t.Fatalf("create product failed: %v", err)
+	}
+
+	updated, err := svc.Update(strconv.FormatUint(uint64(product.ID), 10), CreateProductInput{
+		CategoryID:        category.ID,
+		Slug:              product.Slug,
+		TitleJSON:         map[string]interface{}{"zh-CN": "payment-channel-update"},
+		PriceAmount:       decimal.NewFromInt(10),
+		PurchaseType:      constants.ProductPurchaseMember,
+		FulfillmentType:   constants.FulfillmentTypeAuto,
+		PaymentChannelIDs: []uint{deletedChannel.ID},
+		IsActive: func() *bool {
+			value := true
+			return &value
+		}(),
+	})
+	if err != nil {
+		t.Fatalf("update product failed: %v", err)
+	}
+	if got := DecodeChannelIDs(updated.PaymentChannelIDs); len(got) != 0 {
+		t.Fatalf("expected stale-only payment channels to be cleared, got %v", got)
+	}
+}
+
 func TestProductServiceUpdateRejectsDisablingAutoSKUWithCardSecretStock(t *testing.T) {
 	svc, db := newProductServiceForTest(t)
 
@@ -748,7 +833,7 @@ func newProductServiceForTest(t *testing.T) (*ProductService, *gorm.DB) {
 	if err != nil {
 		t.Fatalf("open sqlite failed: %v", err)
 	}
-	if err := db.AutoMigrate(&models.Category{}, &models.Product{}, &models.ProductSKU{}, &models.CardSecret{}, &models.CardSecretBatch{}, &models.MemberLevelPrice{}, &models.CartItem{}, &models.ProductMapping{}, &models.SKUMapping{}, &models.Order{}, &models.OrderItem{}); err != nil {
+	if err := db.AutoMigrate(&models.Category{}, &models.Product{}, &models.ProductSKU{}, &models.CardSecret{}, &models.CardSecretBatch{}, &models.MemberLevelPrice{}, &models.CartItem{}, &models.ProductMapping{}, &models.SKUMapping{}, &models.Order{}, &models.OrderItem{}, &models.PaymentChannel{}); err != nil {
 		t.Fatalf("auto migrate product service tables failed: %v", err)
 	}
 
@@ -762,7 +847,35 @@ func newProductServiceForTest(t *testing.T) (*ProductService, *gorm.DB) {
 		repository.NewCartRepository(db),
 		repository.NewProductMappingRepository(db),
 		repository.NewOrderRepository(db),
+		repository.NewPaymentChannelRepository(db),
 	), db
+}
+
+func createProductTestPaymentChannel(t *testing.T, db *gorm.DB, name string, active bool, deleted bool) models.PaymentChannel {
+	t.Helper()
+
+	channel := models.PaymentChannel{
+		Name:            name,
+		ProviderType:    "official",
+		ChannelType:     "wechat",
+		InteractionMode: "qr",
+		IsActive:        active,
+	}
+	if err := db.Create(&channel).Error; err != nil {
+		t.Fatalf("create payment channel failed: %v", err)
+	}
+	if !active {
+		if err := db.Model(&channel).Update("is_active", false).Error; err != nil {
+			t.Fatalf("disable payment channel failed: %v", err)
+		}
+		channel.IsActive = false
+	}
+	if deleted {
+		if err := db.Delete(&channel).Error; err != nil {
+			t.Fatalf("delete payment channel failed: %v", err)
+		}
+	}
+	return channel
 }
 
 func TestProductServiceDeleteCascade(t *testing.T) {


### PR DESCRIPTION
## Summary
- Filter product payment_channel_ids to active existing channels before persisting products.
- Treat deleted, inactive, or missing channel IDs as stale so stale-only selections become unrestricted.
- Add create/update regression coverage for stale product payment channel IDs.

## Tests
- go test ./internal/service -run 'TestProductService(Create|Update)FiltersUnavailablePaymentChannels' -count=1
- go test ./internal/service
- go test ./...
- git diff --check
- gitleaks protect --staged --redact