### PR TITLE
完善卡密导出和二维码支付

### DIFF
--- a/internal/dto/payment.go
+++ b/internal/dto/payment.go
@@ -9,22 +9,25 @@ import (
 
 // CreatePaymentResp 创建支付响应
 type CreatePaymentResp struct {
-	OrderPaid        bool         `json:"order_paid"`
-	WalletPaidAmount models.Money `json:"wallet_paid_amount"`
-	OnlinePayAmount  models.Money `json:"online_pay_amount"`
-	PaymentID        *uint        `json:"payment_id,omitempty"`
-	ChannelID        *uint        `json:"channel_id,omitempty"`
-	ProviderType     string       `json:"provider_type,omitempty"`
-	ChannelType      string       `json:"channel_type,omitempty"`
-	InteractionMode  string       `json:"interaction_mode,omitempty"`
-	PayURL           string       `json:"pay_url,omitempty"`
-	QRCode           string       `json:"qr_code,omitempty"`
-	WalletAddress    string       `json:"wallet_address,omitempty"`
-	ChainAmount      string       `json:"chain_amount,omitempty"`
-	Chain            string       `json:"chain,omitempty"`
-	TokenID          string       `json:"token_id,omitempty"`
-	ExpiresAt        *time.Time   `json:"expires_at,omitempty"`
-	ChannelName      string       `json:"channel_name,omitempty"`
+	OrderPaid        bool                  `json:"order_paid"`
+	WalletPaidAmount models.Money          `json:"wallet_paid_amount"`
+	OnlinePayAmount  models.Money          `json:"online_pay_amount"`
+	PaymentID        *uint                 `json:"payment_id,omitempty"`
+	ChannelID        *uint                 `json:"channel_id,omitempty"`
+	ProviderType     string                `json:"provider_type,omitempty"`
+	ChannelType      string                `json:"channel_type,omitempty"`
+	InteractionMode  string                `json:"interaction_mode,omitempty"`
+	PayURL           string                `json:"pay_url,omitempty"`
+	QRCode           string                `json:"qr_code,omitempty"`
+	WalletAddress    string                `json:"wallet_address,omitempty"`
+	ChainAmount      string                `json:"chain_amount,omitempty"`
+	Chain            string                `json:"chain,omitempty"`
+	TokenID          string                `json:"token_id,omitempty"`
+	PaymentMethods   []CryptoPaymentMethod `json:"payment_methods,omitempty"`
+	SelectedCurrency string                `json:"selected_currency,omitempty"`
+	SelectedNetwork  string                `json:"selected_network,omitempty"`
+	ExpiresAt        *time.Time            `json:"expires_at,omitempty"`
+	ChannelName      string                `json:"channel_name,omitempty"`
 }
 
 // NewCreatePaymentResp 从 service.CreatePaymentResult 构造响应
@@ -52,6 +55,12 @@ func NewCreatePaymentResp(result *service.CreatePaymentResult) CreatePaymentResp
 		resp.ChainAmount = info.ChainAmount
 		resp.Chain = info.Chain
 		resp.TokenID = info.TokenID
+		resp.PaymentMethods = ExtractCryptoPaymentMethods(
+			result.Payment.ProviderType,
+			result.Payment.InteractionMode,
+			result.Payment.ProviderPayload,
+		)
+		resp.SelectedCurrency, resp.SelectedNetwork = ExtractSelectedCryptoPaymentMethod(result.Payment.ProviderPayload)
 	}
 	if result.Channel != nil {
 		resp.ChannelName = result.Channel.Name
@@ -61,40 +70,47 @@ func NewCreatePaymentResp(result *service.CreatePaymentResult) CreatePaymentResp
 
 // LatestPaymentResp 最新待支付记录响应
 type LatestPaymentResp struct {
-	PaymentID       uint       `json:"payment_id"`
-	OrderNo         string     `json:"order_no"`
-	ChannelID       uint       `json:"channel_id"`
-	ChannelName     string     `json:"channel_name,omitempty"`
-	ProviderType    string     `json:"provider_type"`
-	ChannelType     string     `json:"channel_type"`
-	InteractionMode string     `json:"interaction_mode"`
-	PayURL          string     `json:"pay_url"`
-	QRCode          string     `json:"qr_code"`
-	WalletAddress   string     `json:"wallet_address,omitempty"`
-	ChainAmount     string     `json:"chain_amount,omitempty"`
-	Chain           string     `json:"chain,omitempty"`
-	TokenID         string     `json:"token_id,omitempty"`
-	ExpiresAt       *time.Time `json:"expires_at"`
+	PaymentID        uint                  `json:"payment_id"`
+	OrderNo          string                `json:"order_no"`
+	ChannelID        uint                  `json:"channel_id"`
+	ChannelName      string                `json:"channel_name,omitempty"`
+	ProviderType     string                `json:"provider_type"`
+	ChannelType      string                `json:"channel_type"`
+	InteractionMode  string                `json:"interaction_mode"`
+	PayURL           string                `json:"pay_url"`
+	QRCode           string                `json:"qr_code"`
+	WalletAddress    string                `json:"wallet_address,omitempty"`
+	ChainAmount      string                `json:"chain_amount,omitempty"`
+	Chain            string                `json:"chain,omitempty"`
+	TokenID          string                `json:"token_id,omitempty"`
+	PaymentMethods   []CryptoPaymentMethod `json:"payment_methods,omitempty"`
+	SelectedCurrency string                `json:"selected_currency,omitempty"`
+	SelectedNetwork  string                `json:"selected_network,omitempty"`
+	ExpiresAt        *time.Time            `json:"expires_at"`
 }
 
 // NewLatestPaymentResp 从 Payment + Order 构造响应
 func NewLatestPaymentResp(payment *models.Payment, orderNo string) LatestPaymentResp {
 	info := ExtractCryptoWalletInfo(payment.ProviderType, payment.InteractionMode, payment.ProviderPayload)
+	currency, network := ExtractSelectedCryptoPaymentMethod(payment.ProviderPayload)
 	return LatestPaymentResp{
-		PaymentID:       payment.ID,
-		OrderNo:         orderNo,
-		ChannelID:       payment.ChannelID,
-		ChannelName:     payment.ChannelName,
-		ProviderType:    payment.ProviderType,
-		ChannelType:     payment.ChannelType,
-		InteractionMode: payment.InteractionMode,
-		PayURL:          payment.PayURL,
-		QRCode:          payment.QRCode,
-		WalletAddress:   info.Address,
-		ChainAmount:     info.ChainAmount,
-		Chain:           info.Chain,
-		TokenID:         info.TokenID,
-		ExpiresAt:       payment.ExpiredAt,
+		PaymentID:        payment.ID,
+		OrderNo:          orderNo,
+		ChannelID:        payment.ChannelID,
+		ChannelName:      payment.ChannelName,
+		ProviderType:     payment.ProviderType,
+		ChannelType:      payment.ChannelType,
+		InteractionMode:  payment.InteractionMode,
+		PayURL:           payment.PayURL,
+		QRCode:           payment.QRCode,
+		WalletAddress:    info.Address,
+		ChainAmount:      info.ChainAmount,
+		Chain:            info.Chain,
+		TokenID:          info.TokenID,
+		PaymentMethods:   ExtractCryptoPaymentMethods(payment.ProviderType, payment.InteractionMode, payment.ProviderPayload),
+		SelectedCurrency: currency,
+		SelectedNetwork:  network,
+		ExpiresAt:        payment.ExpiredAt,
 	}
 	// 排除：OrderID、Amount、FeeRate、FixedFee、FeeAmount、Currency、Status、
 	// ProviderRef、GatewayOrderNo、ProviderPayload、CreatedAt、UpdatedAt、PaidAt、CallbackAt

--- a/internal/dto/payment_usdt.go
+++ b/internal/dto/payment_usdt.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -14,6 +15,19 @@ type CryptoWalletInfo struct {
 	ChainAmount string
 	Chain       string
 	TokenID     string
+}
+
+// CryptoPaymentMethod 是 BEpusdt 收银台订单可选择的链上付款方式。
+type CryptoPaymentMethod struct {
+	Amount          string `json:"amount,omitempty"`
+	ActualAmount    string `json:"actual_amount,omitempty"`
+	Fiat            string `json:"fiat,omitempty"`
+	ExchangeRate    string `json:"exchange_rate,omitempty"`
+	Currency        string `json:"currency"`
+	Network         string `json:"network"`
+	TokenNetName    string `json:"token_net_name,omitempty"`
+	TokenCustomName string `json:"token_custom_name,omitempty"`
+	IsPopular       bool   `json:"is_popular,omitempty"`
 }
 
 // HasAny 返回是否存在任意可展示的链上付款字段。
@@ -78,6 +92,52 @@ func ExtractUSDTWalletInfo(providerType, interactionMode string, payload models.
 	return info.Address, info.ChainAmount
 }
 
+// ExtractCryptoPaymentMethods 从 BEpusdt 创建订单响应中提取可选币种和网络。
+func ExtractCryptoPaymentMethods(providerType, interactionMode string, payload models.JSON) []CryptoPaymentMethod {
+	if !strings.EqualFold(strings.TrimSpace(providerType), constants.PaymentProviderBepusdt) ||
+		!strings.EqualFold(strings.TrimSpace(interactionMode), constants.PaymentInteractionQR) {
+		return nil
+	}
+	data, ok := payloadMap(payload["data"])
+	if !ok {
+		return nil
+	}
+	raw, ok := data["payment_methods"]
+	if !ok || raw == nil {
+		return nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var methods []CryptoPaymentMethod
+	if err := json.Unmarshal(encoded, &methods); err != nil {
+		return nil
+	}
+	result := make([]CryptoPaymentMethod, 0, len(methods))
+	seen := make(map[string]struct{}, len(methods))
+	for _, method := range methods {
+		method.Currency = strings.ToUpper(strings.TrimSpace(method.Currency))
+		method.Network = strings.ToLower(strings.TrimSpace(method.Network))
+		if method.Currency == "" || method.Network == "" {
+			continue
+		}
+		key := method.Currency + ":" + method.Network
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, method)
+	}
+	return result
+}
+
+// ExtractSelectedCryptoPaymentMethod 返回当前已选币种和网络。
+func ExtractSelectedCryptoPaymentMethod(payload models.JSON) (currency, network string) {
+	return strings.ToUpper(readPayloadString(payload, "data", "selected_currency")),
+		strings.ToLower(readPayloadString(payload, "data", "selected_network"))
+}
+
 func firstPayloadString(values ...string) string {
 	for _, value := range values {
 		if value != "" {
@@ -117,5 +177,16 @@ func readPayloadString(payload models.JSON, keys ...string) string {
 		return strings.TrimSpace(fmt.Sprintf("%d", v))
 	default:
 		return strings.TrimSpace(fmt.Sprintf("%v", v))
+	}
+}
+
+func payloadMap(value any) (map[string]any, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed, true
+	case models.JSON:
+		return map[string]any(typed), true
+	default:
+		return nil, false
 	}
 }

--- a/internal/dto/payment_usdt_test.go
+++ b/internal/dto/payment_usdt_test.go
@@ -148,3 +148,29 @@ func TestExtractCryptoWalletInfo_DujiaoPayWrappedPayload(t *testing.T) {
 		t.Fatalf("unexpected info: %+v", info)
 	}
 }
+
+func TestExtractCryptoPaymentMethods(t *testing.T) {
+	payload := models.JSON{
+		"data": map[string]any{
+			"payment_methods": []map[string]any{
+				{"currency": "usdt", "network": "TRON", "actual_amount": "4.25"},
+				{"currency": "USDT", "network": "tron", "actual_amount": "4.25"},
+				{"currency": "USDC", "network": "base", "actual_amount": "4.01"},
+			},
+			"selected_currency": "usdc",
+			"selected_network":  "BASE",
+		},
+	}
+
+	methods := ExtractCryptoPaymentMethods(constants.PaymentProviderBepusdt, constants.PaymentInteractionQR, payload)
+	if len(methods) != 2 {
+		t.Fatalf("methods len = %d, want 2", len(methods))
+	}
+	if methods[0].Currency != "USDT" || methods[0].Network != "tron" {
+		t.Fatalf("unexpected normalized method: %+v", methods[0])
+	}
+	currency, network := ExtractSelectedCryptoPaymentMethod(payload)
+	if currency != "USDC" || network != "base" {
+		t.Fatalf("selected method = %s/%s", currency, network)
+	}
+}

--- a/internal/dto/wallet.go
+++ b/internal/dto/wallet.go
@@ -96,22 +96,25 @@ func NewWalletRechargeRespList(orders []models.WalletRechargeOrder) []WalletRech
 
 // WalletRechargePaymentPayload 钱包充值支付响应载荷
 type WalletRechargePaymentPayload struct {
-	Recharge        *WalletRechargeResp `json:"recharge,omitempty"`
-	RechargeNo      string              `json:"recharge_no,omitempty"`
-	RechargeStatus  string              `json:"recharge_status,omitempty"`
-	Account         *WalletAccountResp  `json:"account,omitempty"`
-	PaymentID       *uint               `json:"payment_id,omitempty"`
-	ProviderType    string              `json:"provider_type,omitempty"`
-	ChannelType     string              `json:"channel_type,omitempty"`
-	InteractionMode string              `json:"interaction_mode,omitempty"`
-	PayURL          string              `json:"pay_url,omitempty"`
-	QRCode          string              `json:"qr_code,omitempty"`
-	WalletAddress   string              `json:"wallet_address,omitempty"`
-	ChainAmount     string              `json:"chain_amount,omitempty"`
-	Chain           string              `json:"chain,omitempty"`
-	TokenID         string              `json:"token_id,omitempty"`
-	ExpiresAt       *time.Time          `json:"expires_at,omitempty"`
-	Status          string              `json:"status,omitempty"`
+	Recharge         *WalletRechargeResp   `json:"recharge,omitempty"`
+	RechargeNo       string                `json:"recharge_no,omitempty"`
+	RechargeStatus   string                `json:"recharge_status,omitempty"`
+	Account          *WalletAccountResp    `json:"account,omitempty"`
+	PaymentID        *uint                 `json:"payment_id,omitempty"`
+	ProviderType     string                `json:"provider_type,omitempty"`
+	ChannelType      string                `json:"channel_type,omitempty"`
+	InteractionMode  string                `json:"interaction_mode,omitempty"`
+	PayURL           string                `json:"pay_url,omitempty"`
+	QRCode           string                `json:"qr_code,omitempty"`
+	WalletAddress    string                `json:"wallet_address,omitempty"`
+	ChainAmount      string                `json:"chain_amount,omitempty"`
+	Chain            string                `json:"chain,omitempty"`
+	TokenID          string                `json:"token_id,omitempty"`
+	PaymentMethods   []CryptoPaymentMethod `json:"payment_methods,omitempty"`
+	SelectedCurrency string                `json:"selected_currency,omitempty"`
+	SelectedNetwork  string                `json:"selected_network,omitempty"`
+	ExpiresAt        *time.Time            `json:"expires_at,omitempty"`
+	Status           string                `json:"status,omitempty"`
 }
 
 // NewWalletRechargePaymentPayload 构造钱包充值支付响应
@@ -145,6 +148,8 @@ func NewWalletRechargePaymentPayload(recharge *models.WalletRechargeOrder, payme
 		p.ChainAmount = info.ChainAmount
 		p.Chain = info.Chain
 		p.TokenID = info.TokenID
+		p.PaymentMethods = ExtractCryptoPaymentMethods(payment.ProviderType, payment.InteractionMode, payment.ProviderPayload)
+		p.SelectedCurrency, p.SelectedNetwork = ExtractSelectedCryptoPaymentMethod(payment.ProviderPayload)
 	}
 	return p
 	// 排除 Payment 的：OrderID、ChannelID、Amount、FeeRate、FixedFee、FeeAmount、Currency、

--- a/internal/http/handlers/admin/card_secret_admin.go
+++ b/internal/http/handlers/admin/card_secret_admin.go
@@ -397,6 +397,10 @@ func (h *Handler) ExportCardSecrets(c *gin.Context) {
 
 // ExportAvailableCardSecrets 从可用库存中导出卡密并出库
 func (h *Handler) ExportAvailableCardSecrets(c *gin.Context) {
+	adminID, ok := shared.GetAdminID(c)
+	if !ok {
+		return
+	}
 	var req ExportAvailableCardSecretRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		shared.RespondBindError(c, err)
@@ -407,6 +411,7 @@ func (h *Handler) ExportAvailableCardSecrets(c *gin.Context) {
 		ProductID:         req.ProductID,
 		SKUID:             req.SKUID,
 		BatchID:           req.BatchID,
+		AdminID:           adminID,
 		Limit:             req.Limit,
 		Format:            req.Format,
 		DeleteAfterExport: req.DeleteAfterExport,
@@ -436,7 +441,56 @@ func (h *Handler) ExportAvailableCardSecrets(c *gin.Context) {
 	c.Header("Content-Type", result.ContentType)
 	c.Header("Content-Disposition", "attachment; filename=\""+filename+"\"")
 	c.Header("X-Exported-Count", strconv.Itoa(result.Count))
+	if result.Record != nil {
+		c.Header("X-Export-Record-ID", strconv.FormatUint(uint64(result.Record.ID), 10))
+	}
 	c.Data(200, result.ContentType, result.Content)
+}
+
+// GetCardSecretExports 获取卡密出库导出记录。
+func (h *Handler) GetCardSecretExports(c *gin.Context) {
+	page, pageSize := shared.ParsePagination(c)
+	parseOptional := func(key string) (uint, bool) {
+		raw := strings.TrimSpace(c.Query(key))
+		if raw == "" {
+			return 0, true
+		}
+		value, err := shared.ParseQueryUint(raw, false)
+		if err != nil {
+			shared.RespondError(c, response.CodeBadRequest, "error.card_secret_invalid", nil)
+			return 0, false
+		}
+		return value, true
+	}
+	id, ok := parseOptional("id")
+	if !ok {
+		return
+	}
+	productID, ok := parseOptional("product_id")
+	if !ok {
+		return
+	}
+	skuID, ok := parseOptional("sku_id")
+	if !ok {
+		return
+	}
+	batchID, ok := parseOptional("batch_id")
+	if !ok {
+		return
+	}
+	rows, total, err := h.CardSecretService.ListCardSecretExports(service.ListCardSecretExportInput{
+		ID:        id,
+		ProductID: productID,
+		SKUID:     skuID,
+		BatchID:   batchID,
+		Page:      page,
+		PageSize:  pageSize,
+	})
+	if err != nil {
+		shared.RespondError(c, response.CodeInternal, "error.card_secret_fetch_failed", err)
+		return
+	}
+	response.SuccessWithPage(c, rows, response.BuildPagination(page, pageSize, total))
 }
 
 // GetCardSecretStats 获取库存统计

--- a/internal/http/handlers/public/payment.go
+++ b/internal/http/handlers/public/payment.go
@@ -25,6 +25,12 @@ type LatestPaymentQuery struct {
 	OrderNo string `form:"order_no" binding:"required"`
 }
 
+// SelectPaymentMethodRequest 选择二维码支付的币种和网络。
+type SelectPaymentMethodRequest struct {
+	Currency string `json:"currency" binding:"required"`
+	Network  string `json:"network" binding:"required"`
+}
+
 // PaypalWebhookQuery PayPal webhook 查询参数。
 type PaypalWebhookQuery struct {
 	ChannelID uint `form:"channel_id" binding:"required"`
@@ -84,6 +90,62 @@ func (h *Handler) CreatePayment(c *gin.Context) {
 	}
 
 	response.Success(c, dto.NewCreatePaymentResp(result))
+}
+
+// SelectPaymentMethod 为当前用户的订单或充值单选择链上付款方式。
+func (h *Handler) SelectPaymentMethod(c *gin.Context) {
+	uid, ok := shared.GetUserID(c)
+	if !ok {
+		return
+	}
+	paymentID, err := shared.ParseParamUint(c, "id")
+	if err != nil {
+		shared.RespondError(c, response.CodeBadRequest, "error.payment_invalid", nil)
+		return
+	}
+	var req SelectPaymentMethodRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		shared.RespondBindError(c, err)
+		return
+	}
+	payment, err := h.PaymentService.GetPayment(paymentID)
+	if err != nil {
+		respondPaymentCaptureError(c, err)
+		return
+	}
+
+	businessNo := ""
+	if payment.OrderID != 0 {
+		order, orderErr := h.OrderService.GetOrderByUserForTenant(tenantFromRequest(c), payment.OrderID, uid)
+		if orderErr != nil {
+			respondPaymentCaptureError(c, orderErr)
+			return
+		}
+		businessNo = order.OrderNo
+	} else {
+		recharge, rechargeErr := h.WalletService.GetRechargeOrderByPaymentIDAndUser(paymentID, uid)
+		if rechargeErr != nil {
+			if errors.Is(rechargeErr, service.ErrWalletRechargeNotFound) {
+				shared.RespondError(c, response.CodeNotFound, "error.payment_not_found", nil)
+				return
+			}
+			shared.RespondError(c, response.CodeInternal, "error.payment_fetch_failed", rechargeErr)
+			return
+		}
+		businessNo = recharge.RechargeNo
+	}
+
+	updated, err := h.PaymentService.SelectPaymentMethod(service.SelectPaymentMethodInput{
+		PaymentID: paymentID,
+		Currency:  req.Currency,
+		Network:   req.Network,
+		Context:   c.Request.Context(),
+	})
+	if err != nil {
+		respondPaymentCaptureError(c, err)
+		return
+	}
+	response.Success(c, dto.NewLatestPaymentResp(updated, businessNo))
 }
 
 // CapturePayment 用户捕获支付。

--- a/internal/http/handlers/public/public.go
+++ b/internal/http/handlers/public/public.go
@@ -1403,6 +1403,62 @@ type CaptureGuestPaymentRequest struct {
 	OrderPassword string `json:"order_password" binding:"required"`
 }
 
+// SelectGuestPaymentMethodRequest 游客选择二维码支付的币种和网络。
+type SelectGuestPaymentMethodRequest struct {
+	Email         string `json:"email" binding:"required"`
+	OrderPassword string `json:"order_password" binding:"required"`
+	Currency      string `json:"currency" binding:"required"`
+	Network       string `json:"network" binding:"required"`
+}
+
+// SelectGuestPaymentMethod 为游客订单选择链上付款方式。
+func (h *Handler) SelectGuestPaymentMethod(c *gin.Context) {
+	paymentID, err := shared.ParseParamUint(c, "id")
+	if err != nil {
+		shared.RespondError(c, response.CodeBadRequest, "error.payment_invalid", nil)
+		return
+	}
+	var req SelectGuestPaymentMethodRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		shared.RespondBindError(c, err)
+		return
+	}
+	payment, err := h.PaymentService.GetPayment(paymentID)
+	if err != nil {
+		respondPaymentCaptureError(c, err)
+		return
+	}
+	if payment.OrderID == 0 {
+		shared.RespondError(c, response.CodeNotFound, "error.guest_order_not_found", nil)
+		return
+	}
+	order, err := h.OrderService.GetOrderByGuestForTenant(
+		tenantFromRequest(c),
+		payment.OrderID,
+		strings.TrimSpace(req.Email),
+		strings.TrimSpace(req.OrderPassword),
+	)
+	if err != nil {
+		if errors.Is(err, service.ErrGuestOrderNotFound) {
+			shared.RespondError(c, response.CodeNotFound, "error.guest_order_not_found", nil)
+			return
+		}
+		shared.RespondError(c, response.CodeInternal, "error.order_fetch_failed", err)
+		return
+	}
+	updated, err := h.PaymentService.SelectPaymentMethod(service.SelectPaymentMethodInput{
+		PaymentID: paymentID,
+		Currency:  req.Currency,
+		Network:   req.Network,
+		Context:   c.Request.Context(),
+	})
+	if err != nil {
+		respondPaymentCaptureError(c, err)
+		return
+	}
+	response.Success(c, dto.NewLatestPaymentResp(updated, order.OrderNo))
+}
+
 // CaptureGuestPayment 游客捕获支付。
 func (h *Handler) CaptureGuestPayment(c *gin.Context) {
 	paymentID, err := shared.ParseParamUint(c, "id")

--- a/internal/models/card_secret.go
+++ b/internal/models/card_secret.go
@@ -21,6 +21,7 @@ type CardSecret struct {
 	Secret     string         `gorm:"type:text;not null" json:"secret"`                                             // 卡密内容
 	Status     string         `gorm:"not null;index:idx_card_secret_reserve" json:"status"`                         // 状态（available/used）
 	OrderID    *uint          `gorm:"index" json:"order_id,omitempty"`                                              // 关联订单ID
+	ExportID   *uint          `gorm:"index" json:"export_id,omitempty"`                                             // 关联导出记录ID
 	ReservedAt *time.Time     `gorm:"index" json:"reserved_at"`                                                     // 占用时间
 	UsedAt     *time.Time     `gorm:"index" json:"used_at"`                                                         // 使用时间
 	CreatedAt  time.Time      `gorm:"index" json:"created_at"`                                                      // 创建时间

--- a/internal/models/card_secret_export.go
+++ b/internal/models/card_secret_export.go
@@ -1,0 +1,20 @@
+package models
+
+import "time"
+
+// CardSecretExport 卡密库存出库导出记录。
+type CardSecretExport struct {
+	ID                uint      `gorm:"primarykey" json:"id"`
+	ProductID         uint      `gorm:"not null;index" json:"product_id"`
+	SKUID             uint      `gorm:"column:sku_id;not null;default:0;index" json:"sku_id"`
+	BatchID           *uint     `gorm:"index" json:"batch_id,omitempty"`
+	AdminID           uint      `gorm:"not null;default:0;index" json:"admin_id"`
+	Format            string    `gorm:"type:varchar(8);not null" json:"format"`
+	Count             int       `gorm:"not null" json:"count"`
+	DeleteAfterExport bool      `gorm:"not null;default:false" json:"delete_after_export"`
+	CreatedAt         time.Time `gorm:"index" json:"created_at"`
+}
+
+func (CardSecretExport) TableName() string {
+	return "card_secret_exports"
+}

--- a/internal/models/db.go
+++ b/internal/models/db.go
@@ -135,6 +135,7 @@ func AutoMigrate() error {
 		&Payment{},
 		&CardSecret{},
 		&CardSecretBatch{},
+		&CardSecretExport{},
 		&GiftCard{},
 		&GiftCardBatch{},
 		&Fulfillment{},

--- a/internal/payment/bepusdt/bepusdt.go
+++ b/internal/payment/bepusdt/bepusdt.go
@@ -50,6 +50,8 @@ const (
 	bepusdtChannelTypeTRX       = "trx"
 
 	bepusdtCreateTransactionPath = "/api/v1/order/create-transaction"
+	bepusdtCreateOrderPath       = "/api/v1/order/create-order"
+	bepusdtUpdateOrderPath       = "/api/v1/pay/update-order"
 	bepusdtStatusSuccessMsg      = "status is not success"
 )
 
@@ -58,6 +60,7 @@ type Config struct {
 	GatewayURL string `json:"gateway_url"` // 网关地址，如 https://usdt.example.com
 	AuthToken  string `json:"auth_token"`  // API Token
 	TradeType  string `json:"trade_type"`  // 交易类型，如 usdt.trc20
+	Currencies string `json:"currencies"`  // 收银台模式允许的币种，逗号分隔
 	Fiat       string `json:"fiat"`        // 法币类型，默认 CNY
 	NotifyURL  string `json:"notify_url"`  // 异步通知地址
 	ReturnURL  string `json:"return_url"`  // 同步跳转地址
@@ -80,7 +83,21 @@ type CreateResult struct {
 	ActualAmount string                 // 实际支付金额（加密货币）
 	Token        string                 // 收款地址
 	PaymentURL   string                 // 收银台地址
+	TradeType    string                 // 实际交易类型
+	Methods      []PaymentMethod        // 可选付款方式
 	Raw          map[string]interface{} // 原始响应
+}
+
+type PaymentMethod struct {
+	Amount          string `json:"amount"`
+	ActualAmount    string `json:"actual_amount"`
+	Fiat            string `json:"fiat"`
+	ExchangeRate    string `json:"exchange_rate"`
+	Currency        string `json:"currency"`
+	Network         string `json:"network"`
+	TokenNetName    string `json:"token_net_name"`
+	TokenCustomName string `json:"token_custom_name"`
+	IsPopular       bool   `json:"is_popular"`
 }
 
 // CallbackData 回调数据
@@ -150,6 +167,7 @@ func (c *Config) Normalize() {
 	c.GatewayURL = strings.TrimRight(strings.TrimSpace(c.GatewayURL), "/")
 	c.AuthToken = strings.TrimSpace(c.AuthToken)
 	c.TradeType = strings.TrimSpace(c.TradeType)
+	c.Currencies = strings.TrimSpace(c.Currencies)
 	c.Fiat = strings.TrimSpace(c.Fiat)
 	c.NotifyURL = strings.TrimSpace(c.NotifyURL)
 	c.ReturnURL = strings.TrimSpace(c.ReturnURL)
@@ -159,6 +177,124 @@ func (c *Config) Normalize() {
 	if c.Fiat == "" {
 		c.Fiat = constants.SiteCurrencyDefault
 	}
+}
+
+// CreateSelectableOrder 创建由商户前台选择付款币种/网络的订单。
+func CreateSelectableOrder(ctx context.Context, cfg *Config, input CreateInput) (*CreateResult, error) {
+	if cfg == nil || input.OrderNo == "" || input.Amount == "" {
+		return nil, ErrConfigInvalid
+	}
+	amount, err := strconv.ParseFloat(input.Amount, 64)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid amount", ErrConfigInvalid)
+	}
+	notifyURL := pickCreateURL(input.NotifyURL, cfg.NotifyURL)
+	returnURL := pickCreateURL(input.ReturnURL, cfg.ReturnURL)
+	params := map[string]interface{}{
+		"order_id":     input.OrderNo,
+		"amount":       amount,
+		"notify_url":   notifyURL,
+		"redirect_url": returnURL,
+		"fiat":         cfg.Fiat,
+		"reselect":     true,
+	}
+	if input.Name != "" {
+		params["name"] = input.Name
+	}
+	if cfg.Currencies != "" {
+		params["currencies"] = cfg.Currencies
+	}
+	params["signature"] = Sign(params, cfg.AuthToken)
+
+	respBytes, err := postJSON(ctx, cfg.GatewayURL+bepusdtCreateOrderPath, params)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrRequestFailed, err)
+	}
+	var resp struct {
+		StatusCode int    `json:"status_code"`
+		Message    string `json:"message"`
+		Data       struct {
+			Fiat           string          `json:"fiat"`
+			TradeID        string          `json:"trade_id"`
+			OrderID        string          `json:"order_id"`
+			Amount         string          `json:"amount"`
+			ExpirationTime int             `json:"expiration_time"`
+			PaymentURL     string          `json:"payment_url"`
+			Methods        []PaymentMethod `json:"network"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrResponseInvalid, err)
+	}
+	if resp.StatusCode != 200 || strings.TrimSpace(resp.Data.TradeID) == "" {
+		return nil, fmt.Errorf("%w: %s", ErrResponseInvalid, resp.Message)
+	}
+	var raw map[string]interface{}
+	_ = json.Unmarshal(respBytes, &raw)
+	return &CreateResult{
+		TradeID:    resp.Data.TradeID,
+		OrderID:    resp.Data.OrderID,
+		Amount:     resp.Data.Amount,
+		PaymentURL: resp.Data.PaymentURL,
+		Methods:    resp.Data.Methods,
+		Raw:        raw,
+	}, nil
+}
+
+// UpdateSelectableOrder 为待支付订单选定币种和网络，返回对应收款地址。
+func UpdateSelectableOrder(ctx context.Context, cfg *Config, tradeID, currency, network string) (*CreateResult, error) {
+	if cfg == nil || strings.TrimSpace(tradeID) == "" || strings.TrimSpace(currency) == "" || strings.TrimSpace(network) == "" {
+		return nil, ErrConfigInvalid
+	}
+	params := map[string]interface{}{
+		"trade_id": strings.TrimSpace(tradeID),
+		"currency": strings.ToUpper(strings.TrimSpace(currency)),
+		"network":  strings.ToLower(strings.TrimSpace(network)),
+	}
+	respBytes, err := postJSON(ctx, cfg.GatewayURL+bepusdtUpdateOrderPath, params)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrRequestFailed, err)
+	}
+	var resp struct {
+		StatusCode int    `json:"status_code"`
+		Message    string `json:"message"`
+		Data       struct {
+			Fiat           string `json:"fiat"`
+			TradeType      string `json:"trade_type"`
+			TradeID        string `json:"trade_id"`
+			OrderID        string `json:"order_id"`
+			Amount         string `json:"amount"`
+			ActualAmount   string `json:"actual_amount"`
+			Token          string `json:"token"`
+			ExpirationTime int    `json:"expiration_time"`
+			PaymentURL     string `json:"payment_url"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrResponseInvalid, err)
+	}
+	if resp.StatusCode != 200 || strings.TrimSpace(resp.Data.Token) == "" {
+		return nil, fmt.Errorf("%w: %s", ErrResponseInvalid, resp.Message)
+	}
+	var raw map[string]interface{}
+	_ = json.Unmarshal(respBytes, &raw)
+	return &CreateResult{
+		TradeID:      resp.Data.TradeID,
+		OrderID:      resp.Data.OrderID,
+		Amount:       resp.Data.Amount,
+		ActualAmount: resp.Data.ActualAmount,
+		Token:        resp.Data.Token,
+		PaymentURL:   resp.Data.PaymentURL,
+		TradeType:    resp.Data.TradeType,
+		Raw:          raw,
+	}, nil
+}
+
+func pickCreateURL(primary, fallback string) string {
+	if value := strings.TrimSpace(primary); value != "" {
+		return value
+	}
+	return strings.TrimSpace(fallback)
 }
 
 // CreatePayment 创建支付订单

--- a/internal/payment/provider/bepusdt_adapter.go
+++ b/internal/payment/provider/bepusdt_adapter.go
@@ -25,8 +25,9 @@ func NewBepusdtAdapter() Provider { return &bepusdtAdapter{} }
 
 // 编译期断言 bepusdtAdapter 实现了 Provider 和 CallbackVerifier。
 var (
-	_ Provider         = (*bepusdtAdapter)(nil)
-	_ CallbackVerifier = (*bepusdtAdapter)(nil)
+	_ Provider              = (*bepusdtAdapter)(nil)
+	_ CallbackVerifier      = (*bepusdtAdapter)(nil)
+	_ PaymentMethodSelector = (*bepusdtAdapter)(nil)
 )
 
 // Type 返回 provider 标识。bepusdt 是多 channel type provider，返回值中 channelType 部分为空。
@@ -88,32 +89,54 @@ func (a *bepusdtAdapter) CreatePayment(ctx context.Context, raw models.JSON, inp
 		NotifyURL: input.NotifyURL,
 		ReturnURL: returnURL,
 	}
-	result, err := bepusdt.CreatePayment(ctx, cfg, native)
-	if err != nil {
-		return nil, mapBepusdtError(err)
-	}
-
 	mode, _ := input.Extra["interaction_mode"].(string)
 	mode = strings.ToLower(strings.TrimSpace(mode))
-	redirectURL := strings.TrimSpace(result.PaymentURL)
-	qrCodeURL := redirectURL
 	switch mode {
 	case constants.PaymentInteractionQR:
-		qrCodeURL = strings.TrimSpace(result.Token)
-		redirectURL = ""
-		if qrCodeURL == "" {
-			return nil, fmt.Errorf("%w: bepusdt token is empty", ErrResponseInvalid)
+		result, err := bepusdt.CreateSelectableOrder(ctx, cfg, native)
+		if err != nil {
+			return nil, mapBepusdtError(err)
 		}
+		if len(result.Methods) == 0 {
+			return nil, fmt.Errorf("%w: bepusdt payment methods are empty", ErrResponseInvalid)
+		}
+		return &CreateResult{
+			ProviderRef: result.TradeID,
+			Payload:     buildBepusdtCreatePayload(result, ""),
+		}, nil
 	case "", constants.PaymentInteractionRedirect:
+		result, err := bepusdt.CreatePayment(ctx, cfg, native)
+		if err != nil {
+			return nil, mapBepusdtError(err)
+		}
+		return &CreateResult{
+			ProviderRef: result.TradeID,
+			RedirectURL: strings.TrimSpace(result.PaymentURL),
+			QRCodeURL:   strings.TrimSpace(result.PaymentURL),
+			Payload:     buildBepusdtCreatePayload(result, cfg.TradeType),
+		}, nil
 	default:
 		return nil, fmt.Errorf("%w: bepusdt interaction_mode %s", ErrConfigInvalid, mode)
 	}
+}
 
-	return &CreateResult{
-		ProviderRef: result.TradeID,
-		RedirectURL: redirectURL,
-		QRCodeURL:   qrCodeURL,
-		Payload:     buildBepusdtCreatePayload(result, cfg.TradeType),
+func (a *bepusdtAdapter) SelectPaymentMethod(ctx context.Context, raw models.JSON, input SelectPaymentMethodInput) (*SelectPaymentMethodResult, error) {
+	cfg, err := a.parseConfig(raw, "")
+	if err != nil {
+		return nil, err
+	}
+	result, err := bepusdt.UpdateSelectableOrder(ctx, cfg, input.ProviderRef, input.Currency, input.Network)
+	if err != nil {
+		return nil, mapBepusdtError(err)
+	}
+	payload := buildBepusdtCreatePayload(result, result.TradeType)
+	data := ensureBepusdtPayloadData(payload)
+	data["selection_required"] = false
+	setBepusdtPayloadString(data, "selected_currency", strings.ToUpper(strings.TrimSpace(input.Currency)))
+	setBepusdtPayloadString(data, "selected_network", strings.ToLower(strings.TrimSpace(input.Network)))
+	return &SelectPaymentMethodResult{
+		QRCodeURL: strings.TrimSpace(result.Token),
+		Payload:   payload,
 	}, nil
 }
 
@@ -129,6 +152,10 @@ func buildBepusdtCreatePayload(result *bepusdt.CreateResult, tradeType string) m
 	}
 
 	data := ensureBepusdtPayloadData(payload)
+	if len(result.Methods) > 0 {
+		data["payment_methods"] = result.Methods
+		data["selection_required"] = strings.TrimSpace(result.Token) == ""
+	}
 	setBepusdtPayloadString(data, "trade_type", tradeType)
 	setBepusdtPayloadString(data, "token", result.Token)
 	setBepusdtPayloadString(data, "actual_amount", result.ActualAmount)
@@ -171,6 +198,18 @@ func resolveBepusdtTradeLabels(tradeType string) (chain string, tokenID string) 
 		return "bsc", "bsc-usdt"
 	case "usdt.polygon":
 		return "polygon", "polygon-usdt"
+	case "usdt.aptos":
+		return "aptos", "aptos-usdt"
+	case "usdt.solana":
+		return "solana", "solana-usdt"
+	case "usdt.xlayer":
+		return "x-layer", "x-layer-usdt"
+	case "usdt.arbitrum":
+		return "arbitrum", "arbitrum-usdt"
+	case "usdt.plasma":
+		return "plasma", "plasma-usdt"
+	case "usdt.ton":
+		return "ton", "ton-usdt"
 	case "usdc.trc20":
 		return "tron", "tron-usdc"
 	case "usdc.erc20":
@@ -179,12 +218,26 @@ func resolveBepusdtTradeLabels(tradeType string) (chain string, tokenID string) 
 		return "polygon", "polygon-usdc"
 	case "usdc.bep20":
 		return "bsc", "bsc-usdc"
+	case "usdc.aptos":
+		return "aptos", "aptos-usdc"
+	case "usdc.solana":
+		return "solana", "solana-usdc"
+	case "usdc.xlayer":
+		return "x-layer", "x-layer-usdc"
+	case "usdc.arbitrum":
+		return "arbitrum", "arbitrum-usdc"
+	case "usdc.base":
+		return "base", "base-usdc"
 	case "tron.trx":
 		return "tron", "tron-trx"
 	case "eth.eth":
 		return "ethereum", "ethereum-eth"
+	case "ethereum.eth":
+		return "ethereum", "ethereum-eth"
 	case "bsc.bnb":
 		return "bsc", "bsc-bnb"
+	case "ton.gram":
+		return "ton", "ton-gram"
 	default:
 		return "", ""
 	}

--- a/internal/payment/provider/bepusdt_adapter_test.go
+++ b/internal/payment/provider/bepusdt_adapter_test.go
@@ -49,12 +49,14 @@ func TestBepusdtAdapter_CreatePayment_ConfigInvalidMapped(t *testing.T) {
 	}
 }
 
-func TestBepusdtAdapter_CreatePayment_QRModeUsesWalletAddress(t *testing.T) {
+func TestBepusdtAdapter_CreatePayment_QRModeReturnsPaymentMethods(t *testing.T) {
 	a := NewBepusdtAdapter()
 	server := newBepusdtCreatePaymentServer(t, "usdt.trc20")
 	defer server.Close()
+	config := validBepusdtConfig(server.URL)
+	config["currencies"] = "USDT,USDC"
 
-	result, err := a.CreatePayment(context.Background(), validBepusdtConfig(server.URL), CreateInput{
+	result, err := a.CreatePayment(context.Background(), config, CreateInput{
 		OrderNo:     "ORDER-QR-1",
 		Subject:     "测试商品",
 		Amount:      models.NewMoneyFromDecimal(decimal.RequireFromString("28.88")),
@@ -68,17 +70,47 @@ func TestBepusdtAdapter_CreatePayment_QRModeUsesWalletAddress(t *testing.T) {
 	if result.RedirectURL != "" {
 		t.Fatalf("RedirectURL = %q, want empty in qr mode", result.RedirectURL)
 	}
-	if result.QRCodeURL != "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t" {
-		t.Fatalf("QRCodeURL = %q, want wallet address", result.QRCodeURL)
+	if result.QRCodeURL != "" {
+		t.Fatalf("QRCodeURL = %q, want empty before selecting a payment method", result.QRCodeURL)
 	}
 	data := result.Payload["data"].(map[string]interface{})
-	if data["actual_amount"] != "4.25" {
-		t.Fatalf("actual_amount = %v, want 4.25", data["actual_amount"])
+	methods, ok := data["payment_methods"].([]bepusdt.PaymentMethod)
+	if !ok || len(methods) != 2 {
+		t.Fatalf("payment_methods = %#v, want two methods", data["payment_methods"])
 	}
-	if data["trade_type"] != "usdt.trc20" {
-		t.Fatalf("trade_type = %v, want usdt.trc20", data["trade_type"])
+	if data["selection_required"] != true {
+		t.Fatalf("selection_required = %v, want true", data["selection_required"])
 	}
-	if data["chain"] != "tron" || data["token_id"] != "tron-usdt" {
+	if methods[0].Currency != "USDT" || methods[0].Network != "tron" {
+		t.Fatalf("unexpected first payment method: %#v", methods[0])
+	}
+}
+
+func TestBepusdtAdapter_SelectPaymentMethodReturnsWalletAddress(t *testing.T) {
+	adapter := NewBepusdtAdapter()
+	selector, ok := adapter.(PaymentMethodSelector)
+	if !ok {
+		t.Fatal("bepusdt adapter does not implement PaymentMethodSelector")
+	}
+	server := newBepusdtCreatePaymentServer(t, "usdt.trc20")
+	defer server.Close()
+
+	result, err := selector.SelectPaymentMethod(context.Background(), validBepusdtConfig(server.URL), SelectPaymentMethodInput{
+		ProviderRef: "BEP-SELECT-1",
+		Currency:    "USDC",
+		Network:     "base",
+	})
+	if err != nil {
+		t.Fatalf("SelectPaymentMethod() failed: %v", err)
+	}
+	if result.QRCodeURL != "0xBaseWalletAddress" {
+		t.Fatalf("QRCodeURL = %q, want selected wallet address", result.QRCodeURL)
+	}
+	data := result.Payload["data"].(map[string]interface{})
+	if data["selection_required"] != false || data["selected_currency"] != "USDC" || data["selected_network"] != "base" {
+		t.Fatalf("unexpected selection payload: %#v", data)
+	}
+	if data["chain"] != "base" || data["token_id"] != "base-usdc" {
 		t.Fatalf("unexpected chain labels: chain=%v token_id=%v", data["chain"], data["token_id"])
 	}
 }
@@ -144,19 +176,60 @@ func validBepusdtConfig(gatewayURL string) models.JSON {
 func newBepusdtCreatePaymentServer(t *testing.T, wantTradeType string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/order/create-transaction" {
-			t.Fatalf("path = %s, want /api/v1/order/create-transaction", r.URL.Path)
-		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode request failed: %v", err)
 		}
-		if payload["trade_type"] != wantTradeType {
-			t.Fatalf("trade_type = %v, want %s", payload["trade_type"], wantTradeType)
-		}
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
+		switch r.URL.Path {
+		case "/api/v1/order/create-order":
+			if payload["reselect"] != true {
+				t.Fatalf("reselect = %v, want true", payload["reselect"])
+			}
+			if payload["currencies"] != "USDT,USDC" {
+				t.Fatalf("currencies = %v, want USDT,USDC", payload["currencies"])
+			}
+			_, _ = w.Write([]byte(`{
+				"status_code": 200,
+				"message": "success",
+				"data": {
+					"fiat": "CNY",
+					"trade_id": "BEP-SELECT-1",
+					"order_id": "ORDER-QR-1",
+					"amount": "28.88",
+					"expiration_time": 1200,
+					"payment_url": "https://bepusdt.example/pay/cashier/BEP-SELECT-1",
+					"network": [
+						{"amount":"28.88","actual_amount":"4.25","fiat":"CNY","exchange_rate":"6.79","currency":"USDT","network":"tron","token_net_name":"TRC20","is_popular":true},
+						{"amount":"28.88","actual_amount":"4.01","fiat":"CNY","exchange_rate":"7.20","currency":"USDC","network":"base","token_net_name":"Base","is_popular":false}
+					]
+				}
+			}`))
+		case "/api/v1/pay/update-order":
+			if payload["trade_id"] != "BEP-SELECT-1" || payload["currency"] != "USDC" || payload["network"] != "base" {
+				t.Fatalf("unexpected update-order payload: %#v", payload)
+			}
+			_, _ = w.Write([]byte(`{
+				"status_code": 200,
+				"message": "success",
+				"data": {
+					"fiat": "CNY",
+					"trade_type": "usdc.base",
+					"trade_id": "BEP-SELECT-1",
+					"order_id": "ORDER-QR-1",
+					"amount": "28.88",
+					"actual_amount": "4.01",
+					"token": "0xBaseWalletAddress",
+					"expiration_time": 1200,
+					"payment_url": "https://bepusdt.example/pay/checkout-counter/BEP-SELECT-1"
+				}
+			}`))
+		case "/api/v1/order/create-transaction":
+			if payload["trade_type"] != wantTradeType {
+				t.Fatalf("trade_type = %v, want %s", payload["trade_type"], wantTradeType)
+			}
+			_, _ = w.Write([]byte(`{
 			"status_code": 200,
 			"message": "success",
 			"data": {
@@ -170,6 +243,9 @@ func newBepusdtCreatePaymentServer(t *testing.T, wantTradeType string) *httptest
 				"status": 1,
 				"payment_url": "https://bepusdt.example/pay/checkout-counter/BEP-1"
 			}
-		}`))
+			}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
 	}))
 }

--- a/internal/payment/provider/types.go
+++ b/internal/payment/provider/types.go
@@ -44,6 +44,17 @@ type CreateResult struct {
 	CurrencySent string
 }
 
+type SelectPaymentMethodInput struct {
+	ProviderRef string
+	Currency    string
+	Network     string
+}
+
+type SelectPaymentMethodResult struct {
+	QRCodeURL string
+	Payload   models.JSON
+}
+
 // QueryResult 主动查询订单状态返回。
 type QueryResult struct {
 	ProviderRef string
@@ -74,6 +85,12 @@ type Provider interface {
 	Type() string
 	ValidateConfig(cfg models.JSON, channelType string) error
 	CreatePayment(ctx context.Context, cfg models.JSON, input CreateInput) (*CreateResult, error)
+}
+
+// PaymentMethodSelector 是支持在订单创建后选择链上付款方式的可选能力。
+type PaymentMethodSelector interface {
+	Provider
+	SelectPaymentMethod(ctx context.Context, cfg models.JSON, input SelectPaymentMethodInput) (*SelectPaymentMethodResult, error)
 }
 
 // Capturer 可选能力:主动查询订单状态(stripe/paypal/wechat 实现)。

--- a/internal/repository/card_secret_repository.go
+++ b/internal/repository/card_secret_repository.go
@@ -30,6 +30,15 @@ type CardSecretBatchStatusCount struct {
 	Total   int64  `gorm:"column:total"`
 }
 
+type CardSecretExportListFilter struct {
+	ID        uint
+	ProductID uint
+	SKUID     uint
+	BatchID   uint
+	Page      int
+	PageSize  int
+}
+
 // CardSecretRepository 卡密库存数据访问接口
 type CardSecretRepository interface {
 	CreateBatch(items []models.CardSecret) error
@@ -50,7 +59,10 @@ type CardSecretRepository interface {
 	GetByID(id uint) (*models.CardSecret, error)
 	Update(secret *models.CardSecret) error
 	BatchUpdateStatus(ids []uint, status string, updatedAt time.Time) (int64, error)
+	MarkExported(ids []uint, exportID uint, usedAt time.Time) (int64, error)
 	BatchDeleteByIDs(ids []uint) (int64, error)
+	CreateExport(record *models.CardSecretExport) error
+	ListExports(filter CardSecretExportListFilter) ([]models.CardSecretExport, int64, error)
 	CountByProduct(productID, skuID uint) (int64, int64, int64, error)
 	CountAvailable(productID, skuID uint) (int64, error)
 	CountAvailableByProductIDs(productIDs []uint) (map[uint]int64, error)
@@ -295,6 +307,60 @@ func (r *GormCardSecretRepository) BatchUpdateStatus(ids []uint, status string, 
 			"updated_at": updatedAt,
 		})
 	return result.RowsAffected, result.Error
+}
+
+// MarkExported 将卡密标记为已使用并关联导出记录。
+func (r *GormCardSecretRepository) MarkExported(ids []uint, exportID uint, usedAt time.Time) (int64, error) {
+	if len(ids) == 0 || exportID == 0 {
+		return 0, nil
+	}
+	if usedAt.IsZero() {
+		usedAt = time.Now()
+	}
+	result := r.db.Model(&models.CardSecret{}).
+		Where("id IN ? AND status = ?", ids, models.CardSecretStatusAvailable).
+		Updates(map[string]interface{}{
+			"status":      models.CardSecretStatusUsed,
+			"order_id":    nil,
+			"export_id":   exportID,
+			"reserved_at": nil,
+			"used_at":     usedAt,
+			"updated_at":  usedAt,
+		})
+	return result.RowsAffected, result.Error
+}
+
+func (r *GormCardSecretRepository) CreateExport(record *models.CardSecretExport) error {
+	if record == nil {
+		return errors.New("card secret export is nil")
+	}
+	return r.db.Create(record).Error
+}
+
+func (r *GormCardSecretRepository) ListExports(filter CardSecretExportListFilter) ([]models.CardSecretExport, int64, error) {
+	query := r.db.Model(&models.CardSecretExport{})
+	if filter.ID > 0 {
+		query = query.Where("id = ?", filter.ID)
+	}
+	if filter.ProductID > 0 {
+		query = query.Where("product_id = ?", filter.ProductID)
+	}
+	if filter.SKUID > 0 {
+		query = query.Where("sku_id = ?", filter.SKUID)
+	}
+	if filter.BatchID > 0 {
+		query = query.Where("batch_id = ?", filter.BatchID)
+	}
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	query = applyPagination(query, filter.Page, filter.PageSize)
+	var rows []models.CardSecretExport
+	if err := query.Order("id DESC").Find(&rows).Error; err != nil {
+		return nil, 0, err
+	}
+	return rows, total, nil
 }
 
 // BatchDeleteByIDs 批量删除卡密

--- a/internal/repository/payment_repository.go
+++ b/internal/repository/payment_repository.go
@@ -130,10 +130,12 @@ func (r *GormPaymentRepository) GetLatestPendingByOrder(orderID uint, now time.T
 	result := r.db.
 		Select("payments.*, payment_channels.name AS channel_name").
 		Joins("LEFT JOIN payment_channels ON payment_channels.id = payments.channel_id AND payment_channels.deleted_at IS NULL").
-		Where("payments.order_id = ? AND payments.status IN ? AND (payments.expired_at IS NULL OR payments.expired_at > ?) AND ((payments.pay_url IS NOT NULL AND payments.pay_url <> '') OR (payments.qr_code IS NOT NULL AND payments.qr_code <> ''))",
+		Where("payments.order_id = ? AND payments.status IN ? AND (payments.expired_at IS NULL OR payments.expired_at > ?) AND ((payments.pay_url IS NOT NULL AND payments.pay_url <> '') OR (payments.qr_code IS NOT NULL AND payments.qr_code <> '') OR (LOWER(payments.provider_type) = ? AND LOWER(payments.interaction_mode) = ? AND payments.provider_ref IS NOT NULL AND payments.provider_ref <> ''))",
 			orderID,
 			[]string{constants.PaymentStatusInitiated, constants.PaymentStatusPending},
 			now,
+			constants.PaymentProviderBepusdt,
+			constants.PaymentInteractionQR,
 		).Order("payments.id desc").Limit(1).Find(&payment)
 	if result.Error != nil {
 		return nil, result.Error
@@ -147,11 +149,13 @@ func (r *GormPaymentRepository) GetLatestPendingByOrder(orderID uint, now time.T
 // GetLatestPendingByOrderChannel 获取订单+渠道最新待支付记录
 func (r *GormPaymentRepository) GetLatestPendingByOrderChannel(orderID uint, channelID uint, now time.Time) (*models.Payment, error) {
 	var payment models.Payment
-	result := r.db.Where("order_id = ? AND channel_id = ? AND status IN ? AND (expired_at IS NULL OR expired_at > ?) AND ((pay_url IS NOT NULL AND pay_url <> '') OR (qr_code IS NOT NULL AND qr_code <> ''))",
+	result := r.db.Where("order_id = ? AND channel_id = ? AND status IN ? AND (expired_at IS NULL OR expired_at > ?) AND ((pay_url IS NOT NULL AND pay_url <> '') OR (qr_code IS NOT NULL AND qr_code <> '') OR (LOWER(provider_type) = ? AND LOWER(interaction_mode) = ? AND provider_ref IS NOT NULL AND provider_ref <> ''))",
 		orderID,
 		channelID,
 		[]string{constants.PaymentStatusInitiated, constants.PaymentStatusPending},
 		now,
+		constants.PaymentProviderBepusdt,
+		constants.PaymentInteractionQR,
 	).Order("id desc").Limit(1).Find(&payment)
 	if result.Error != nil {
 		return nil, result.Error

--- a/internal/repository/payment_repository_test.go
+++ b/internal/repository/payment_repository_test.go
@@ -23,12 +23,48 @@ func setupPaymentRepositoryTest(t *testing.T) (*GormPaymentRepository, *gorm.DB)
 	if err := db.AutoMigrate(
 		&models.User{},
 		&models.Order{},
+		&models.PaymentChannel{},
 		&models.Payment{},
 		&models.WalletRechargeOrder{},
 	); err != nil {
 		t.Fatalf("auto migrate failed: %v", err)
 	}
 	return NewPaymentRepository(db), db
+}
+
+func TestPaymentRepositoryFindsBepusdtMethodSelectionPayment(t *testing.T) {
+	repo, db := setupPaymentRepositoryTest(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	expiresAt := now.Add(10 * time.Minute)
+
+	payment := models.Payment{
+		OrderID:         101,
+		ChannelID:       7,
+		ProviderType:    constants.PaymentProviderBepusdt,
+		ChannelType:     constants.PaymentChannelTypeUsdtTrc20,
+		InteractionMode: constants.PaymentInteractionQR,
+		Amount:          models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+		FeeRate:         models.NewMoneyFromDecimal(decimal.Zero),
+		FixedFee:        models.NewMoneyFromDecimal(decimal.Zero),
+		FeeAmount:       models.NewMoneyFromDecimal(decimal.Zero),
+		Currency:        "CNY",
+		Status:          constants.PaymentStatusPending,
+		ProviderRef:     "BEP-METHOD-1",
+		ExpiredAt:       &expiresAt,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := db.Create(&payment).Error; err != nil {
+		t.Fatalf("create payment failed: %v", err)
+	}
+
+	got, err := repo.GetLatestPendingByOrderChannel(payment.OrderID, payment.ChannelID, now)
+	if err != nil {
+		t.Fatalf("get pending payment failed: %v", err)
+	}
+	if got == nil || got.ID != payment.ID {
+		t.Fatalf("expected method-selection payment %d, got %+v", payment.ID, got)
+	}
 }
 
 func TestPaymentRepositoryListAdminByUserIncludesWalletRechargePayments(t *testing.T) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -112,6 +112,7 @@ func SetupRouter(cfg *config.Config, c *provider.Container) *gin.Engine {
 			guest.GET("/orders/:order_no", publicHandler.GetGuestOrderByOrderNo)
 			guest.GET("/orders/:order_no/fulfillment/download", publicHandler.DownloadGuestFulfillment)
 			guest.POST("/payments", publicHandler.CreateGuestPayment)
+			guest.POST("/payments/:id/method", publicHandler.SelectGuestPaymentMethod)
 			guest.POST("/payments/:id/capture", publicHandler.CaptureGuestPayment)
 			guest.GET("/payments/latest", publicHandler.GetGuestLatestPayment)
 		}
@@ -164,6 +165,7 @@ func SetupRouter(cfg *config.Config, c *provider.Container) *gin.Engine {
 			user.GET("/orders/:order_no/fulfillment/download", publicHandler.DownloadFulfillment)
 			user.POST("/orders/:order_no/cancel", publicHandler.CancelOrder)
 			user.POST("/payments", publicHandler.CreatePayment)
+			user.POST("/payments/:id/method", publicHandler.SelectPaymentMethod)
 			user.POST("/payments/:id/capture", publicHandler.CapturePayment)
 			user.GET("/payments/latest", publicHandler.GetLatestPayment)
 			user.GET("/wallet", publicHandler.GetMyWallet)
@@ -463,6 +465,7 @@ func SetupRouter(cfg *config.Config, c *provider.Container) *gin.Engine {
 				authorized.POST("/card-secrets/batch-delete", adminHandler.BatchDeleteCardSecrets)
 				authorized.POST("/card-secrets/export", adminHandler.ExportCardSecrets)
 				authorized.POST("/card-secrets/export-available", adminHandler.ExportAvailableCardSecrets)
+				authorized.GET("/card-secret-exports", adminHandler.GetCardSecretExports)
 				authorized.GET("/card-secrets/stats", adminHandler.GetCardSecretStats)
 				authorized.GET("/card-secrets/batches", adminHandler.GetCardSecretBatches)
 				authorized.GET("/card-secrets/template", adminHandler.GetCardSecretTemplate)

--- a/internal/service/card_secret_service.go
+++ b/internal/service/card_secret_service.go
@@ -190,6 +190,7 @@ type ExportAvailableCardSecretInput struct {
 	ProductID         uint
 	SKUID             uint
 	BatchID           uint
+	AdminID           uint
 	Limit             int
 	Format            string
 	DeleteAfterExport bool
@@ -200,6 +201,16 @@ type ExportAvailableCardSecretResult struct {
 	Content     []byte
 	ContentType string
 	Count       int
+	Record      *models.CardSecretExport
+}
+
+type ListCardSecretExportInput struct {
+	ID        uint
+	ProductID uint
+	SKUID     uint
+	BatchID   uint
+	Page      int
+	PageSize  int
 }
 
 // ListCardSecrets 获取卡密列表
@@ -339,6 +350,24 @@ func (s *CardSecretService) ExportAvailableCardSecrets(input ExportAvailableCard
 			ids = append(ids, item.ID)
 		}
 
+		var batchID *uint
+		if input.BatchID > 0 {
+			value := input.BatchID
+			batchID = &value
+		}
+		exportRecord := &models.CardSecretExport{
+			ProductID:         input.ProductID,
+			SKUID:             input.SKUID,
+			BatchID:           batchID,
+			AdminID:           input.AdminID,
+			Format:            normalizedFormat,
+			Count:             len(items),
+			DeleteAfterExport: input.DeleteAfterExport,
+		}
+		if err := secretRepo.CreateExport(exportRecord); err != nil {
+			return ErrCardSecretUpdateFailed
+		}
+
 		var affected int64
 		if input.DeleteAfterExport {
 			affected, err = secretRepo.BatchDeleteByIDs(ids)
@@ -346,7 +375,7 @@ func (s *CardSecretService) ExportAvailableCardSecrets(input ExportAvailableCard
 				return ErrCardSecretDeleteFailed
 			}
 		} else {
-			affected, err = secretRepo.BatchUpdateStatus(ids, models.CardSecretStatusUsed, time.Now())
+			affected, err = secretRepo.MarkExported(ids, exportRecord.ID, time.Now())
 			if err != nil {
 				return ErrCardSecretUpdateFailed
 			}
@@ -362,6 +391,7 @@ func (s *CardSecretService) ExportAvailableCardSecrets(input ExportAvailableCard
 			Content:     content,
 			ContentType: contentType,
 			Count:       len(items),
+			Record:      exportRecord,
 		}
 		return nil
 	})
@@ -369,6 +399,21 @@ func (s *CardSecretService) ExportAvailableCardSecrets(input ExportAvailableCard
 		return nil, err
 	}
 	return result, nil
+}
+
+func (s *CardSecretService) ListCardSecretExports(input ListCardSecretExportInput) ([]models.CardSecretExport, int64, error) {
+	rows, total, err := s.secretRepo.ListExports(repository.CardSecretExportListFilter{
+		ID:        input.ID,
+		ProductID: input.ProductID,
+		SKUID:     input.SKUID,
+		BatchID:   input.BatchID,
+		Page:      input.Page,
+		PageSize:  input.PageSize,
+	})
+	if err != nil {
+		return nil, 0, ErrCardSecretFetchFailed
+	}
+	return rows, total, nil
 }
 
 func normalizeCardSecretExportFormat(format string) (string, error) {

--- a/internal/service/card_secret_service_test.go
+++ b/internal/service/card_secret_service_test.go
@@ -32,6 +32,7 @@ func setupCardSecretServiceTestDB(t *testing.T) *gorm.DB {
 		&models.ProductSKU{},
 		&models.CardSecretBatch{},
 		&models.CardSecret{},
+		&models.CardSecretExport{},
 	); err != nil {
 		t.Fatalf("auto migrate failed: %v", err)
 	}
@@ -742,6 +743,11 @@ func TestExportAvailableCardSecretsMarksUsed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create batch failed: %v", err)
 	}
+	if err := db.Model(&models.CardSecret{}).
+		Where("product_id = ? AND secret = ?", product.ID, "EXP-A-001").
+		Update("order_id", 99).Error; err != nil {
+		t.Fatalf("seed stale order id failed: %v", err)
+	}
 
 	result, err := svc.ExportAvailableCardSecrets(ExportAvailableCardSecretInput{
 		ProductID: product.ID,
@@ -749,12 +755,16 @@ func TestExportAvailableCardSecretsMarksUsed(t *testing.T) {
 		BatchID:   batch.ID,
 		Limit:     2,
 		Format:    constants.ExportFormatTXT,
+		AdminID:   9,
 	})
 	if err != nil {
 		t.Fatalf("export available failed: %v", err)
 	}
 	if result.Count != 2 || strings.TrimSpace(string(result.Content)) != "EXP-A-001\nEXP-A-002" {
 		t.Fatalf("unexpected export result: count=%d content=%q", result.Count, string(result.Content))
+	}
+	if result.Record == nil || result.Record.ID == 0 || result.Record.AdminID != 9 {
+		t.Fatalf("expected export record, got %+v", result.Record)
 	}
 
 	rows, _, err := svc.ListCardSecrets(ListCardSecretInput{
@@ -770,6 +780,12 @@ func TestExportAvailableCardSecretsMarksUsed(t *testing.T) {
 	statusBySecret := map[string]string{}
 	for _, row := range rows {
 		statusBySecret[row.Secret] = row.Status
+		if row.Secret != "EXP-A-003" && (row.ExportID == nil || *row.ExportID != result.Record.ID) {
+			t.Fatalf("expected exported secret linked to record: %+v", row)
+		}
+		if row.Secret != "EXP-A-003" && row.OrderID != nil {
+			t.Fatalf("expected exported secret order link cleared: %+v", row)
+		}
 	}
 	if statusBySecret["EXP-A-001"] != models.CardSecretStatusUsed ||
 		statusBySecret["EXP-A-002"] != models.CardSecretStatusUsed ||
@@ -825,12 +841,16 @@ func TestExportAvailableCardSecretsDeletesAfterExport(t *testing.T) {
 		Limit:             1,
 		Format:            constants.ExportFormatTXT,
 		DeleteAfterExport: true,
+		AdminID:           10,
 	})
 	if err != nil {
 		t.Fatalf("export available with delete failed: %v", err)
 	}
 	if result.Count != 1 || strings.TrimSpace(string(result.Content)) != "EXP-D-001" {
 		t.Fatalf("unexpected export result: count=%d content=%q", result.Count, string(result.Content))
+	}
+	if result.Record == nil || !result.Record.DeleteAfterExport || result.Record.AdminID != 10 {
+		t.Fatalf("expected delete export record, got %+v", result.Record)
 	}
 
 	rows, _, err := svc.ListCardSecrets(ListCardSecretInput{

--- a/internal/service/payment_service.go
+++ b/internal/service/payment_service.go
@@ -144,7 +144,12 @@ func hasProviderResult(payment *models.Payment) bool {
 	if payment == nil {
 		return false
 	}
-	return strings.TrimSpace(payment.PayURL) != "" || strings.TrimSpace(payment.QRCode) != ""
+	if strings.TrimSpace(payment.PayURL) != "" || strings.TrimSpace(payment.QRCode) != "" {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(payment.ProviderType), constants.PaymentProviderBepusdt) &&
+		strings.EqualFold(strings.TrimSpace(payment.InteractionMode), constants.PaymentInteractionQR) &&
+		strings.TrimSpace(payment.ProviderRef) != ""
 }
 
 func shouldMarkFulfilling(order *models.Order) bool {

--- a/internal/service/payment_service_method_selection.go
+++ b/internal/service/payment_service_method_selection.go
@@ -1,0 +1,167 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/dujiao-next/internal/constants"
+	"github.com/dujiao-next/internal/models"
+	"github.com/dujiao-next/internal/payment/provider"
+
+	"gorm.io/gorm"
+)
+
+type SelectPaymentMethodInput struct {
+	PaymentID uint
+	Currency  string
+	Network   string
+	Context   context.Context
+}
+
+// SelectPaymentMethod 为支持动态付款方式的二维码网关选择币种和网络。
+func (s *PaymentService) SelectPaymentMethod(input SelectPaymentMethodInput) (*models.Payment, error) {
+	currency := strings.ToUpper(strings.TrimSpace(input.Currency))
+	network := strings.ToLower(strings.TrimSpace(input.Network))
+	if input.PaymentID == 0 || currency == "" || network == "" {
+		return nil, ErrPaymentInvalid
+	}
+	payment, err := s.paymentRepo.GetByID(input.PaymentID)
+	if err != nil {
+		return nil, ErrPaymentUpdateFailed
+	}
+	if payment == nil {
+		return nil, ErrPaymentNotFound
+	}
+	if payment.Status != constants.PaymentStatusPending ||
+		strings.ToLower(strings.TrimSpace(payment.ProviderType)) != constants.PaymentProviderBepusdt ||
+		strings.ToLower(strings.TrimSpace(payment.InteractionMode)) != constants.PaymentInteractionQR ||
+		strings.TrimSpace(payment.ProviderRef) == "" ||
+		(payment.ExpiredAt != nil && !payment.ExpiredAt.After(time.Now())) {
+		return nil, ErrPaymentStatusInvalid
+	}
+	if !paymentMethodAllowed(payment.ProviderPayload, currency, network) {
+		return nil, ErrPaymentInvalid
+	}
+	channel, err := s.channelRepo.GetByID(payment.ChannelID)
+	if err != nil || channel == nil {
+		return nil, ErrPaymentChannelNotFound
+	}
+	if s.paymentProviderRegistry == nil {
+		return nil, ErrPaymentProviderNotSupported
+	}
+	p, ok := s.paymentProviderRegistry.Lookup(channel.ProviderType, channel.ChannelType)
+	if !ok {
+		return nil, ErrPaymentProviderNotSupported
+	}
+	selector, ok := p.(provider.PaymentMethodSelector)
+	if !ok {
+		return nil, ErrPaymentProviderNotSupported
+	}
+
+	ctx, cancel := detachOutboundRequestContext(input.Context)
+	defer cancel()
+	selection, err := selector.SelectPaymentMethod(ctx, channel.ConfigJSON, provider.SelectPaymentMethodInput{
+		ProviderRef: payment.ProviderRef,
+		Currency:    currency,
+		Network:     network,
+	})
+	if err != nil {
+		return nil, mapProviderErrorToService(err)
+	}
+	if selection == nil || strings.TrimSpace(selection.QRCodeURL) == "" {
+		return nil, ErrPaymentGatewayResponseInvalid
+	}
+
+	var updated *models.Payment
+	err = s.paymentRepo.Transaction(func(tx *gorm.DB) error {
+		repo := s.paymentRepo.WithTx(tx)
+		locked, err := repo.GetByIDForUpdate(payment.ID)
+		if err != nil {
+			return err
+		}
+		if locked == nil {
+			return ErrPaymentNotFound
+		}
+		if locked.Status != constants.PaymentStatusPending ||
+			(locked.ExpiredAt != nil && !locked.ExpiredAt.After(time.Now())) {
+			return ErrPaymentStatusInvalid
+		}
+		locked.PayURL = ""
+		locked.QRCode = strings.TrimSpace(selection.QRCodeURL)
+		locked.ProviderPayload = mergePaymentProviderPayload(locked.ProviderPayload, selection.Payload)
+		locked.UpdatedAt = time.Now()
+		if err := repo.Update(locked); err != nil {
+			return ErrPaymentUpdateFailed
+		}
+		updated = locked
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func paymentMethodAllowed(payload models.JSON, currency, network string) bool {
+	data := paymentPayloadMap(payload["data"])
+	raw, exists := data["payment_methods"]
+	if !exists || raw == nil {
+		return false
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return false
+	}
+	var methods []struct {
+		Currency string `json:"currency"`
+		Network  string `json:"network"`
+	}
+	if err := json.Unmarshal(encoded, &methods); err != nil {
+		return false
+	}
+	for _, method := range methods {
+		if strings.EqualFold(strings.TrimSpace(method.Currency), currency) &&
+			strings.EqualFold(strings.TrimSpace(method.Network), network) {
+			return true
+		}
+	}
+	return false
+}
+
+func mergePaymentProviderPayload(current, next models.JSON) models.JSON {
+	merged := models.JSON{}
+	for key, value := range current {
+		merged[key] = value
+	}
+	for key, value := range next {
+		if key != "data" {
+			merged[key] = value
+		}
+	}
+	currentData := paymentPayloadMap(current["data"])
+	nextData := paymentPayloadMap(next["data"])
+	data := map[string]interface{}{}
+	for key, value := range currentData {
+		data[key] = value
+	}
+	for key, value := range nextData {
+		data[key] = value
+	}
+	if len(data) > 0 {
+		merged["data"] = data
+	}
+	return merged
+}
+
+func paymentPayloadMap(value interface{}) map[string]interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return typed
+	case models.JSON:
+		return map[string]interface{}(typed)
+	default:
+		return map[string]interface{}{}
+	}
+}

--- a/internal/service/payment_service_method_selection_test.go
+++ b/internal/service/payment_service_method_selection_test.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/dujiao-next/internal/models"
+)
+
+func TestPaymentMethodAllowed(t *testing.T) {
+	payload := models.JSON{
+		"data": map[string]any{
+			"payment_methods": []map[string]any{
+				{"currency": "USDT", "network": "tron"},
+				{"currency": "USDC", "network": "base"},
+			},
+		},
+	}
+
+	if !paymentMethodAllowed(payload, "USDC", "base") {
+		t.Fatal("expected listed payment method to be allowed")
+	}
+	if paymentMethodAllowed(payload, "USDT", "base") {
+		t.Fatal("expected unlisted currency/network pair to be rejected")
+	}
+	if paymentMethodAllowed(models.JSON{}, "USDT", "tron") {
+		t.Fatal("expected missing payment method list to be rejected")
+	}
+}
+
+func TestHasProviderResultAcceptsBepusdtMethodSelection(t *testing.T) {
+	payment := &models.Payment{
+		ProviderType:    "bepusdt",
+		InteractionMode: "qr",
+		ProviderRef:     "BEP-1",
+	}
+	if !hasProviderResult(payment) {
+		t.Fatal("expected BEpusdt selection state to be reusable")
+	}
+	payment.ProviderType = "official"
+	if hasProviderResult(payment) {
+		t.Fatal("expected a generic provider reference without destination to be unusable")
+	}
+}


### PR DESCRIPTION
  - 卡密库存“订单 ID”列会显示“导出 #ID”，可跳转对应导出记录；新增导出历史。
  - BEpusdt 二维码模式支持用户在本站选择 币种 + 网络，并切换对应收款地址，无需打开 BEpusdt 公网页。
  - 管理端可通过 currencies 限制可选币种。