### PR TITLE
feat: 上下游同步功能增加个排除项目

### DIFF
--- a/internal/http/handlers/admin/admin_product_mapping.go
+++ b/internal/http/handlers/admin/admin_product_mapping.go
@@ -210,13 +210,16 @@ func (h *Handler) BatchSyncProductMappings(c *gin.Context) {
 	}
 
 	successCount := 0
+	skippedCount := 0
 	for _, id := range req.IDs {
 		if err := h.ProductMappingService.SyncProduct(id); err == nil {
 			successCount++
+		} else if errors.Is(err, service.ErrProductExcluded) {
+			skippedCount++
 		}
 	}
 
-	response.Success(c, gin.H{"total": len(req.IDs), "success_count": successCount})
+	response.Success(c, gin.H{"total": len(req.IDs), "success_count": successCount, "skipped_count": skippedCount})
 }
 
 // BatchUpdateMappingStatusRequest 批量更新状态请求

--- a/internal/models/site_connection.go
+++ b/internal/models/site_connection.go
@@ -1,6 +1,9 @@
 package models
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -25,6 +28,7 @@ type SiteConnection struct {
 	PriceMarkupPercent decimal.Decimal `gorm:"type:decimal(10,4);not null;default:0" json:"price_markup_percent"`   // 加价百分比，如 100 = +100%（翻倍）
 	PriceRoundingMode  string          `gorm:"type:varchar(20);not null;default:'none'" json:"price_rounding_mode"` // none / ceil_int / ceil_tenth
 	AutoSyncPrice      bool            `gorm:"not null;default:false" json:"auto_sync_price"`                       // 同步时自动更新本地价格
+	ExcludedProductIDs string          `gorm:"type:text" json:"excluded_product_ids"`                               // JSON 数组，存储要排除的上游商品 ID
 	CreatedAt          time.Time       `gorm:"index" json:"created_at"`
 	UpdatedAt          time.Time       `gorm:"index" json:"updated_at"`
 	DeletedAt          gorm.DeletedAt  `gorm:"index" json:"-"`
@@ -33,4 +37,51 @@ type SiteConnection struct {
 // TableName 指定表名
 func (SiteConnection) TableName() string {
 	return "site_connections"
+}
+
+// IsProductExcluded 判断指定上游商品 ID 是否在排除列表中
+func (c *SiteConnection) IsProductExcluded(upstreamProductID uint) bool {
+	set := c.GetExcludedProductIDSet()
+	if set == nil {
+		return false
+	}
+	return set[upstreamProductID]
+}
+
+// GetExcludedProductIDSet 返回排除 ID 的集合（map[uint]bool），用于 O(1) 批量查找。
+// 仅解析一次 JSON，调用方应缓存结果用于循环场景。
+func (c *SiteConnection) GetExcludedProductIDSet() map[uint]bool {
+	if c.ExcludedProductIDs == "" {
+		return nil
+	}
+	var ids []uint
+	if err := json.Unmarshal([]byte(c.ExcludedProductIDs), &ids); err != nil {
+		return nil
+	}
+	set := make(map[uint]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+	return set
+}
+
+// ValidateExcludedProductIDs 校验排除列表是否为有效 JSON 正整数数组或空字符串
+func ValidateExcludedProductIDs(raw string) error {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return nil
+	}
+	var ids []uint
+	if err := json.Unmarshal([]byte(s), &ids); err != nil {
+		return fmt.Errorf("excluded_product_ids must be a valid JSON array of positive integers")
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	for _, id := range ids {
+		if id == 0 {
+			return fmt.Errorf("excluded_product_ids contains invalid item: 0 (must be positive integer)")
+		}
+	}
+	return nil
 }

--- a/internal/service/product_mapping_service.go
+++ b/internal/service/product_mapping_service.go
@@ -21,6 +21,7 @@ var (
 	ErrMappingAlreadyExists    = errors.New("product mapping already exists for this upstream product")
 	ErrUpstreamProductNotFound = errors.New("upstream product not found")
 	ErrMappingInactive         = errors.New("product mapping is inactive")
+	ErrProductExcluded         = errors.New("product excluded from upstream sync")
 )
 
 // ProductMappingService 商品映射业务服务

--- a/internal/service/product_mapping_sync.go
+++ b/internal/service/product_mapping_sync.go
@@ -35,6 +35,17 @@ func (s *ProductMappingService) SyncProduct(mappingID uint) error {
 		return ErrConnectionNotFound
 	}
 
+	// 检查排除列表：被排除的上游商品跳过同步
+	if conn.IsProductExcluded(mapping.UpstreamProductID) {
+		logger.Infow("sync_single_product_skipped_excluded",
+			"connection_id", mapping.ConnectionID,
+			"upstream_product_id", mapping.UpstreamProductID,
+			"local_product_id", mapping.LocalProductID,
+			"mapping_id", mapping.ID,
+		)
+		return ErrProductExcluded
+	}
+
 	adapter, err := s.connService.GetAdapter(conn)
 	if err != nil {
 		return err
@@ -388,14 +399,21 @@ func (s *ProductMappingService) EnsureUpstreamStockForOrder(localSKUID uint, req
 
 	// 缓存库存不足 → 实时同步上游商品
 	if syncErr := s.SyncProduct(skuMapping.ProductMappingID); syncErr != nil {
-		// 上游抖动：fail-open，记录但不阻断下单
-		logger.Warnw("preorder_stock_check_realtime_sync_failed",
-			"local_sku_id", localSKUID,
-			"product_mapping_id", skuMapping.ProductMappingID,
-			"required_qty", requiredQty,
-			"cached_stock", skuMapping.UpstreamStock,
-			"error", syncErr,
-		)
+		if errors.Is(syncErr, ErrProductExcluded) {
+			logger.Debugw("preorder_stock_check_excluded_skipped",
+				"local_sku_id", localSKUID,
+				"product_mapping_id", skuMapping.ProductMappingID,
+			)
+		} else {
+			// 上游抖动：fail-open，记录但不阻断下单
+			logger.Warnw("preorder_stock_check_realtime_sync_failed",
+				"local_sku_id", localSKUID,
+				"product_mapping_id", skuMapping.ProductMappingID,
+				"required_qty", requiredQty,
+				"cached_stock", skuMapping.UpstreamStock,
+				"error", syncErr,
+			)
+		}
 		return nil
 	}
 
@@ -559,6 +577,7 @@ func (s *ProductMappingService) syncConnectionStock(connectionID uint, connMappi
 	// 对每个映射执行同步
 	now := time.Now()
 	isFullSync := updatedAfter == nil
+	excludedSet := conn.GetExcludedProductIDSet()
 	for i := range connMappings {
 		mapping := &connMappings[i]
 		upProduct, ok := upstreamProducts[mapping.UpstreamProductID]
@@ -587,6 +606,15 @@ func (s *ProductMappingService) syncConnectionStock(connectionID uint, connMappi
 		// 上游 is_active=false → 标记为 inactive
 		if !upProduct.IsActive {
 			_ = s.markUpstreamUnavailable(mapping, models.UpstreamStatusInactive, now)
+			continue
+		}
+		// 检查排除列表：被排除的上游商品跳过库存/价格同步，但上游删除/下架检测不受影响
+		if excludedSet != nil && excludedSet[mapping.UpstreamProductID] {
+			logger.Debugw("sync_connection_stock_excluded",
+				"connection_id", connectionID,
+				"upstream_product_id", mapping.UpstreamProductID,
+				"local_product_id", mapping.LocalProductID,
+			)
 			continue
 		}
 		s.syncProductFromData(mapping, conn, &upProduct, &now)

--- a/internal/service/site_connection_service.go
+++ b/internal/service/site_connection_service.go
@@ -63,6 +63,7 @@ type CreateConnectionInput struct {
 	PriceMarkupPercent float64 `json:"price_markup_percent"`
 	PriceRoundingMode  string  `json:"price_rounding_mode"`
 	AutoSyncPrice      bool    `json:"auto_sync_price"`
+	ExcludedProductIDs string  `json:"excluded_product_ids"`
 }
 
 // Create 创建连接
@@ -98,6 +99,11 @@ func (s *SiteConnectionService) Create(input CreateConnectionInput) (*models.Sit
 		roundingMode = "none"
 	}
 
+	excludedIDs := strings.TrimSpace(input.ExcludedProductIDs)
+	if err := models.ValidateExcludedProductIDs(excludedIDs); err != nil {
+		return nil, err
+	}
+
 	conn := &models.SiteConnection{
 		Name:               strings.TrimSpace(input.Name),
 		BaseURL:            strings.TrimRight(strings.TrimSpace(input.BaseURL), "/"),
@@ -112,6 +118,7 @@ func (s *SiteConnectionService) Create(input CreateConnectionInput) (*models.Sit
 		PriceMarkupPercent: decimal.NewFromFloat(input.PriceMarkupPercent),
 		PriceRoundingMode:  roundingMode,
 		AutoSyncPrice:      input.AutoSyncPrice,
+		ExcludedProductIDs: excludedIDs,
 	}
 
 	if err := s.connRepo.Create(conn); err != nil {
@@ -134,6 +141,7 @@ type UpdateConnectionInput struct {
 	PriceMarkupPercent *float64 `json:"price_markup_percent"` // 指针类型，区分 0 和未传
 	PriceRoundingMode  *string  `json:"price_rounding_mode"`
 	AutoSyncPrice      *bool    `json:"auto_sync_price"`
+	ExcludedProductIDs *string  `json:"excluded_product_ids"`
 }
 
 // Update 更新连接
@@ -194,6 +202,13 @@ func (s *SiteConnectionService) Update(id uint, input UpdateConnectionInput) (*m
 	}
 	if input.AutoSyncPrice != nil {
 		conn.AutoSyncPrice = *input.AutoSyncPrice
+	}
+	if input.ExcludedProductIDs != nil {
+		trimmed := strings.TrimSpace(*input.ExcludedProductIDs)
+		if err := models.ValidateExcludedProductIDs(trimmed); err != nil {
+			return nil, err
+		}
+		conn.ExcludedProductIDs = trimmed
 	}
 
 	if err := s.connRepo.Update(conn); err != nil {


### PR DESCRIPTION
## 新增商品同步排除功能，可指定商品跳过自动同步，仅屏蔽价格、库存每日自动更新，不影响正常下单流程。

### 设计背景：系统默认按预设利润率自动更新商品售价，部分商品我手动自定义了定价（售价可能高于或低于基准利润率）。若开启全自动同步，自定义价格会被系统反复覆盖，影响经营。因此想做个排除功能。

### 将商品加入排除列表后，系统每日同步时会跳过该商品的价格、库存更新，保留手动设置的价格，下单、交易等核心功能不受任何影响。

<img width="1792" height="2122" alt="image" src="https://github.com/user-attachments/assets/dd573f24-9bd4-499f-abea-d0d4f8260a09" />
