### PR TITLE
feat: product_mappings 列表接口支持 upstream_status 筛选

### DIFF
--- a/internal/http/handlers/admin/admin_product_mapping.go
+++ b/internal/http/handlers/admin/admin_product_mapping.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/dujiao-next/internal/http/handlers/shared"
 	"github.com/dujiao-next/internal/http/response"
+	"github.com/dujiao-next/internal/models"
 	"github.com/dujiao-next/internal/repository"
 	"github.com/dujiao-next/internal/service"
 
@@ -16,9 +17,30 @@ func (h *Handler) GetProductMappings(c *gin.Context) {
 	page, pageSize := shared.ParsePagination(c)
 
 	connectionID, _ := shared.ParseQueryUint(c.Query("connection_id"), false)
+	upstreamStatus := c.Query("upstream_status")
+	if upstreamStatus != "" {
+		validStatuses := map[string]bool{
+			models.UpstreamStatusActive:   true,
+			models.UpstreamStatusInactive: true,
+			models.UpstreamStatusDeleted:  true,
+		}
+		if !validStatuses[upstreamStatus] {
+			shared.RespondError(c, response.CodeBadRequest, "error.invalid_upstream_status", nil)
+			return
+		}
+	}
+	productStatus := c.Query("product_status")
+	if productStatus != "" && productStatus != "active" && productStatus != "inactive" {
+		shared.RespondError(c, response.CodeBadRequest, "error.invalid_product_status", nil)
+		return
+	}
+	search := c.Query("search")
 
 	mappings, total, err := h.ProductMappingService.List(repository.ProductMappingListFilter{
-		ConnectionID: connectionID,
+		ConnectionID:   connectionID,
+		UpstreamStatus: upstreamStatus,
+		ProductStatus:  productStatus,
+		Search:         search,
 		Pagination: repository.Pagination{
 			Page:     page,
 			PageSize: pageSize,

--- a/internal/i18n/messages.go
+++ b/internal/i18n/messages.go
@@ -330,6 +330,8 @@ var messages = map[string]map[string]string{
 		"error.totp_too_many_attempts":           "失败次数过多，请稍后重试",
 		"error.totp_challenge_invalid":           "登录会话已失效，请重新输入密码",
 		"error.totp_cannot_reset_self":           "无法通过此入口重置自己的 2FA，请使用 admin-tool CLI",
+		"error.invalid_upstream_status":          "无效的上游状态参数",
+		"error.invalid_product_status":           "无效的商品状态参数",
 	},
 	LocaleTW: {
 		"error.jwt_secret_missing":                       "JWT secret 未配置",
@@ -646,6 +648,8 @@ var messages = map[string]map[string]string{
 		"error.totp_too_many_attempts":           "失敗次數過多，請稍後重試",
 		"error.totp_challenge_invalid":           "登入工作階段已失效，請重新輸入密碼",
 		"error.totp_cannot_reset_self":           "無法透過此入口重設自己的 2FA，請使用 admin-tool CLI",
+		"error.invalid_upstream_status":          "無效的上游狀態參數",
+		"error.invalid_product_status":           "無效的商品狀態參數",
 	},
 	LocaleEN: {
 		"error.jwt_secret_missing":                       "JWT secret is not configured",
@@ -962,6 +966,8 @@ var messages = map[string]map[string]string{
 		"error.totp_too_many_attempts":           "Too many failed attempts, please try again later",
 		"error.totp_challenge_invalid":           "Login session expired, please re-enter your password",
 		"error.totp_cannot_reset_self":           "You cannot reset your own 2FA from this endpoint; use admin-tool CLI",
+		"error.invalid_upstream_status":          "Invalid upstream status parameter",
+		"error.invalid_product_status":           "Invalid product status parameter",
 	},
 }
 

--- a/internal/repository/product_mapping_repository.go
+++ b/internal/repository/product_mapping_repository.go
@@ -27,7 +27,10 @@ type ProductMappingRepository interface {
 
 // ProductMappingListFilter 映射列表筛选
 type ProductMappingListFilter struct {
-	ConnectionID uint
+	ConnectionID   uint
+	UpstreamStatus string // active / inactive / deleted，空值不筛选
+	ProductStatus  string // active / inactive，空值不筛选
+	Search         string // 商品名称模糊搜索，空值不筛选
 	Pagination
 }
 
@@ -108,6 +111,22 @@ func (r *GormProductMappingRepository) List(filter ProductMappingListFilter) ([]
 	q := r.db.Model(&models.ProductMapping{})
 	if filter.ConnectionID > 0 {
 		q = q.Where("connection_id = ?", filter.ConnectionID)
+	}
+	if filter.UpstreamStatus != "" {
+		q = q.Where("upstream_status = ?", filter.UpstreamStatus)
+	}
+	if filter.ProductStatus == "active" {
+		q = q.Where("product_mappings.is_active = ?", true)
+	} else if filter.ProductStatus == "inactive" {
+		q = q.Where("product_mappings.is_active = ?", false)
+	}
+	if filter.Search != "" {
+		like := "%" + filter.Search + "%"
+		condition, argCount := buildLocalizedLikeCondition(r.db, nil, []string{"title_json"})
+		q = q.Where(
+			"product_mappings.local_product_id IN (SELECT id FROM products WHERE deleted_at IS NULL AND ("+condition+"))",
+			repeatLikeArgs(like, argCount)...,
+		)
 	}
 
 	if err := q.Count(&total).Error; err != nil {


### PR DESCRIPTION
此次修改涉及 前端后端修改。 
1、后端 增加了筛选状态的接口。 
2、前端 增加了筛选项
最终完成效果如下。
可以快速筛选 上游供应商的 商品状态。 
如果上游供应商已经比如下降 或者删除了。 我们也好快速操作，如果你商品较多，内容较多的情况下。当前没有任何筛选功能。着实难搞！

增加了三个功能。 
分别是。 搜索  2 个商品状态的筛选项。 

<img width="2558" height="1458" alt="image" src="https://github.com/user-attachments/assets/81073021-040d-4a20-bb42-b3be5d216bd5" />
### 筛选上游状态。 是否 下架。 是否删除。 
<img width="1890" height="932" alt="image" src="https://github.com/user-attachments/assets/93a245d6-5c82-44f4-bb59-2e74dab82b13" />


### 筛选本地状态。启用或者禁用

<img width="2140" height="950" alt="image" src="https://github.com/user-attachments/assets/4ec23dc5-21f0-4aaa-b88b-ab5dfdb0c91b" />

