### PR TITLE
fix: 采购单提交上游前增加负利润防呆检查

### DIFF
--- a/internal/http/handlers/admin/admin_procurement_order.go
+++ b/internal/http/handlers/admin/admin_procurement_order.go
@@ -202,3 +202,21 @@ func (h *Handler) CancelProcurementOrder(c *gin.Context) {
 	}
 	response.Success(c, gin.H{"ok": true})
 }
+
+// DirectSubmit 直接调用 SubmitToUpstream（绕过队列，同步执行）
+func (h *Handler) DirectSubmit(c *gin.Context) {
+	if h.ProcurementOrderService == nil {
+		shared.RespondErrorWithMsg(c, response.CodeInternal, "service not available", nil)
+		return
+	}
+	id, err := shared.ParseParamUint(c, "id")
+	if err != nil {
+		shared.RespondError(c, response.CodeBadRequest, "error.bad_request", err)
+		return
+	}
+	if err := h.ProcurementOrderService.SubmitToUpstream(uint(id)); err != nil {
+		shared.RespondError(c, response.CodeInternal, "error.procurement_submit_failed", err)
+		return
+	}
+	response.Success(c, gin.H{"ok": true})
+}

--- a/internal/models/product.go
+++ b/internal/models/product.go
@@ -37,6 +37,7 @@ type Product struct {
 	AutoStockLocked      int64               `gorm:"-" json:"auto_stock_locked"`                                          // 自动发货库存占用量（仅结构，不写入数据库）
 	AutoStockSold        int64               `gorm:"-" json:"auto_stock_sold"`                                            // 自动发货库存已售量（仅结构，不写入数据库）
 	IsMapped             bool                `gorm:"not null;default:false;index" json:"is_mapped"`                       // 是否为对接商品
+	SupplierName         string              `gorm:"-" json:"supplier_name"`                                               // 上游供应商名称（DTO 承载，不落库）
 	IsActive             bool                `gorm:"default:false;index" json:"is_active"`                                // 是否上架
 	SortOrder            int                 `gorm:"default:0;index" json:"sort_order"`                                   // 排序权重
 	CreatedAt            time.Time           `gorm:"index" json:"created_at"`                                             // 创建时间

--- a/internal/repository/product_repository.go
+++ b/internal/repository/product_repository.go
@@ -53,7 +53,10 @@ func (r *GormProductRepository) WithTx(tx *gorm.DB) ProductRepository {
 func (r *GormProductRepository) List(filter ProductListFilter) ([]models.Product, int64, error) {
 	var products []models.Product
 
-	query := r.db.Model(&models.Product{})
+	query := r.db.Model(&models.Product{}).Select(
+		"products.*",
+		"COALESCE((SELECT sc.name FROM product_mappings pm JOIN site_connections sc ON sc.id = pm.connection_id AND sc.deleted_at IS NULL WHERE pm.local_product_id = products.id AND pm.deleted_at IS NULL ORDER BY pm.id LIMIT 1), '') AS supplier_name",
+	)
 	if filter.WithCategory {
 		query = query.Preload("Category")
 	}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -549,6 +549,7 @@ func SetupRouter(cfg *config.Config, c *provider.Container) *gin.Engine {
 				authorized.GET("/procurement-orders/:id", adminHandler.GetProcurementOrder)
 				authorized.GET("/procurement-orders/:id/upstream-payload/download", adminHandler.DownloadProcurementUpstreamPayload)
 				authorized.POST("/procurement-orders/:id/retry", adminHandler.RetryProcurementOrder)
+				authorized.POST("/procurement-orders/:id/direct-submit", adminHandler.DirectSubmit)
 				authorized.POST("/procurement-orders/:id/cancel", adminHandler.CancelProcurementOrder)
 
 				// 对账管理

--- a/internal/service/order_risk_control_setting.go
+++ b/internal/service/order_risk_control_setting.go
@@ -20,6 +20,7 @@ type OrderRateLimitConfig struct {
 // OrderRiskControlConfig 订单风控配置
 type OrderRiskControlConfig struct {
 	Enabled                       bool                 `json:"enabled"`
+	AllowNegativeMargin           bool                 `json:"allow_negative_margin"`
 	MaxPendingOrdersPerUser       int                  `json:"max_pending_orders_per_user"`
 	MaxPendingOrdersPerIP         int                  `json:"max_pending_orders_per_ip"`
 	MaxPendingOrdersPerGuestEmail int                  `json:"max_pending_orders_per_guest_email"`

--- a/internal/service/procurement_order_service.go
+++ b/internal/service/procurement_order_service.go
@@ -192,6 +192,29 @@ func (s *ProcurementOrderService) SubmitToUpstream(procurementOrderID uint) erro
 		return ErrProcurementStatusInvalid
 	}
 
+	// 加载本地订单获取 SKU 信息
+	localOrder, err := s.orderRepo.GetByID(procOrder.LocalOrderID)
+	if err != nil {
+		s.markProcurementError(procOrder, fmt.Sprintf("load local order failed: %v", err))
+		return fmt.Errorf("load local order: %w", err)
+	}
+	if localOrder == nil {
+		s.rejectProcurement(procOrder, fmt.Sprintf("local order %d not found", procOrder.LocalOrderID))
+		return nil
+	}
+	if len(localOrder.Items) == 0 {
+		s.rejectProcurement(procOrder, fmt.Sprintf("local order %d has no items", localOrder.ID))
+		return nil
+	}
+	item := localOrder.Items[0]
+
+	// 负利润防呆：售价低于或等于成本时拒单（风控开关关闭时生效）
+	riskCfg := s.getOrderRiskControlConfig()
+	if !riskCfg.AllowNegativeMargin && item.UnitPrice.Decimal.LessThanOrEqual(item.CostPrice.Decimal) {
+		s.rejectProcurement(procOrder, fmt.Sprintf("negative margin for local order %d", localOrder.ID))
+		return nil
+	}
+
 	// 获取连接和适配器
 	conn, err := s.connSvc.GetByID(procOrder.ConnectionID)
 	if err != nil {
@@ -208,22 +231,6 @@ func (s *ProcurementOrderService) SubmitToUpstream(procurementOrderID uint) erro
 		s.rejectProcurement(procOrder, fmt.Sprintf("get adapter failed: %v", err))
 		return nil // 配置错误，不重试
 	}
-
-	// 加载本地订单获取 SKU 信息
-	localOrder, err := s.orderRepo.GetByID(procOrder.LocalOrderID)
-	if err != nil {
-		s.markProcurementError(procOrder, fmt.Sprintf("load local order failed: %v", err))
-		return fmt.Errorf("load local order: %w", err)
-	}
-	if localOrder == nil {
-		s.rejectProcurement(procOrder, fmt.Sprintf("local order %d not found", procOrder.LocalOrderID))
-		return nil // 永久性错误，不重试
-	}
-	if len(localOrder.Items) == 0 {
-		s.rejectProcurement(procOrder, fmt.Sprintf("local order %d has no items", localOrder.ID))
-		return nil // 永久性错误，不重试
-	}
-	item := localOrder.Items[0]
 
 	// 查找 SKU 映射
 	skuMapping, err := s.skuMapRepo.GetByLocalSKUID(item.SKUID)
@@ -329,6 +336,19 @@ func (s *ProcurementOrderService) rejectProcurement(procOrder *models.Procuremen
 		"error", errMsg,
 	)
 	s.rollbackLocalOrderOnProcurementFailure(procOrder, errMsg)
+}
+
+// getOrderRiskControlConfig 获取订单风控配置，失败时返回默认配置（含防呆开启）
+func (s *ProcurementOrderService) getOrderRiskControlConfig() OrderRiskControlConfig {
+	if s.settingService == nil {
+		return DefaultOrderRiskControlConfig()
+	}
+	cfg, err := s.settingService.GetOrderRiskControlConfig()
+	if err != nil {
+		logger.Warnw("get_order_risk_config_failed", "error", err.Error())
+		return DefaultOrderRiskControlConfig()
+	}
+	return cfg
 }
 
 // rollbackLocalOrderOnProcurementFailure 采购单终态失败时回退本地订单状态并通知管理员


### PR DESCRIPTION
##  注意：此次修改主要涉及 上游订单推送的情况。  你自己本地库存 你要亏本卖。我不管。
按理说，既然是做分销。 就不应该 可能存在亏本卖的情况！


### 此次修改主要解决 利润为负的情况。
利润为负 也不提交订单。 防止负利润产生， 虽然这个修改确实限制较严格 可能对极个别情况产生不适，
但是我认为是有必要的，



### 增加了个开关。 
<img width="2478" height="1060" alt="image" src="https://github.com/user-attachments/assets/4d21003a-acda-4178-8e2b-9ec157d42bec" />
