### PR TITLE
fix: handle OKPay JSON callbacks and gateway currency

### DIFF
--- a/internal/http/handlers/public/payment_callback_okpay.go
+++ b/internal/http/handlers/public/payment_callback_okpay.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"net/url"
 	"strings"
 
 	"github.com/dujiao-next/internal/constants"
 	"github.com/dujiao-next/internal/http/handlers/shared"
 	"github.com/dujiao-next/internal/models"
+	"github.com/dujiao-next/internal/payment/okpay"
 
 	"github.com/gin-gonic/gin"
 )
@@ -23,21 +23,20 @@ func (h *Handler) HandleOkpayCallback(c *gin.Context) bool {
 	}
 	c.Request.Body = io.NopCloser(bytes.NewBuffer(body))
 
-	// 轻量级特征检测：从 form 或 JSON body 中探测 sign + data[unique_id] + data[order_id]
-	// okpay callback 是 form POST（application/x-www-form-urlencoded）
+	// 轻量级特征检测：okpay callback 可能是 form 或 JSON body。
 	trimmed := strings.TrimSpace(string(body))
 	if trimmed == "" {
 		log.Debugw("okpay_callback_not_matched", "reason", "empty_body")
 		return false
 	}
-	probeForm, parseErr := url.ParseQuery(trimmed)
+	probe, parseErr := okpay.ParseCallback(body)
 	if parseErr != nil {
 		log.Debugw("okpay_callback_parse_failed", "error", parseErr)
 		return false
 	}
-	sign := strings.TrimSpace(probeForm.Get("sign"))
-	uniqueID := strings.TrimSpace(probeForm.Get("data[unique_id]"))
-	orderID := strings.TrimSpace(probeForm.Get("data[order_id]"))
+	sign := strings.TrimSpace(probe.Sign)
+	uniqueID := strings.TrimSpace(probe.UniqueID)
+	orderID := strings.TrimSpace(probe.OrderID)
 	if sign == "" || (uniqueID == "" && orderID == "") {
 		log.Debugw("okpay_callback_not_matched", "reason", "missing_sign_or_ids")
 		return false

--- a/internal/http/handlers/public/payment_callback_okpay_test.go
+++ b/internal/http/handlers/public/payment_callback_okpay_test.go
@@ -193,6 +193,111 @@ func TestPaymentCallbackHandlesOkpay(t *testing.T) {
 	}
 }
 
