### PR TITLE
fix: payment adapter: the return URL should include parameters

### DIFF
--- a/internal/payment/provider/bepusdt_adapter.go
+++ b/internal/payment/provider/bepusdt_adapter.go
@@ -75,12 +75,18 @@ func (a *bepusdtAdapter) CreatePayment(ctx context.Context, raw models.JSON, inp
 		return nil, err
 	}
 
+	returnURL := strings.TrimSpace(input.ReturnURL)
+	if returnURL == "" {
+		returnURL = strings.TrimSpace(cfg.ReturnURL)
+	}
+	returnURL = appendQueryParams(returnURL, input.ReturnURLQuery)
+
 	native := bepusdt.CreateInput{
 		OrderNo:   input.OrderNo,
 		Amount:    input.Amount.Decimal.String(),
 		Name:      input.Subject,
 		NotifyURL: input.NotifyURL,
-		ReturnURL: input.ReturnURL,
+		ReturnURL: returnURL,
 	}
 	result, err := bepusdt.CreatePayment(ctx, cfg, native)
 	if err != nil {

--- a/internal/payment/provider/epusdt_adapter.go
+++ b/internal/payment/provider/epusdt_adapter.go
@@ -58,12 +58,18 @@ func (a *epusdtAdapter) CreatePayment(ctx context.Context, raw models.JSON, inpu
 		return nil, err
 	}
 
+	returnURL := strings.TrimSpace(input.ReturnURL)
+	if returnURL == "" {
+		returnURL = strings.TrimSpace(cfg.ReturnURL)
+	}
+	returnURL = appendQueryParams(returnURL, input.ReturnURLQuery)
+
 	native := epusdt.CreateInput{
 		OrderNo:   input.OrderNo,
 		Amount:    input.Amount.Decimal.String(),
 		Name:      input.Subject,
 		NotifyURL: input.NotifyURL,
-		ReturnURL: input.ReturnURL,
+		ReturnURL: returnURL,
 	}
 	result, err := epusdt.CreatePayment(ctx, cfg, native)
 	if err != nil {

--- a/internal/payment/provider/okpay_adapter.go
+++ b/internal/payment/provider/okpay_adapter.go
@@ -82,12 +82,18 @@ func (a *okpayAdapter) CreatePayment(ctx context.Context, raw models.JSON, input
 	originalAmount := input.Amount.Decimal.String()
 	originalCurrency := input.Currency
 
+	returnURL := strings.TrimSpace(input.ReturnURL)
+	if returnURL == "" {
+		returnURL = strings.TrimSpace(cfg.ReturnURL)
+	}
+	returnURL = appendQueryParams(returnURL, input.ReturnURLQuery)
+
 	// 注意 okpay CreateInput 字段命名独特
 	native := okpay.CreateInput{
 		UniqueID:    input.OrderNo,
 		Name:        input.Subject,
 		Amount:      originalAmount,
-		ReturnURL:   input.ReturnURL,
+		ReturnURL:   returnURL,
 		CallbackURL: cfg.CallbackURL, // 从 cfg 取（对齐现有 service 逻辑）
 		Coin:        cfg.Coin,
 		Status:      cfg.Status,

--- a/internal/payment/provider/tokenpay_adapter.go
+++ b/internal/payment/provider/tokenpay_adapter.go
@@ -62,6 +62,12 @@ func (a *tokenpayAdapter) CreatePayment(ctx context.Context, raw models.JSON, in
 	// tokenpay 特殊字段，用户标识符
 	orderUserKey, _ := input.Extra["order_user_key"].(string)
 
+	redirectURL := strings.TrimSpace(input.ReturnURL)
+	if redirectURL == "" {
+		redirectURL = strings.TrimSpace(cfg.RedirectURL)
+	}
+	redirectURL = appendQueryParams(redirectURL, input.ReturnURLQuery)
+
 	// Currency 是 TokenPay 的“加密货币币种”（如 USDT_TRC20 / TRX），必须取自渠道配置 cfg.Currency。
 	// 切勿使用 input.Currency——那是订单法币币种（CNY/USD 等），它对应 TokenPay 的 ActualAmount 金额币种。
 	native := tokenpay.CreateInput{
@@ -70,7 +76,7 @@ func (a *tokenpayAdapter) CreatePayment(ctx context.Context, raw models.JSON, in
 		ActualAmount: input.Amount.Decimal.String(),
 		Currency:     cfg.Currency,
 		NotifyURL:    input.NotifyURL,
-		RedirectURL:  input.ReturnURL,
+		RedirectURL:  redirectURL,
 	}
 	result, err := tokenpay.CreatePayment(ctx, cfg, native)
 	if err != nil {


### PR DESCRIPTION
不知道从何时起（可能从 457d4d25146b2f4823ece27135896b0a29bf5b53 重构开始） https://xxx.com/pay 入口，支付成功后，失去了跳转回原订单的能力。所以，我在此处为返回地址加上参数，让 BEpusdt 等明确返回到指定的订单。

卡住 pay 页面：
<img width="2430" height="1134" alt="screenshot_2026-06-14_09-18-26" src="https://github.com/user-attachments/assets/a06c9330-25af-4c75-9b09-cba63c7659d2" />
