### PR TITLE
feat: 上游同步参数可配置 

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -454,6 +454,9 @@ const (
 	SettingKeyUpstreamSyncConfig        = "upstream_sync_config"
 	SettingFieldUpstreamSyncIntervalMin = "interval_minutes"
 	SettingFieldUpstreamPreOrderCheck   = "pre_order_stock_check_enabled"
+	SettingFieldUpstreamSyncPageSize    = "sync_page_size"
+	SettingFieldUpstreamSyncMaxPages    = "sync_max_pages"
+	SettingFieldUpstreamSyncConcurrency = "sync_conn_concurrency"
 
 	SettingKeyCallbackRoutesConfig = "callback_routes_config"
 

--- a/internal/service/product_mapping_service_test.go
+++ b/internal/service/product_mapping_service_test.go
@@ -417,7 +417,7 @@ func TestSyncConnectionStockMarksDeletedWhenFullSyncMissing(t *testing.T) {
 	)
 	defer cleanup()
 
-	if err := svc.syncConnectionStock(mapping.ConnectionID, []models.ProductMapping{*mapping}); err != nil {
+	if err := svc.syncConnectionStock(mapping.ConnectionID, []models.ProductMapping{*mapping}, 50, 200); err != nil {
 		t.Fatalf("syncConnectionStock returned error: %v", err)
 	}
 
@@ -450,7 +450,7 @@ func TestSyncConnectionStockKeepsLegacyUpstreamMissing(t *testing.T) {
 	)
 	defer cleanup()
 
-	if err := svc.syncConnectionStock(mapping.ConnectionID, []models.ProductMapping{*mapping}); err != nil {
+	if err := svc.syncConnectionStock(mapping.ConnectionID, []models.ProductMapping{*mapping}, 50, 200); err != nil {
 		t.Fatalf("syncConnectionStock returned error: %v", err)
 	}
 
@@ -512,7 +512,7 @@ func TestSyncConnectionStockKeepsMappingWhenFullSyncIncomplete(t *testing.T) {
 	)
 	defer cleanup()
 
-	if err := svc.syncConnectionStock(mapping.ConnectionID, []models.ProductMapping{*mapping}); err != nil {
+	if err := svc.syncConnectionStock(mapping.ConnectionID, []models.ProductMapping{*mapping}, 50, 200); err != nil {
 		t.Fatalf("syncConnectionStock returned error: %v", err)
 	}
 

--- a/internal/service/product_mapping_sync.go
+++ b/internal/service/product_mapping_sync.go
@@ -259,7 +259,7 @@ func (s *ProductMappingService) markUpstreamUnavailable(mapping *models.ProductM
 
 // SyncAllStock 同步所有活跃映射的库存（供定时任务调用）
 // 使用 Redis 锁防止任务重叠执行，并发调用上游 API 提升吞吐量
-func (s *ProductMappingService) SyncAllStock() error {
+func (s *ProductMappingService) SyncAllStock(cfg UpstreamSyncConfig) error {
 	ctx := context.Background()
 	const lockKey = "upstream:sync_stock_running"
 
@@ -291,9 +291,8 @@ func (s *ProductMappingService) SyncAllStock() error {
 	var errs []error
 	var wg sync.WaitGroup
 
-	// 每个连接并发处理
-	const connConcurrency = 3
-	sem := make(chan struct{}, connConcurrency)
+	// 每个连接并发处理，并发数由配置控制
+	sem := make(chan struct{}, cfg.SyncConnConcurrency)
 
 	for connID, connMappings := range byConn {
 		wg.Add(1)
@@ -301,7 +300,7 @@ func (s *ProductMappingService) SyncAllStock() error {
 		go func(connID uint, connMappings []models.ProductMapping) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			if err := s.syncConnectionStock(connID, connMappings); err != nil {
+			if err := s.syncConnectionStock(connID, connMappings, cfg.SyncPageSize, cfg.SyncMaxPages); err != nil {
 				mu.Lock()
 				errs = append(errs, err)
 				mu.Unlock()
@@ -407,7 +406,7 @@ func (s *ProductMappingService) computeFullSyncInterval() time.Duration {
 }
 
 // syncConnectionStock 按连接批量同步：一次 ListProducts 拉取所有商品，内存匹配映射
-func (s *ProductMappingService) syncConnectionStock(connectionID uint, connMappings []models.ProductMapping) error {
+func (s *ProductMappingService) syncConnectionStock(connectionID uint, connMappings []models.ProductMapping, pageSize int, maxPages int) error {
 	conn, err := s.connService.GetByID(connectionID)
 	if err != nil || conn == nil {
 		return fmt.Errorf("get connection %d: %w", connectionID, err)
@@ -459,8 +458,6 @@ func (s *ProductMappingService) syncConnectionStock(connectionID uint, connMappi
 	fetchComplete := false
 	expectedTotal := 0
 	page := 1
-	const pageSize = 50
-	const maxPages = 200
 	for {
 		ctx, cancel := context.WithTimeout(syncCtx, 30*time.Second)
 		result, err := adapter.ListProducts(ctx, upstream.ListProductsOpts{

--- a/internal/service/upstream_sync_setting.go
+++ b/internal/service/upstream_sync_setting.go
@@ -12,12 +12,25 @@ const (
 	upstreamSyncIntervalMinDefault = 5
 	upstreamSyncIntervalMinMin     = 5
 	upstreamSyncIntervalMinMax     = 1440 // 24h 上限，避免误填超长间隔
+
+	upstreamSyncPageSizeDefault    = 50
+	upstreamSyncPageSizeMin        = 10
+	upstreamSyncPageSizeMax        = 200
+	upstreamSyncMaxPagesDefault    = 200
+	upstreamSyncMaxPagesMin        = 10
+	upstreamSyncMaxPagesMax        = 500
+	upstreamSyncConnConcurrencyDef = 3
+	upstreamSyncConnConcurrencyMin = 1
+	upstreamSyncConnConcurrencyMax = 10
 )
 
 // UpstreamSyncConfig 上游同步配置。
 type UpstreamSyncConfig struct {
 	IntervalMinutes           int  `json:"interval_minutes"`
 	PreOrderStockCheckEnabled bool `json:"pre_order_stock_check_enabled"`
+	SyncPageSize              int  `json:"sync_page_size"`
+	SyncMaxPages              int  `json:"sync_max_pages"`
+	SyncConnConcurrency       int  `json:"sync_conn_concurrency"`
 }
 
 // DefaultUpstreamSyncConfig 默认上游同步配置。
@@ -25,6 +38,9 @@ func DefaultUpstreamSyncConfig() UpstreamSyncConfig {
 	return UpstreamSyncConfig{
 		IntervalMinutes:           upstreamSyncIntervalMinDefault,
 		PreOrderStockCheckEnabled: true,
+		SyncPageSize:              upstreamSyncPageSizeDefault,
+		SyncMaxPages:              upstreamSyncMaxPagesDefault,
+		SyncConnConcurrency:       upstreamSyncConnConcurrencyDef,
 	}
 }
 
@@ -35,6 +51,24 @@ func NormalizeUpstreamSyncConfig(cfg UpstreamSyncConfig) UpstreamSyncConfig {
 	}
 	if cfg.IntervalMinutes > upstreamSyncIntervalMinMax {
 		cfg.IntervalMinutes = upstreamSyncIntervalMinMax
+	}
+	if cfg.SyncPageSize < upstreamSyncPageSizeMin {
+		cfg.SyncPageSize = upstreamSyncPageSizeDefault
+	}
+	if cfg.SyncPageSize > upstreamSyncPageSizeMax {
+		cfg.SyncPageSize = upstreamSyncPageSizeMax
+	}
+	if cfg.SyncMaxPages < upstreamSyncMaxPagesMin {
+		cfg.SyncMaxPages = upstreamSyncMaxPagesDefault
+	}
+	if cfg.SyncMaxPages > upstreamSyncMaxPagesMax {
+		cfg.SyncMaxPages = upstreamSyncMaxPagesMax
+	}
+	if cfg.SyncConnConcurrency < upstreamSyncConnConcurrencyMin {
+		cfg.SyncConnConcurrency = upstreamSyncConnConcurrencyDef
+	}
+	if cfg.SyncConnConcurrency > upstreamSyncConnConcurrencyMax {
+		cfg.SyncConnConcurrency = upstreamSyncConnConcurrencyMax
 	}
 	return cfg
 }
@@ -51,6 +85,15 @@ func upstreamSyncConfigFromJSON(raw models.JSON, fallback UpstreamSyncConfig) Up
 	if v, ok := raw[constants.SettingFieldUpstreamPreOrderCheck]; ok {
 		result.PreOrderStockCheckEnabled = parseSettingBool(v)
 	}
+	if v, err := parseSettingInt(raw[constants.SettingFieldUpstreamSyncPageSize]); err == nil {
+		result.SyncPageSize = v
+	}
+	if v, err := parseSettingInt(raw[constants.SettingFieldUpstreamSyncMaxPages]); err == nil {
+		result.SyncMaxPages = v
+	}
+	if v, err := parseSettingInt(raw[constants.SettingFieldUpstreamSyncConcurrency]); err == nil {
+		result.SyncConnConcurrency = v
+	}
 	return NormalizeUpstreamSyncConfig(result)
 }
 
@@ -60,6 +103,9 @@ func UpstreamSyncConfigToMap(cfg UpstreamSyncConfig) models.JSON {
 	return models.JSON{
 		constants.SettingFieldUpstreamSyncIntervalMin: normalized.IntervalMinutes,
 		constants.SettingFieldUpstreamPreOrderCheck:   normalized.PreOrderStockCheckEnabled,
+		constants.SettingFieldUpstreamSyncPageSize:    normalized.SyncPageSize,
+		constants.SettingFieldUpstreamSyncMaxPages:    normalized.SyncMaxPages,
+		constants.SettingFieldUpstreamSyncConcurrency: normalized.SyncConnConcurrency,
 	}
 }
 

--- a/internal/worker/asynq_worker.go
+++ b/internal/worker/asynq_worker.go
@@ -416,7 +416,8 @@ func (c *Consumer) handleUpstreamSyncStock(_ context.Context, _ *asynq.Task) err
 		logger.Debugw("worker_upstream_sync_stock_skip_nil", "consumer_nil", c == nil)
 		return nil
 	}
-	if err := c.ProductMappingService.SyncAllStock(); err != nil {
+	cfg, _ := c.SettingService.GetUpstreamSyncConfig("5m")
+	if err := c.ProductMappingService.SyncAllStock(cfg); err != nil {
 		logger.Warnw("worker_upstream_sync_stock_failed", "error", err)
 		return err
 	}


### PR DESCRIPTION
— SyncPageSize/SyncMaxPages/SyncConnConcurrency 
将上游同步参数 从硬编码 改为后台可调整， 可以根据自己上游情况自行设计同步时间 频率  单次数量等，可以极大增加灵活性，增加成功率，降低上下游的服务器压力，