+func TestPaymentCallbackHandlesOkpayJSON(t *testing.T) {
+	fixture := newOkpayCallbackFixture(t)
+	body := signedOkpayJSONCallback("616.00000000", "USDT", "token-1")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/payments/callback", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	fixture.handler.PaymentCallback(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if strings.TrimSpace(w.Body.String()) != constants.OkpayCallbackSuccess {
+		t.Fatalf("unexpected response body: %s", w.Body.String())
+	}
+
+	updatedPayment, err := fixture.paymentRepo.GetByID(fixture.payment.ID)
+	if err != nil {
+		t.Fatalf("reload payment failed: %v", err)
+	}
+	if updatedPayment == nil || updatedPayment.Status != constants.PaymentStatusSuccess {
+		t.Fatalf("payment status not updated: %+v", updatedPayment)
+	}
+	updatedOrder, err := fixture.orderRepo.GetByID(fixture.order.ID)
+	if err != nil {
+		t.Fatalf("reload order failed: %v", err)
+	}
+	if updatedOrder == nil || updatedOrder.Status != constants.OrderStatusPaid {
+		t.Fatalf("order status not updated: %+v", updatedOrder)
+	}
+}
+
+func TestPaymentCallbackRejectsOkpayJSONInvalidSignature(t *testing.T) {
+	fixture := newOkpayCallbackFixture(t)
+	body := strings.Replace(signedOkpayJSONCallback("616.00000000", "USDT", "token-1"), `"sign":"`, `"sign":"BAD`, 1)
+	w := performOkpayJSONCallback(t, fixture, body)
+	assertOkpayCallbackRejected(t, fixture, w)
+}
+
+func TestPaymentCallbackRejectsOkpayJSONAmountMismatch(t *testing.T) {
+	fixture := newOkpayCallbackFixture(t)
+	body := signedOkpayJSONCallback("615.00000000", "USDT", "token-1")
+	w := performOkpayJSONCallback(t, fixture, body)
+	assertOkpayCallbackRejected(t, fixture, w)
+}
+
+func TestPaymentCallbackRejectsOkpayJSONCurrencyMismatch(t *testing.T) {
+	fixture := newOkpayCallbackFixture(t)
+	body := signedOkpayJSONCallback("616.00000000", "TRX", "token-1")
+	w := performOkpayJSONCallback(t, fixture, body)
+	assertOkpayCallbackRejected(t, fixture, w)
+}
+
+func performOkpayJSONCallback(t *testing.T, fixture *okpayCallbackFixture, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/payments/callback", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	fixture.handler.PaymentCallback(c)
+	return w
+}
+
+func assertOkpayCallbackRejected(t *testing.T, fixture *okpayCallbackFixture, w *httptest.ResponseRecorder) {
+	t.Helper()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200 for okpay retry contract, got %d", w.Code)
+	}
+	if strings.TrimSpace(w.Body.String()) != constants.OkpayCallbackFail {
+		t.Fatalf("expected okpay fail response, got %s", w.Body.String())
+	}
+	updatedPayment, err := fixture.paymentRepo.GetByID(fixture.payment.ID)
+	if err != nil {
+		t.Fatalf("reload payment failed: %v", err)
+	}
+	if updatedPayment == nil || updatedPayment.Status != constants.PaymentStatusPending {
+		t.Fatalf("payment should remain pending: %+v", updatedPayment)
+	}
+	updatedOrder, err := fixture.orderRepo.GetByID(fixture.order.ID)
+	if err != nil {
+		t.Fatalf("reload order failed: %v", err)
+	}
+	if updatedOrder == nil || updatedOrder.Status != constants.OrderStatusPendingPayment {
+		t.Fatalf("order should remain pending payment: %+v", updatedOrder)
+	}
+}
+
+func signedOkpayJSONCallback(amount string, coin string, token string) string {
+	bodyWithoutSign := fmt.Sprintf(
+		`{"code":200,"data":{"order_id":"OKPAY-ORDER-1","unique_id":"DJP9001","pay_user_id":"7238234930","amount":%q,"coin":%q,"status":1,"type":"deposit"},"id":"shop-1","status":"success"}`,
+		amount,
+		coin,
+	)
+	signBase := fmt.Sprintf(
+		`code=200&data[order_id]=OKPAY-ORDER-1&data[unique_id]=DJP9001&data[pay_user_id]=7238234930&data[amount]=%s&data[coin]=%s&data[status]=1&data[type]=deposit&id=shop-1&status=success`,
+		amount,
+		coin,
+	)
+	sign := md5HexUpper(signBase + "&token=" + token)
+	return strings.TrimSuffix(bodyWithoutSign, "}") + `,"sign":"` + sign + `"}`
+}
+
 func md5HexUpper(raw string) string {
 	sum := md5.Sum([]byte(raw))
 	return strings.ToUpper(hex.EncodeToString(sum[:]))

--- a/internal/payment/provider/okpay_adapter.go
+++ b/internal/payment/provider/okpay_adapter.go
@@ -107,12 +107,14 @@ func (a *okpayAdapter) CreatePayment(ctx context.Context, raw models.JSON, input
 	// okpay native 已做 conversion，wrapper 这里只是**重新计算一遍**以填 AmountSent/CurrencySent，
 	// 不影响实际发给网关的数字（那由 native 决定）。
 	amountSent := originalAmount
-	currencySent := originalCurrency
+	currencySent := strings.ToUpper(strings.TrimSpace(originalCurrency))
+	if coin := strings.ToUpper(strings.TrimSpace(cfg.Coin)); coin != "" {
+		currencySent = coin
+	}
 	converted := false
 	if rate := strings.TrimSpace(cfg.ExchangeRate); rate != "" && rate != "1" && rate != "1.0" {
 		if convertedDec, convErr := okpay.ConvertAmountByRate(originalAmount, cfg.ExchangeRate); convErr == nil {
 			amountSent = convertedDec.StringFixed(8)
-			currencySent = strings.ToUpper(strings.TrimSpace(cfg.Coin))
 			converted = true
 		}
 	}

--- a/internal/payment/provider/okpay_adapter_test.go
+++ b/internal/payment/provider/okpay_adapter_test.go
@@ -165,6 +165,94 @@ func TestOkpayAdapter_CreatePayment_NoExchangeRate_AmountSentEqualsOriginal(t *t
 	}
 }
 
+// TestOkpayAdapter_CreatePayment_ExchangeRateOneUsesCoinCurrency reproduces the demo callback failure:
+// the shop order is stored as USD, but okpay receives coin=USDT and callbacks with coin=USDT.
+// Even when exchange_rate=1, the payment row must be updated to the gateway coin to avoid callback currency mismatch.
+func TestOkpayAdapter_CreatePayment_ExchangeRateOneUsesCoinCurrency(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","code":200,"data":{"order_id":"OK-ORDER-USD-USDT","pay_url":"https://pay.example.com/usd-usdt"}}`))
+	}))
+	defer server.Close()
+
+	a := NewOkpayAdapter()
+	raw := models.JSON{
+		"gateway_url":    server.URL,
+		"merchant_id":    "shop-usd-usdt",
+		"merchant_token": "token-usd-usdt",
+		"return_url":     "https://shop.example.com/pay",
+		"callback_url":   "https://api.example.com/api/v1/payments/callback/okpay",
+		"exchange_rate":  "1",
+		"coin":           "USDT",
+	}
+
+	input := CreateInput{
+		OrderNo:     "USD-ORDER-1",
+		Subject:     "test",
+		ChannelType: "usdt",
+		Currency:    "USD",
+		Amount:      models.NewMoneyFromDecimal(decimal.NewFromFloat(1)),
+		ReturnURL:   "https://shop.example.com/pay",
+	}
+
+	result, err := a.CreatePayment(context.Background(), raw, input)
+	if err != nil {
+		t.Fatalf("CreatePayment() failed: %v", err)
+	}
+
+	if result.AmountSent != "1" {
+		t.Fatalf("AmountSent should remain original amount '1', got %s", result.AmountSent)
+	}
+	if result.CurrencySent != "USDT" {
+		t.Fatalf("CurrencySent should use okpay coin USDT, got %s", result.CurrencySent)
+	}
+	if _, ok := result.Payload["exchange_rate"]; ok {
+		t.Fatal("Payload should NOT contain exchange_rate audit field when no amount conversion")
+	}
+}
+
+func TestOkpayAdapter_CreatePayment_ExchangeRateOneResolvesTRXChannelCurrency(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","code":200,"data":{"order_id":"OK-ORDER-USD-TRX","pay_url":"https://pay.example.com/usd-trx"}}`))
+	}))
+	defer server.Close()
+
+	a := NewOkpayAdapter()
+	raw := models.JSON{
+		"gateway_url":    server.URL,
+		"merchant_id":    "shop-usd-trx",
+		"merchant_token": "token-usd-trx",
+		"return_url":     "https://shop.example.com/pay",
+		"callback_url":   "https://api.example.com/api/v1/payments/callback/okpay",
+		"exchange_rate":  "1",
+	}
+
+	input := CreateInput{
+		OrderNo:     "USD-ORDER-TRX-1",
+		Subject:     "test",
+		ChannelType: constants.PaymentChannelTypeTrx,
+		Currency:    "USD",
+		Amount:      models.NewMoneyFromDecimal(decimal.NewFromFloat(1)),
+		ReturnURL:   "https://shop.example.com/pay",
+	}
+
+	result, err := a.CreatePayment(context.Background(), raw, input)
+	if err != nil {
+		t.Fatalf("CreatePayment() failed: %v", err)
+	}
+
+	if result.AmountSent != "1" {
+		t.Fatalf("AmountSent should remain original amount '1', got %s", result.AmountSent)
+	}
+	if result.CurrencySent != "TRX" {
+		t.Fatalf("CurrencySent should use resolved okpay coin TRX, got %s", result.CurrencySent)
+	}
+	if _, ok := result.Payload["exchange_rate"]; ok {
+		t.Fatal("Payload should NOT contain exchange_rate audit field when no amount conversion")
+	}
+}
+
 func TestOkpayAdapter_MapOkpayError(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

- Support OKPay callbacks sent as JSON bodies.
- Store OKPay payments using the actual gateway coin (`USDT` / `TRX`) even when `exchange_rate=1`.
- Add regression tests for JSON callbacks, signature/amount/currency rejection, and TRX coin resolution.

## Tests

- `go test ./internal/http/handlers/public ./internal/payment/okpay ./internal/payment/provider ./internal/service -count=1`
