### PR TITLE
BEpusdt & Epusdt add cashier mode

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -92,6 +92,12 @@ const (
 	PaymentBepusdtOrderModeCashier     = "cashier"
 )
 
+// Epusdt 订单接口模式常量
+const (
+	PaymentEpusdtOrderModeTransaction = "transaction"
+	PaymentEpusdtOrderModeCashier     = "cashier"
+)
+
 // 钱包交易类型常量
 const (
 	WalletTxnTypeRecharge    = "recharge"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -86,6 +86,12 @@ const (
 	PaymentInteractionBalance  = "balance"
 )
 
+// BEpusdt 订单接口模式常量
+const (
+	PaymentBepusdtOrderModeTransaction = "transaction"
+	PaymentBepusdtOrderModeCashier     = "cashier"
+)
+
 // 钱包交易类型常量
 const (
 	WalletTxnTypeRecharge    = "recharge"

--- a/internal/http/handlers/admin/admin_payment.go
+++ b/internal/http/handlers/admin/admin_payment.go
@@ -110,6 +110,7 @@ func (h *Handler) ExportAdminPayments(c *gin.Context) {
 		"channel_id",
 		"provider_type",
 		"channel_type",
+		"display_channel_type",
 		"status",
 		"amount",
 		"currency",
@@ -195,8 +196,8 @@ func (h *Handler) GetAdminPayment(c *gin.Context) {
 }
 
 // paymentDisplayChannelType 提取后台支付记录的展示用渠道类型。
-// 列表 lightweight 查询会把 provider_payload.display_channel_type 提取到 Payment.DisplayChannelType；
-// 详情或非 lightweight 查询保留完整 ProviderPayload，因此需要从 payload 里兜底读取。
+// CSV 导出的 lightweight 查询会把 provider_payload.display_channel_type 提取到 Payment.DisplayChannelType；
+// 后台列表和详情保留完整 ProviderPayload，因此需要从 payload 里兜底读取。
 func paymentDisplayChannelType(payment models.Payment) string {
 	if displayChannelType := strings.TrimSpace(payment.DisplayChannelType); displayChannelType != "" {
 		return displayChannelType
@@ -264,6 +265,7 @@ func (h *Handler) writeAdminPaymentCSVRows(writer *csv.Writer, payments []models
 			strconv.FormatUint(uint64(payment.ChannelID), 10),
 			payment.ProviderType,
 			payment.ChannelType,
+			paymentDisplayChannelType(payment),
 			payment.Status,
 			payment.Amount.String(),
 			payment.Currency,

--- a/internal/http/handlers/admin/admin_payment.go
+++ b/internal/http/handlers/admin/admin_payment.go
@@ -20,11 +20,12 @@ import (
 // AdminPaymentItem 支付记录返回
 type AdminPaymentItem struct {
 	models.Payment
-	ChannelName    string `json:"channel_name"`
-	OrderNo        string `json:"order_no,omitempty"`
-	RechargeNo     string `json:"recharge_no,omitempty"`
-	RechargeStatus string `json:"recharge_status,omitempty"`
-	RechargeUserID uint   `json:"recharge_user_id,omitempty"`
+	ChannelName        string `json:"channel_name"`
+	DisplayChannelType string `json:"display_channel_type,omitempty"`
+	OrderNo            string `json:"order_no,omitempty"`
+	RechargeNo         string `json:"recharge_no,omitempty"`
+	RechargeStatus     string `json:"recharge_status,omitempty"`
+	RechargeUserID     uint   `json:"recharge_user_id,omitempty"`
 }
 
 const adminPaymentExportBatchSize = 500
@@ -66,12 +67,13 @@ func (h *Handler) GetAdminPayments(c *gin.Context) {
 	for _, payment := range payments {
 		rechargeMeta := rechargeMetaMap[payment.ID]
 		items = append(items, AdminPaymentItem{
-			Payment:        payment,
-			ChannelName:    channelNameMap[payment.ChannelID],
-			OrderNo:        orderNoMap[payment.OrderID],
-			RechargeNo:     rechargeMeta.RechargeNo,
-			RechargeStatus: rechargeMeta.Status,
-			RechargeUserID: rechargeMeta.UserID,
+			Payment:            payment,
+			ChannelName:        channelNameMap[payment.ChannelID],
+			DisplayChannelType: paymentDisplayChannelType(payment),
+			OrderNo:            orderNoMap[payment.OrderID],
+			RechargeNo:         rechargeMeta.RechargeNo,
+			RechargeStatus:     rechargeMeta.Status,
+			RechargeUserID:     rechargeMeta.UserID,
 		})
 	}
 
@@ -182,13 +184,28 @@ func (h *Handler) GetAdminPayment(c *gin.Context) {
 	}
 	rechargeMeta := rechargeMetaMap[payment.ID]
 	response.Success(c, AdminPaymentItem{
-		Payment:        *payment,
-		ChannelName:    channelNameMap[payment.ChannelID],
-		OrderNo:        orderNoMap[payment.OrderID],
-		RechargeNo:     rechargeMeta.RechargeNo,
-		RechargeStatus: rechargeMeta.Status,
-		RechargeUserID: rechargeMeta.UserID,
+		Payment:            *payment,
+		ChannelName:        channelNameMap[payment.ChannelID],
+		DisplayChannelType: paymentDisplayChannelType(*payment),
+		OrderNo:            orderNoMap[payment.OrderID],
+		RechargeNo:         rechargeMeta.RechargeNo,
+		RechargeStatus:     rechargeMeta.Status,
+		RechargeUserID:     rechargeMeta.UserID,
 	})
+}
+
+// paymentDisplayChannelType 提取后台支付记录的展示用渠道类型。
+// 列表 lightweight 查询会把 provider_payload.display_channel_type 提取到 Payment.DisplayChannelType；
+// 详情或非 lightweight 查询保留完整 ProviderPayload，因此需要从 payload 里兜底读取。
+func paymentDisplayChannelType(payment models.Payment) string {
+	if displayChannelType := strings.TrimSpace(payment.DisplayChannelType); displayChannelType != "" {
+		return displayChannelType
+	}
+	value, ok := payment.ProviderPayload["display_channel_type"]
+	if !ok || value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
 }
 
 func formatTimeNullable(raw *time.Time) string {

--- a/internal/http/handlers/admin/admin_payment_test.go
+++ b/internal/http/handlers/admin/admin_payment_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -327,6 +328,11 @@ func TestGetAdminPaymentsFiltersByUserID(t *testing.T) {
 func TestExportAdminPaymentsByUserID(t *testing.T) {
 	h, db := setupAdminPaymentHandlerTest(t)
 	fixture := seedAdminPaymentData(t, db)
+	if err := db.Model(&models.Payment{}).Where("id = ?", fixture.OrderPaymentID).Update(
+		"provider_payload", models.JSON{"display_channel_type": "usdt.arbitrum"},
+	).Error; err != nil {
+		t.Fatalf("set display channel type failed: %v", err)
+	}
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -350,14 +356,18 @@ func TestExportAdminPaymentsByUserID(t *testing.T) {
 		t.Fatalf("csv rows want 3 got %d", len(records))
 	}
 	header := strings.Join(records[0], ",")
-	if header != "id,order_id,recharge_no,recharge_status,recharge_user_id,channel_id,provider_type,channel_type,status,amount,currency,created_at,paid_at,expired_at,provider_ref" {
+	if header != "id,order_id,recharge_no,recharge_status,recharge_user_id,channel_id,provider_type,channel_type,display_channel_type,status,amount,currency,created_at,paid_at,expired_at,provider_ref" {
 		t.Fatalf("csv header mismatch, got %s", header)
 	}
 
 	foundRechargeNo := false
+	foundDisplayChannelType := false
 	for _, row := range records[1:] {
-		if len(row) < 3 {
+		if len(row) < 9 {
 			t.Fatalf("csv row columns too short: %+v", row)
+		}
+		if row[0] == strconv.FormatUint(uint64(fixture.OrderPaymentID), 10) && row[8] == "usdt.arbitrum" {
+			foundDisplayChannelType = true
 		}
 		if row[2] == fixture.RechargeNoUser1 {
 			foundRechargeNo = true
@@ -368,6 +378,9 @@ func TestExportAdminPaymentsByUserID(t *testing.T) {
 	}
 	if !foundRechargeNo {
 		t.Fatalf("csv missing user1 recharge row")
+	}
+	if !foundDisplayChannelType {
+		t.Fatalf("csv missing order payment display_channel_type")
 	}
 }
 

--- a/internal/http/handlers/admin/order_admin.go
+++ b/internal/http/handlers/admin/order_admin.go
@@ -240,8 +240,9 @@ func (h *Handler) AdminGetOrder(c *gin.Context) {
 	paymentItems := make([]AdminPaymentItem, 0, len(payments))
 	for _, payment := range payments {
 		paymentItems = append(paymentItems, AdminPaymentItem{
-			Payment:     payment,
-			ChannelName: channelNameMap[payment.ChannelID],
+			Payment:            payment,
+			ChannelName:        channelNameMap[payment.ChannelID],
+			DisplayChannelType: paymentDisplayChannelType(payment),
 		})
 	}
 

--- a/internal/models/db.go
+++ b/internal/models/db.go
@@ -19,6 +19,7 @@ const (
 	skuMigrationSettingKey                          = "migration/product_sku_v1"
 	categoryParentMigrationSettingKey               = "migration/category_parent_v1"
 	paymentProviderBepusdtRenameMigrationSettingKey = "migration/payment_provider_bepusdt_rename_v1"
+	paymentChannelBepusdtConfigMigrationSettingKey  = "migration/payment_channel_bepusdt_config_v2"
 	orderItemOriginalPriceMigrationKey              = "migration/order_item_original_price_v1"
 	manualStockUnlimitedValue                       = -1
 )
@@ -180,6 +181,9 @@ func AutoMigrate() error {
 		return err
 	}
 	if err := ensurePaymentProviderBepusdtRenameMigration(); err != nil {
+		return err
+	}
+	if err := ensurePaymentChannelBepusdtConfigMigration(); err != nil {
 		return err
 	}
 	if err := ensureOrderItemOriginalPriceMigration(); err != nil {

--- a/internal/models/migrations.go
+++ b/internal/models/migrations.go
@@ -401,6 +401,86 @@ func ensurePaymentProviderBepusdtRenameMigration() error {
 	})
 }
 
+// ensurePaymentChannelBepusdtConfigMigration 把旧 BEpusdt channel_type 规范化为新配置结构。
+// 缺少显式 trade_type 时保持旧版实际行为，统一使用 usdt.trc20；未知 channel 类型保持原样，
+// 并把跳过的渠道 ID 写入 migration marker，避免静默改成错误的支付类型。
+func ensurePaymentChannelBepusdtConfigMigration() error {
+	if DB == nil {
+		return errors.New("database is not initialized")
+	}
+
+	var marker Setting
+	if err := DB.First(&marker, "key = ?", paymentChannelBepusdtConfigMigrationSettingKey).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+	} else if migrationDone(marker.ValueJSON) {
+		return nil
+	}
+
+	return DB.Transaction(func(tx *gorm.DB) error {
+		var channels []PaymentChannel
+		if err := tx.Where("provider_type = ?", "bepusdt").Find(&channels).Error; err != nil {
+			return err
+		}
+
+		legacyChannelTypes := map[string]struct{}{
+			"usdt":       {},
+			"usdt-trc20": {},
+			"usdc-trc20": {},
+			"trx":        {},
+		}
+		migratedCount := 0
+		skippedChannelIDs := make([]uint, 0)
+		for index := range channels {
+			channel := &channels[index]
+			config := channel.ConfigJSON
+			if config == nil {
+				config = JSON{}
+			}
+			channelType := strings.ToLower(strings.TrimSpace(channel.ChannelType))
+			tradeType, _ := config["trade_type"].(string)
+			tradeType = strings.TrimSpace(tradeType)
+			if tradeType == "" {
+				_, knownLegacyType := legacyChannelTypes[channelType]
+				if !knownLegacyType {
+					if channelType != "bepusdt" {
+						skippedChannelIDs = append(skippedChannelIDs, channel.ID)
+					}
+					continue
+				}
+				tradeType = "usdt.trc20"
+			}
+			if channelType == "bepusdt" {
+				continue
+			}
+
+			config["trade_type"] = tradeType
+			if orderMode, _ := config["order_mode"].(string); strings.TrimSpace(orderMode) == "" {
+				config["order_mode"] = "transaction"
+			}
+			if err := tx.Model(channel).Updates(map[string]interface{}{
+				"channel_type": "bepusdt",
+				"config_json":  config,
+			}).Error; err != nil {
+				return fmt.Errorf("migrate bepusdt channel %d: %w", channel.ID, err)
+			}
+			migratedCount++
+		}
+
+		marker := Setting{
+			Key: paymentChannelBepusdtConfigMigrationSettingKey,
+			ValueJSON: JSON{
+				"done":                true,
+				"migrated_at":         time.Now().UTC().Format(time.RFC3339),
+				"migrated_count":      migratedCount,
+				"skipped_channel_ids": skippedChannelIDs,
+			},
+		}
+		return tx.Save(&marker).Error
+	})
+}
+
 // ensureCategoryParentMigration 兼容历史单层分类数据，统一将空 parent_id 视为 0。
 func ensureCategoryParentMigration() error {
 	if DB == nil {

--- a/internal/models/migrations_payment_provider_test.go
+++ b/internal/models/migrations_payment_provider_test.go
@@ -113,3 +113,88 @@ func TestEnsurePaymentProviderBepusdtRenameMigration_RenamesAndIsIdempotent(t *t
 		t.Fatalf("idempotency broken: bepusdt count expected 2, got %d", bepusdtCount)
 	}
 }
+
+func TestEnsurePaymentChannelBepusdtConfigMigration_NormalizesLegacyChannels(t *testing.T) {
+	db := setupPaymentProviderRenameTestDB(t)
+	tests := []struct {
+		name        string
+		channelType string
+		tradeType   string
+	}{
+		{name: "legacy-usdt", channelType: "usdt", tradeType: "usdt.trc20"},
+		{name: "legacy-usdt-trc20", channelType: "usdt-trc20", tradeType: "usdt.trc20"},
+		{name: "legacy-usdc-trc20", channelType: "usdc-trc20", tradeType: "usdt.trc20"},
+		{name: "legacy-trx", channelType: "trx", tradeType: "usdt.trc20"},
+	}
+	for _, tc := range tests {
+		if err := db.Create(&PaymentChannel{
+			Name: tc.name, ProviderType: "bepusdt", ChannelType: tc.channelType,
+			InteractionMode: "redirect", IsActive: true, ConfigJSON: JSON{"gateway_url": "https://bepusdt.example.com"},
+		}).Error; err != nil {
+			t.Fatalf("seed %s failed: %v", tc.name, err)
+		}
+	}
+	if err := db.Create(&PaymentChannel{
+		Name: "explicit", ProviderType: "bepusdt", ChannelType: "usdt-trc20",
+		InteractionMode: "redirect", IsActive: true, ConfigJSON: JSON{"trade_type": "usdt.arbitrum"},
+	}).Error; err != nil {
+		t.Fatalf("seed explicit failed: %v", err)
+	}
+	if err := db.Create(&PaymentChannel{
+		Name: "unknown", ProviderType: "bepusdt", ChannelType: "future-coin",
+		InteractionMode: "redirect", IsActive: true, ConfigJSON: JSON{},
+	}).Error; err != nil {
+		t.Fatalf("seed unknown failed: %v", err)
+	}
+
+	if err := ensurePaymentChannelBepusdtConfigMigration(); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+	for _, tc := range tests {
+		var channel PaymentChannel
+		if err := db.First(&channel, "name = ?", tc.name).Error; err != nil {
+			t.Fatalf("load %s failed: %v", tc.name, err)
+		}
+		if channel.ChannelType != "bepusdt" {
+			t.Fatalf("%s channel_type = %q, want bepusdt", tc.name, channel.ChannelType)
+		}
+		if got := channel.ConfigJSON["trade_type"]; got != tc.tradeType {
+			t.Fatalf("%s trade_type = %v, want %s", tc.name, got, tc.tradeType)
+		}
+		if got := channel.ConfigJSON["order_mode"]; got != "transaction" {
+			t.Fatalf("%s order_mode = %v, want transaction", tc.name, got)
+		}
+	}
+
+	var explicit PaymentChannel
+	if err := db.First(&explicit, "name = ?", "explicit").Error; err != nil {
+		t.Fatalf("load explicit failed: %v", err)
+	}
+	if got := explicit.ConfigJSON["trade_type"]; got != "usdt.arbitrum" {
+		t.Fatalf("explicit trade_type changed to %v", got)
+	}
+	if explicit.ChannelType != "bepusdt" {
+		t.Fatalf("explicit channel_type = %q, want bepusdt", explicit.ChannelType)
+	}
+	if got := explicit.ConfigJSON["order_mode"]; got != "transaction" {
+		t.Fatalf("explicit order_mode = %v, want transaction", got)
+	}
+	var unknown PaymentChannel
+	if err := db.First(&unknown, "name = ?", "unknown").Error; err != nil {
+		t.Fatalf("load unknown failed: %v", err)
+	}
+	if unknown.ChannelType != "future-coin" || len(unknown.ConfigJSON) != 0 {
+		t.Fatalf("unknown channel should stay unchanged: channel_type=%q config=%v", unknown.ChannelType, unknown.ConfigJSON)
+	}
+
+	if err := ensurePaymentChannelBepusdtConfigMigration(); err != nil {
+		t.Fatalf("second migration should be idempotent: %v", err)
+	}
+	var marker Setting
+	if err := db.First(&marker, "key = ?", paymentChannelBepusdtConfigMigrationSettingKey).Error; err != nil {
+		t.Fatalf("load marker failed: %v", err)
+	}
+	if !migrationDone(marker.ValueJSON) || marker.ValueJSON["migrated_count"] != float64(len(tests)+1) {
+		t.Fatalf("unexpected marker: %v", marker.ValueJSON)
+	}
+}

--- a/internal/models/payment.go
+++ b/internal/models/payment.go
@@ -8,30 +8,31 @@ import (
 
 // Payment 支付记录
 type Payment struct {
-	ID              uint           `gorm:"primarykey" json:"id"`                                    // 主键
-	OrderID         uint           `gorm:"index;not null" json:"order_id"`                          // 订单ID
-	ChannelID       uint           `gorm:"index;not null" json:"channel_id"`                        // 支付渠道ID
-	ProviderType    string         `gorm:"not null" json:"provider_type"`                           // 提供方类型（official/epay）
-	ChannelType     string         `gorm:"not null" json:"channel_type"`                            // 渠道类型（wechat/alipay/qqpay/paypal）
-	InteractionMode string         `gorm:"not null" json:"interaction_mode"`                        // 交互方式（qr/redirect）
-	Amount          Money          `gorm:"type:decimal(20,2);not null" json:"amount"`               // 支付金额（含手续费）
-	FeeRate         Money          `gorm:"type:decimal(6,2);not null;default:0" json:"fee_rate"`    // 手续费比例（百分比）
-	FixedFee        Money          `gorm:"type:decimal(6,2);not null;default:0" json:"fixed_fee"`   // 固定手续费
-	FeeAmount       Money          `gorm:"type:decimal(20,2);not null;default:0" json:"fee_amount"` // 手续费金额
-	Currency        string         `gorm:"not null" json:"currency"`                                // 币种
-	Status          string         `gorm:"index;not null" json:"status"`                            // 支付状态
-	ProviderRef     string         `gorm:"index" json:"provider_ref"`                               // 第三方流水号
-	GatewayOrderNo  string         `gorm:"index;size:64" json:"gateway_order_no"`                   // 网关侧订单号
-	ProviderPayload JSON           `gorm:"type:json" json:"provider_payload"`                       // 第三方回调数据
-	PayURL          string         `gorm:"type:text" json:"pay_url"`                                // 跳转链接
-	QRCode          string         `gorm:"type:text" json:"qr_code"`                                // 二维码内容/地址
-	CreatedAt       time.Time      `gorm:"index" json:"created_at"`                                 // 创建时间
-	UpdatedAt       time.Time      `gorm:"index" json:"updated_at"`                                 // 更新时间
-	PaidAt          *time.Time     `gorm:"index" json:"paid_at"`                                    // 支付时间
-	ExpiredAt       *time.Time     `gorm:"index" json:"expired_at"`                                 // 过期时间
-	CallbackAt      *time.Time     `gorm:"index" json:"callback_at"`                                // 回调时间
-	DeletedAt       gorm.DeletedAt `gorm:"index" json:"-"`                                          // 软删除时间
-	ChannelName     string         `gorm:"-" json:"channel_name,omitempty"`                         // 支付渠道名称（非数据库字段，JOIN 填充）
+	ID                 uint           `gorm:"primarykey" json:"id"`                                    // 主键
+	OrderID            uint           `gorm:"index;not null" json:"order_id"`                          // 订单ID
+	ChannelID          uint           `gorm:"index;not null" json:"channel_id"`                        // 支付渠道ID
+	ProviderType       string         `gorm:"not null" json:"provider_type"`                           // 提供方类型（official/epay）
+	ChannelType        string         `gorm:"not null" json:"channel_type"`                            // 渠道类型（wechat/alipay/qqpay/paypal）
+	InteractionMode    string         `gorm:"not null" json:"interaction_mode"`                        // 交互方式（qr/redirect）
+	Amount             Money          `gorm:"type:decimal(20,2);not null" json:"amount"`               // 支付金额（含手续费）
+	FeeRate            Money          `gorm:"type:decimal(6,2);not null;default:0" json:"fee_rate"`    // 手续费比例（百分比）
+	FixedFee           Money          `gorm:"type:decimal(6,2);not null;default:0" json:"fixed_fee"`   // 固定手续费
+	FeeAmount          Money          `gorm:"type:decimal(20,2);not null;default:0" json:"fee_amount"` // 手续费金额
+	Currency           string         `gorm:"not null" json:"currency"`                                // 币种
+	Status             string         `gorm:"index;not null" json:"status"`                            // 支付状态
+	ProviderRef        string         `gorm:"index" json:"provider_ref"`                               // 第三方流水号
+	GatewayOrderNo     string         `gorm:"index;size:64" json:"gateway_order_no"`                   // 网关侧订单号
+	ProviderPayload    JSON           `gorm:"type:json" json:"provider_payload"`                       // 第三方回调数据
+	PayURL             string         `gorm:"type:text" json:"pay_url"`                                // 跳转链接
+	QRCode             string         `gorm:"type:text" json:"qr_code"`                                // 二维码内容/地址
+	CreatedAt          time.Time      `gorm:"index" json:"created_at"`                                 // 创建时间
+	UpdatedAt          time.Time      `gorm:"index" json:"updated_at"`                                 // 更新时间
+	PaidAt             *time.Time     `gorm:"index" json:"paid_at"`                                    // 支付时间
+	ExpiredAt          *time.Time     `gorm:"index" json:"expired_at"`                                 // 过期时间
+	CallbackAt         *time.Time     `gorm:"index" json:"callback_at"`                                // 回调时间
+	DeletedAt          gorm.DeletedAt `gorm:"index" json:"-"`                                          // 软删除时间
+	ChannelName        string         `gorm:"-" json:"channel_name,omitempty"`                         // 支付渠道名称（非数据库字段，JOIN 填充）
+	DisplayChannelType string         `gorm:"-" json:"display_channel_type,omitempty"`                 // 展示用渠道类型（非数据库字段）
 }
 
 // TableName 指定表名

--- a/internal/payment/bepusdt/bepusdt.go
+++ b/internal/payment/bepusdt/bepusdt.go
@@ -61,6 +61,7 @@ type Config struct {
 	AuthToken  string `json:"auth_token"`  // API Token
 	TradeType  string `json:"trade_type"`  // 交易类型，如 usdt.trc20
 	OrderMode  string `json:"order_mode"`  // 订单接口模式：transaction/cashier
+	Currencies string `json:"currencies"`  // 收银台模式限定交易币种，逗号分隔；留空不限制
 	Fiat       string `json:"fiat"`        // 法币类型，默认 CNY
 	NotifyURL  string `json:"notify_url"`  // 异步通知地址
 	ReturnURL  string `json:"return_url"`  // 同步跳转地址
@@ -158,6 +159,7 @@ func (c *Config) Normalize() {
 	c.AuthToken = strings.TrimSpace(c.AuthToken)
 	c.TradeType = strings.TrimSpace(c.TradeType)
 	c.OrderMode = strings.ToLower(strings.TrimSpace(c.OrderMode))
+	c.Currencies = strings.ToUpper(strings.ReplaceAll(strings.TrimSpace(c.Currencies), " ", ""))
 	c.Fiat = strings.TrimSpace(c.Fiat)
 	c.NotifyURL = strings.TrimSpace(c.NotifyURL)
 	c.ReturnURL = strings.TrimSpace(c.ReturnURL)
@@ -168,6 +170,9 @@ func (c *Config) Normalize() {
 		c.TradeType = ""
 	} else if c.TradeType == "" {
 		c.TradeType = bepusdtTradeTypeUSDTTRC20
+	}
+	if c.OrderMode != constants.PaymentBepusdtOrderModeCashier {
+		c.Currencies = ""
 	}
 	if c.Fiat == "" {
 		c.Fiat = constants.SiteCurrencyDefault
@@ -287,6 +292,9 @@ func CreateCashierOrder(ctx context.Context, cfg *Config, input CreateInput) (*C
 	}
 	if input.Name != "" {
 		params["name"] = input.Name
+	}
+	if cfg.Currencies != "" {
+		params["currencies"] = cfg.Currencies
 	}
 
 	signature := Sign(params, cfg.AuthToken)

--- a/internal/payment/bepusdt/bepusdt.go
+++ b/internal/payment/bepusdt/bepusdt.go
@@ -48,8 +48,10 @@ const (
 	bepusdtChannelTypeUSDTTRC20 = "usdt-trc20"
 	bepusdtChannelTypeUSDCTRC20 = "usdc-trc20"
 	bepusdtChannelTypeTRX       = "trx"
+	bepusdtChannelTypeCashier   = "bepusdt"
 
 	bepusdtCreateTransactionPath = "/api/v1/order/create-transaction"
+	bepusdtCreateOrderPath       = "/api/v1/order/create-order"
 	bepusdtStatusSuccessMsg      = "status is not success"
 )
 
@@ -58,6 +60,7 @@ type Config struct {
 	GatewayURL string `json:"gateway_url"` // 网关地址，如 https://usdt.example.com
 	AuthToken  string `json:"auth_token"`  // API Token
 	TradeType  string `json:"trade_type"`  // 交易类型，如 usdt.trc20
+	OrderMode  string `json:"order_mode"`  // 订单接口模式：transaction/cashier
 	Fiat       string `json:"fiat"`        // 法币类型，默认 CNY
 	NotifyURL  string `json:"notify_url"`  // 异步通知地址
 	ReturnURL  string `json:"return_url"`  // 同步跳转地址
@@ -143,6 +146,10 @@ func ValidateConfig(cfg *Config) error {
 	if strings.TrimSpace(cfg.ReturnURL) == "" {
 		return fmt.Errorf("%w: return_url is required", ErrConfigInvalid)
 	}
+	orderMode := strings.ToLower(strings.TrimSpace(cfg.OrderMode))
+	if orderMode != "" && orderMode != constants.PaymentBepusdtOrderModeTransaction && orderMode != constants.PaymentBepusdtOrderModeCashier {
+		return fmt.Errorf("%w: order_mode is invalid", ErrConfigInvalid)
+	}
 	return nil
 }
 
@@ -150,10 +157,16 @@ func (c *Config) Normalize() {
 	c.GatewayURL = strings.TrimRight(strings.TrimSpace(c.GatewayURL), "/")
 	c.AuthToken = strings.TrimSpace(c.AuthToken)
 	c.TradeType = strings.TrimSpace(c.TradeType)
+	c.OrderMode = strings.ToLower(strings.TrimSpace(c.OrderMode))
 	c.Fiat = strings.TrimSpace(c.Fiat)
 	c.NotifyURL = strings.TrimSpace(c.NotifyURL)
 	c.ReturnURL = strings.TrimSpace(c.ReturnURL)
-	if c.TradeType == "" {
+	if c.OrderMode == "" {
+		c.OrderMode = constants.PaymentBepusdtOrderModeTransaction
+	}
+	if c.OrderMode == constants.PaymentBepusdtOrderModeCashier {
+		c.TradeType = ""
+	} else if c.TradeType == "" {
 		c.TradeType = bepusdtTradeTypeUSDTTRC20
 	}
 	if c.Fiat == "" {
@@ -239,6 +252,81 @@ func CreatePayment(ctx context.Context, cfg *Config, input CreateInput) (*Create
 		Token:        resp.Data.Token,
 		PaymentURL:   resp.Data.PaymentURL,
 		Raw:          raw,
+	}, nil
+}
+
+// CreateCashierOrder 创建 BEpusdt 收银台订单。
+func CreateCashierOrder(ctx context.Context, cfg *Config, input CreateInput) (*CreateResult, error) {
+	if cfg == nil {
+		return nil, ErrConfigInvalid
+	}
+	if input.OrderNo == "" || input.Amount == "" {
+		return nil, ErrConfigInvalid
+	}
+
+	notifyURL := input.NotifyURL
+	if notifyURL == "" {
+		notifyURL = cfg.NotifyURL
+	}
+	returnURL := input.ReturnURL
+	if returnURL == "" {
+		returnURL = cfg.ReturnURL
+	}
+
+	amountFloat, err := strconv.ParseFloat(input.Amount, 64)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid amount", ErrConfigInvalid)
+	}
+
+	params := map[string]interface{}{
+		"order_id":     input.OrderNo,
+		"amount":       amountFloat,
+		"notify_url":   notifyURL,
+		"redirect_url": returnURL,
+		"fiat":         cfg.Fiat,
+	}
+	if input.Name != "" {
+		params["name"] = input.Name
+	}
+
+	signature := Sign(params, cfg.AuthToken)
+	params["signature"] = signature
+
+	endpoint := cfg.GatewayURL + bepusdtCreateOrderPath
+	respBytes, err := postJSON(ctx, endpoint, params)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrRequestFailed, err)
+	}
+
+	var resp struct {
+		StatusCode int    `json:"status_code"`
+		Message    string `json:"message"`
+		Data       struct {
+			Fiat           string `json:"fiat"`
+			TradeID        string `json:"trade_id"`
+			OrderID        string `json:"order_id"`
+			Amount         string `json:"amount"`
+			ExpirationTime int    `json:"expiration_time"`
+			PaymentURL     string `json:"payment_url"`
+			Reselect       bool   `json:"reselect"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrResponseInvalid, err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("%w: %s", ErrResponseInvalid, resp.Message)
+	}
+
+	var raw map[string]interface{}
+	_ = json.Unmarshal(respBytes, &raw)
+
+	return &CreateResult{
+		TradeID:    resp.Data.TradeID,
+		OrderID:    resp.Data.OrderID,
+		Amount:     resp.Data.Amount,
+		PaymentURL: resp.Data.PaymentURL,
+		Raw:        raw,
 	}, nil
 }
 
@@ -357,11 +445,6 @@ func postJSON(ctx context.Context, endpoint string, params map[string]interface{
 	}
 
 	return io.ReadAll(resp.Body)
-}
-
-// IsSupportedChannelType 判断是否支持的渠道类型
-func IsSupportedChannelType(channelType string) bool {
-	return ResolveTradeType(channelType) != ""
 }
 
 // ResolveTradeType 根据 channel_type 解析 trade_type

--- a/internal/payment/bepusdt/bepusdt_test.go
+++ b/internal/payment/bepusdt/bepusdt_test.go
@@ -27,6 +27,23 @@ func TestParseConfigAndNormalizeDefaults(t *testing.T) {
 	}
 }
 
+func TestParseConfig_CashierModeKeepsTradeTypeEmpty(t *testing.T) {
+	cfg, err := ParseConfig(map[string]interface{}{
+		"gateway_url": " https://pay.example.com/ ",
+		"auth_token":  " token ",
+		"order_mode":  constants.PaymentBepusdtOrderModeCashier,
+		"trade_type":  " usdt.trc20 ",
+		"notify_url":  " https://example.com/notify ",
+		"return_url":  " https://example.com/return ",
+	})
+	if err != nil {
+		t.Fatalf("parse config failed: %v", err)
+	}
+	if cfg.TradeType != "" {
+		t.Fatalf("cashier mode trade type should stay empty, got %s", cfg.TradeType)
+	}
+}
+
 func TestResolveTradeType(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/payment/bepusdt/bepusdt_test.go
+++ b/internal/payment/bepusdt/bepusdt_test.go
@@ -10,6 +10,7 @@ func TestParseConfigAndNormalizeDefaults(t *testing.T) {
 	cfg, err := ParseConfig(map[string]interface{}{
 		"gateway_url": " https://pay.example.com/ ",
 		"auth_token":  " token ",
+		"currencies":  "USDT,USDC",
 		"notify_url":  " https://example.com/notify ",
 		"return_url":  " https://example.com/return ",
 	})
@@ -25,6 +26,9 @@ func TestParseConfigAndNormalizeDefaults(t *testing.T) {
 	if cfg.GatewayURL != "https://pay.example.com" {
 		t.Fatalf("unexpected normalized gateway url: %s", cfg.GatewayURL)
 	}
+	if cfg.Currencies != "" {
+		t.Fatalf("transaction mode currencies should be empty, got %q", cfg.Currencies)
+	}
 }
 
 func TestParseConfig_CashierModeKeepsTradeTypeEmpty(t *testing.T) {
@@ -33,6 +37,7 @@ func TestParseConfig_CashierModeKeepsTradeTypeEmpty(t *testing.T) {
 		"auth_token":  " token ",
 		"order_mode":  constants.PaymentBepusdtOrderModeCashier,
 		"trade_type":  " usdt.trc20 ",
+		"currencies":  " usdt, usdc ",
 		"notify_url":  " https://example.com/notify ",
 		"return_url":  " https://example.com/return ",
 	})
@@ -41,6 +46,9 @@ func TestParseConfig_CashierModeKeepsTradeTypeEmpty(t *testing.T) {
 	}
 	if cfg.TradeType != "" {
 		t.Fatalf("cashier mode trade type should stay empty, got %s", cfg.TradeType)
+	}
+	if cfg.Currencies != "USDT,USDC" {
+		t.Fatalf("cashier currencies = %q, want USDT,USDC", cfg.Currencies)
 	}
 }
 

--- a/internal/payment/epusdt/epusdt.go
+++ b/internal/payment/epusdt/epusdt.go
@@ -40,6 +40,7 @@ type Config struct {
 	GatewayURL  string `json:"gateway_url"`
 	PID         string `json:"pid"`
 	SecretKey   string `json:"secret_key"`
+	OrderMode   string `json:"order_mode"` // 订单接口模式：transaction/cashier
 	Token       string `json:"token"`
 	Network     string `json:"network"`
 	Currency    string `json:"currency,omitempty"`
@@ -61,12 +62,23 @@ func (c *Config) Normalize() {
 	c.GatewayURL = strings.TrimRight(strings.TrimSpace(c.GatewayURL), "/")
 	c.PID = strings.TrimSpace(c.PID)
 	c.SecretKey = strings.TrimSpace(c.SecretKey)
+	c.OrderMode = strings.ToLower(strings.TrimSpace(c.OrderMode))
+	if c.OrderMode == "" {
+		c.OrderMode = constants.PaymentEpusdtOrderModeTransaction
+	}
 	c.Token = strings.ToLower(strings.TrimSpace(c.Token))
 	c.Network = strings.ToLower(strings.TrimSpace(c.Network))
+	if c.OrderMode == constants.PaymentEpusdtOrderModeCashier {
+		c.Token = ""
+		c.Network = ""
+	}
 	c.Currency = strings.ToLower(strings.TrimSpace(c.Currency))
 	c.NotifyURL = strings.TrimSpace(c.NotifyURL)
 	c.ReturnURL = strings.TrimSpace(c.ReturnURL)
 	c.PaymentType = strings.TrimSpace(c.PaymentType)
+	if c.OrderMode == constants.PaymentEpusdtOrderModeCashier {
+		c.PaymentType = ""
+	}
 	if c.Currency == "" {
 		c.Currency = strings.ToLower(constants.SiteCurrencyDefault)
 	}
@@ -84,14 +96,27 @@ func ValidateConfig(cfg *Config) error {
 		{"gateway_url", cfg.GatewayURL},
 		{"pid", cfg.PID},
 		{"secret_key", cfg.SecretKey},
-		{"token", cfg.Token},
-		{"network", cfg.Network},
 		{"notify_url", cfg.NotifyURL},
 		{"return_url", cfg.ReturnURL},
 	}
 	for _, c := range checks {
 		if strings.TrimSpace(c.val) == "" {
 			return fmt.Errorf("%w: %s is required", ErrConfigInvalid, c.field)
+		}
+	}
+	orderMode := strings.ToLower(strings.TrimSpace(cfg.OrderMode))
+	if orderMode == "" {
+		orderMode = constants.PaymentEpusdtOrderModeTransaction
+	}
+	if orderMode != constants.PaymentEpusdtOrderModeTransaction && orderMode != constants.PaymentEpusdtOrderModeCashier {
+		return fmt.Errorf("%w: order_mode is invalid", ErrConfigInvalid)
+	}
+	if orderMode == constants.PaymentEpusdtOrderModeTransaction {
+		if strings.TrimSpace(cfg.Token) == "" {
+			return fmt.Errorf("%w: token is required", ErrConfigInvalid)
+		}
+		if strings.TrimSpace(cfg.Network) == "" {
+			return fmt.Errorf("%w: network is required", ErrConfigInvalid)
 		}
 	}
 	return nil
@@ -190,7 +215,9 @@ func toFloat(v interface{}) float64 {
 	return 0
 }
 
-// CreatePayment 调 POST /payments/gmpay/v1/order/create-transaction，返回 trade_id 和拼好的收银台 URL。
+// CreatePayment 调用 GMPay 创建交易接口并返回 trade_id 和收银台 URL。
+// epusdt 的收银台模式仍使用 create-transaction，只是同时省略 token/network，
+// 由服务端创建等待用户选择支付网络和代币的占位订单。
 func CreatePayment(ctx context.Context, cfg *Config, input CreateInput) (*CreateResult, error) {
 	if cfg == nil {
 		return nil, ErrConfigInvalid
@@ -223,11 +250,13 @@ func CreatePayment(ctx context.Context, cfg *Config, input CreateInput) (*Create
 		"pid":          cfg.PID,
 		"order_id":     input.OrderNo,
 		"currency":     cfg.Currency,
-		"token":        cfg.Token,
-		"network":      cfg.Network,
 		"amount":       amount,
 		"notify_url":   notifyURL,
 		"redirect_url": returnURL,
+	}
+	if cfg.OrderMode != constants.PaymentEpusdtOrderModeCashier {
+		params["token"] = cfg.Token
+		params["network"] = cfg.Network
 	}
 	if strings.TrimSpace(input.Name) != "" {
 		params["name"] = input.Name

--- a/internal/payment/epusdt/epusdt_test.go
+++ b/internal/payment/epusdt/epusdt_test.go
@@ -80,6 +80,28 @@ func TestValidateConfigPassesWhenAllRequiredFieldsPresent(t *testing.T) {
 	}
 }
 
+func TestValidateConfigCashierDoesNotRequireTokenAndNetwork(t *testing.T) {
+	cfg := &Config{
+		GatewayURL: "https://x", PID: "1", SecretKey: "s",
+		OrderMode: constants.PaymentEpusdtOrderModeCashier,
+		NotifyURL: "https://n", ReturnURL: "https://r",
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("cashier config should not require token/network: %v", err)
+	}
+}
+
+func TestValidateConfigTransactionRequiresTokenAndNetwork(t *testing.T) {
+	base := Config{
+		GatewayURL: "https://x", PID: "1", SecretKey: "s",
+		OrderMode: constants.PaymentEpusdtOrderModeTransaction,
+		NotifyURL: "https://n", ReturnURL: "https://r",
+	}
+	if err := ValidateConfig(&base); err == nil {
+		t.Fatal("transaction config without token/network should be rejected")
+	}
+}
+
 func TestSignDeterministicAndOmitsEmptyAndSignature(t *testing.T) {
 	params := map[string]interface{}{
 		"pid":          "1000",
@@ -199,6 +221,42 @@ func TestCreatePayment_BuildsRequestAndConstructsPaymentURL(t *testing.T) {
 	}
 	if capturedBody["name"] != "VIP Plan" {
 		t.Fatalf("name mismatch: %v", capturedBody["name"])
+	}
+}
+
+func TestCreatePaymentCashierUsesCreateTransactionAndOmitsTokenNetwork(t *testing.T) {
+	var capturedBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/payments/gmpay/v1/order/create-transaction" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &capturedBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"trade_id":"CASHIER-1"}}`))
+	}))
+	defer srv.Close()
+
+	cfg := &Config{
+		GatewayURL: srv.URL, PID: "1000", SecretKey: "sk-test",
+		OrderMode: constants.PaymentEpusdtOrderModeCashier,
+		Currency:  "cny", NotifyURL: "https://example.com/notify", ReturnURL: "https://example.com/return",
+	}
+	result, err := CreatePayment(context.Background(), cfg, CreateInput{OrderNo: "ORD-1", Amount: "100"})
+	if err != nil {
+		t.Fatalf("CreatePayment cashier failed: %v", err)
+	}
+	if result.TradeID != "CASHIER-1" {
+		t.Fatalf("trade_id = %q, want CASHIER-1", result.TradeID)
+	}
+	if _, ok := capturedBody["token"]; ok {
+		t.Fatalf("cashier request must omit token: %v", capturedBody["token"])
+	}
+	if _, ok := capturedBody["network"]; ok {
+		t.Fatalf("cashier request must omit network: %v", capturedBody["network"])
+	}
+	if _, ok := capturedBody["signature"]; !ok {
+		t.Fatal("cashier request signature missing")
 	}
 }
 

--- a/internal/payment/provider/bepusdt_adapter.go
+++ b/internal/payment/provider/bepusdt_adapter.go
@@ -15,8 +15,8 @@ import (
 )
 
 // bepusdtAdapter 是 bepusdt 网关的 Provider + CallbackVerifier 实现。
-// 与 epusdt 相似，但多 channel type 支持（usdt-trc20 / usdc-trc20 / trx 等），
-// transaction 模式需要根据 channelType 动态设置 cfg.TradeType；cashier 模式走 BEpusdt 收银台。
+// 与 epusdt 相似，但需要兼容旧 channel type（usdt-trc20 / usdc-trc20 / trx 等）；
+// transaction 模式的交易类型由 trade_type 配置决定，缺省为 usdt.trc20，cashier 模式走 BEpusdt 收银台。
 // callback 是同步 JSON POST（不是 form），所以**不**实现 Capturer 和 Webhooker。
 type bepusdtAdapter struct{}
 
@@ -35,26 +35,11 @@ func (a *bepusdtAdapter) Type() string {
 }
 
 // parseConfig 解析并验证 bepusdt Config。
-// 关键：如果 cfg.TradeType 未显式配置且 channelType 非空，
-// 则从 channelType 自动 resolve trade_type（沿用 payment_service_provider.go 的逻辑）。
-func (a *bepusdtAdapter) parseConfig(raw models.JSON, channelType string) (*bepusdt.Config, error) {
-	rawTradeType := ""
-	if raw != nil && raw["trade_type"] != nil {
-		rawTradeType = strings.TrimSpace(fmt.Sprint(raw["trade_type"]))
-	}
+// transaction 模式未配置 trade_type 时，由 Config.Normalize 保持旧行为并使用 usdt.trc20。
+func (a *bepusdtAdapter) parseConfig(raw models.JSON) (*bepusdt.Config, error) {
 	cfg, err := bepusdt.ParseConfig(raw)
 	if err != nil {
 		return nil, mapBepusdtError(err)
-	}
-	// 兼容旧数据：如果配置中没有指定 trade_type，根据旧 channel_type 自动设置。
-	// 新格式 channel_type 固定为 bepusdt，不再用于推导 trade_type。
-	if cfg.OrderMode != constants.PaymentBepusdtOrderModeCashier && rawTradeType == "" && channelType != "" {
-		resolvedTradeType := bepusdt.ResolveTradeType(channelType)
-		if resolvedTradeType != "" {
-			cfg.TradeType = resolvedTradeType
-		} else {
-			cfg.TradeType = ""
-		}
 	}
 	if err := bepusdt.ValidateConfig(cfg); err != nil {
 		return nil, mapBepusdtError(err)
@@ -69,7 +54,7 @@ func (a *bepusdtAdapter) ValidateConfig(raw models.JSON, channelType string) err
 	if normalizedChannelType != "" && normalizedChannelType != constants.PaymentProviderBepusdt && !isLegacyBepusdtChannelType(normalizedChannelType) {
 		return fmt.Errorf("%w: bepusdt channel_type %s", ErrUnsupportedChannel, channelType)
 	}
-	cfg, err := a.parseConfig(raw, channelType)
+	cfg, err := a.parseConfig(raw)
 	if err != nil {
 		return err
 	}
@@ -96,7 +81,7 @@ func (a *bepusdtAdapter) ValidateConfig(raw models.JSON, channelType string) err
 
 // CreatePayment 创建支付。bepusdt 多 channel type，需要先校验 channelType。
 func (a *bepusdtAdapter) CreatePayment(ctx context.Context, raw models.JSON, input CreateInput) (*CreateResult, error) {
-	cfg, err := a.parseConfig(raw, input.ChannelType)
+	cfg, err := a.parseConfig(raw)
 	if err != nil {
 		return nil, err
 	}
@@ -227,31 +212,45 @@ func setBepusdtPayloadString(payload map[string]interface{}, key string, value s
 }
 
 func resolveBepusdtTradeLabels(tradeType string) (chain string, tokenID string) {
-	switch strings.ToLower(strings.TrimSpace(tradeType)) {
-	case "usdt.trc20":
-		return "tron", "tron-usdt"
-	case "usdt.erc20":
-		return "ethereum", "ethereum-usdt"
-	case "usdt.bep20":
-		return "bsc", "bsc-usdt"
-	case "usdt.polygon":
-		return "polygon", "polygon-usdt"
-	case "usdc.trc20":
-		return "tron", "tron-usdc"
-	case "usdc.erc20":
-		return "ethereum", "ethereum-usdc"
-	case "usdc.polygon":
-		return "polygon", "polygon-usdc"
-	case "usdc.bep20":
-		return "bsc", "bsc-usdc"
-	case "tron.trx":
-		return "tron", "tron-trx"
-	case "eth.eth":
-		return "ethereum", "ethereum-eth"
-	case "bsc.bnb":
-		return "bsc", "bsc-bnb"
-	default:
+	normalized := strings.ToLower(strings.TrimSpace(tradeType))
+	parts := strings.Split(normalized, ".")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", ""
+	}
+
+	// BEpusdt 的稳定币采用 token.network，原生币采用 network.token。
+	// 根据官方 trade type 合同识别稳定币前缀，其余类型按原生币格式解析，
+	// 从而让未来的原生代币支持比如 solana.sol、aptos.apt 等类型无需逐个维护。
+	if isBepusdtTokenPrefix(parts[0]) {
+		token := parts[0]
+		network := normalizeBepusdtNetwork(parts[1])
+		return network, network + "-" + token
+	}
+
+	network := normalizeBepusdtNetwork(parts[0])
+	token := parts[1]
+	return network, network + "-" + token
+}
+
+func isBepusdtTokenPrefix(value string) bool {
+	switch value {
+	case "usdt", "usdc":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeBepusdtNetwork(network string) string {
+	switch network {
+	case "trc20":
+		return "tron"
+	case "erc20", "eth":
+		return "ethereum"
+	case "bep20":
+		return "bsc"
+	default:
+		return network
 	}
 }
 

--- a/internal/payment/provider/bepusdt_adapter.go
+++ b/internal/payment/provider/bepusdt_adapter.go
@@ -16,7 +16,7 @@ import (
 
 // bepusdtAdapter 是 bepusdt 网关的 Provider + CallbackVerifier 实现。
 // 与 epusdt 相似，但多 channel type 支持（usdt-trc20 / usdc-trc20 / trx 等），
-// 需要根据 channelType 动态设置 cfg.TradeType。
+// transaction 模式需要根据 channelType 动态设置 cfg.TradeType；cashier 模式走 BEpusdt 收银台。
 // callback 是同步 JSON POST（不是 form），所以**不**实现 Capturer 和 Webhooker。
 type bepusdtAdapter struct{}
 
@@ -38,13 +38,23 @@ func (a *bepusdtAdapter) Type() string {
 // 关键：如果 cfg.TradeType 未显式配置且 channelType 非空，
 // 则从 channelType 自动 resolve trade_type（沿用 payment_service_provider.go 的逻辑）。
 func (a *bepusdtAdapter) parseConfig(raw models.JSON, channelType string) (*bepusdt.Config, error) {
+	rawTradeType := ""
+	if raw != nil && raw["trade_type"] != nil {
+		rawTradeType = strings.TrimSpace(fmt.Sprint(raw["trade_type"]))
+	}
 	cfg, err := bepusdt.ParseConfig(raw)
 	if err != nil {
 		return nil, mapBepusdtError(err)
 	}
-	// 如果配置中没有指定 trade_type，根据 channel_type 自动设置
-	if strings.TrimSpace(cfg.TradeType) == "" && channelType != "" {
-		cfg.TradeType = bepusdt.ResolveTradeType(channelType)
+	// 兼容旧数据：如果配置中没有指定 trade_type，根据旧 channel_type 自动设置。
+	// 新格式 channel_type 固定为 bepusdt，不再用于推导 trade_type。
+	if cfg.OrderMode != constants.PaymentBepusdtOrderModeCashier && rawTradeType == "" && channelType != "" {
+		resolvedTradeType := bepusdt.ResolveTradeType(channelType)
+		if resolvedTradeType != "" {
+			cfg.TradeType = resolvedTradeType
+		} else {
+			cfg.TradeType = ""
+		}
 	}
 	if err := bepusdt.ValidateConfig(cfg); err != nil {
 		return nil, mapBepusdtError(err)
@@ -53,26 +63,56 @@ func (a *bepusdtAdapter) parseConfig(raw models.JSON, channelType string) (*bepu
 }
 
 // ValidateConfig 验证 channel.ConfigJSON。
-// 入口先校验 channelType（如果非空）是否被 bepusdt 支持，
-// 然后调用 parseConfig 验证配置完整性。
+// 新格式 channel_type 固定为 bepusdt；旧数据继续允许 usdt-trc20 / usdc-trc20 / trx 等 legacy channel_type。
 func (a *bepusdtAdapter) ValidateConfig(raw models.JSON, channelType string) error {
-	if channelType != "" && !bepusdt.IsSupportedChannelType(channelType) {
+	normalizedChannelType := strings.ToLower(strings.TrimSpace(channelType))
+	if normalizedChannelType != "" && normalizedChannelType != constants.PaymentProviderBepusdt && !isLegacyBepusdtChannelType(normalizedChannelType) {
 		return fmt.Errorf("%w: bepusdt channel_type %s", ErrUnsupportedChannel, channelType)
 	}
-	_, err := a.parseConfig(raw, channelType)
-	return err
+	cfg, err := a.parseConfig(raw, channelType)
+	if err != nil {
+		return err
+	}
+	if normalizedChannelType == "" {
+		return nil
+	}
+	if cfg.OrderMode == constants.PaymentBepusdtOrderModeCashier {
+		if normalizedChannelType != constants.PaymentProviderBepusdt {
+			return fmt.Errorf("%w: bepusdt cashier channel_type %s", ErrUnsupportedChannel, channelType)
+		}
+		return nil
+	}
+	if normalizedChannelType == constants.PaymentProviderBepusdt {
+		if strings.TrimSpace(cfg.TradeType) == "" {
+			return fmt.Errorf("%w: bepusdt trade_type is required", ErrConfigInvalid)
+		}
+		return nil
+	}
+	if !isLegacyBepusdtChannelType(normalizedChannelType) {
+		return fmt.Errorf("%w: bepusdt channel_type %s", ErrUnsupportedChannel, channelType)
+	}
+	return nil
 }
 
 // CreatePayment 创建支付。bepusdt 多 channel type，需要先校验 channelType。
 func (a *bepusdtAdapter) CreatePayment(ctx context.Context, raw models.JSON, input CreateInput) (*CreateResult, error) {
-	// 先校验 channelType
-	if input.ChannelType != "" && !bepusdt.IsSupportedChannelType(input.ChannelType) {
-		return nil, fmt.Errorf("%w: bepusdt channel_type %s", ErrUnsupportedChannel, input.ChannelType)
-	}
-
 	cfg, err := a.parseConfig(raw, input.ChannelType)
 	if err != nil {
 		return nil, err
+	}
+	channelType := strings.ToLower(strings.TrimSpace(input.ChannelType))
+	if cfg.OrderMode == constants.PaymentBepusdtOrderModeCashier {
+		if channelType != "" && channelType != constants.PaymentProviderBepusdt {
+			return nil, fmt.Errorf("%w: bepusdt cashier channel_type %s", ErrUnsupportedChannel, input.ChannelType)
+		}
+	} else if channelType != "" {
+		if channelType == constants.PaymentProviderBepusdt {
+			if strings.TrimSpace(cfg.TradeType) == "" {
+				return nil, fmt.Errorf("%w: bepusdt trade_type is required", ErrConfigInvalid)
+			}
+		} else if !isLegacyBepusdtChannelType(channelType) {
+			return nil, fmt.Errorf("%w: bepusdt channel_type %s", ErrUnsupportedChannel, input.ChannelType)
+		}
 	}
 
 	returnURL := strings.TrimSpace(input.ReturnURL)
@@ -88,13 +128,22 @@ func (a *bepusdtAdapter) CreatePayment(ctx context.Context, raw models.JSON, inp
 		NotifyURL: input.NotifyURL,
 		ReturnURL: returnURL,
 	}
-	result, err := bepusdt.CreatePayment(ctx, cfg, native)
+	mode, _ := input.Extra["interaction_mode"].(string)
+	mode = strings.ToLower(strings.TrimSpace(mode))
+
+	var result *bepusdt.CreateResult
+	if cfg.OrderMode == constants.PaymentBepusdtOrderModeCashier {
+		if mode == constants.PaymentInteractionQR {
+			return nil, fmt.Errorf("%w: bepusdt cashier order mode only supports redirect interaction_mode", ErrConfigInvalid)
+		}
+		result, err = bepusdt.CreateCashierOrder(ctx, cfg, native)
+	} else {
+		result, err = bepusdt.CreatePayment(ctx, cfg, native)
+	}
 	if err != nil {
 		return nil, mapBepusdtError(err)
 	}
 
-	mode, _ := input.Extra["interaction_mode"].(string)
-	mode = strings.ToLower(strings.TrimSpace(mode))
 	redirectURL := strings.TrimSpace(result.PaymentURL)
 	qrCodeURL := redirectURL
 	switch mode {
@@ -110,14 +159,25 @@ func (a *bepusdtAdapter) CreatePayment(ctx context.Context, raw models.JSON, inp
 	}
 
 	return &CreateResult{
-		ProviderRef: result.TradeID,
-		RedirectURL: redirectURL,
-		QRCodeURL:   qrCodeURL,
-		Payload:     buildBepusdtCreatePayload(result, cfg.TradeType),
+		ProviderRef:        result.TradeID,
+		RedirectURL:        redirectURL,
+		QRCodeURL:          qrCodeURL,
+		Payload:            buildBepusdtCreatePayload(result, cfg.TradeType, cfg.OrderMode),
+		DisplayChannelType: bepusdtDisplayChannelType(cfg),
 	}, nil
 }
 
-func buildBepusdtCreatePayload(result *bepusdt.CreateResult, tradeType string) models.JSON {
+// bepusdtDisplayChannelType 返回 BEpusdt 支付记录的展示用渠道类型。
+// 新格式下 payment.channel_type 固定保存为 bepusdt；交易模式需要展示真实 trade_type，
+// 收银台模式没有固定币种，保持空值并回退展示 bepusdt。
+func bepusdtDisplayChannelType(cfg *bepusdt.Config) string {
+	if cfg == nil || cfg.OrderMode == constants.PaymentBepusdtOrderModeCashier {
+		return ""
+	}
+	return strings.TrimSpace(cfg.TradeType)
+}
+
+func buildBepusdtCreatePayload(result *bepusdt.CreateResult, tradeType string, orderMode string) models.JSON {
 	payload := models.JSON{}
 	if result == nil {
 		return payload
@@ -129,6 +189,7 @@ func buildBepusdtCreatePayload(result *bepusdt.CreateResult, tradeType string) m
 	}
 
 	data := ensureBepusdtPayloadData(payload)
+	setBepusdtPayloadString(data, "order_mode", orderMode)
 	setBepusdtPayloadString(data, "trade_type", tradeType)
 	setBepusdtPayloadString(data, "token", result.Token)
 	setBepusdtPayloadString(data, "actual_amount", result.ActualAmount)
@@ -138,6 +199,10 @@ func buildBepusdtCreatePayload(result *bepusdt.CreateResult, tradeType string) m
 	setBepusdtPayloadString(data, "chain", chain)
 	setBepusdtPayloadString(data, "token_id", tokenID)
 	return payload
+}
+
+func isLegacyBepusdtChannelType(channelType string) bool {
+	return bepusdt.ResolveTradeType(channelType) != ""
 }
 
 func ensureBepusdtPayloadData(payload models.JSON) map[string]interface{} {

--- a/internal/payment/provider/bepusdt_adapter_test.go
+++ b/internal/payment/provider/bepusdt_adapter_test.go
@@ -184,6 +184,9 @@ func TestBepusdtAdapter_CreatePayment_CashierModeUsesCreateOrder(t *testing.T) {
 		if _, ok := payload["trade_type"]; ok {
 			t.Fatalf("trade_type should not be sent for cashier order mode")
 		}
+		if payload["currencies"] != "USDT,USDC" {
+			t.Fatalf("currencies = %v, want USDT,USDC", payload["currencies"])
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
@@ -206,6 +209,7 @@ func TestBepusdtAdapter_CreatePayment_CashierModeUsesCreateOrder(t *testing.T) {
 	cfg := validBepusdtConfig(server.URL)
 	cfg["order_mode"] = constants.PaymentBepusdtOrderModeCashier
 	cfg["trade_type"] = "usdt.trc20"
+	cfg["currencies"] = " usdt, usdc "
 	result, err := a.CreatePayment(context.Background(), cfg, CreateInput{
 		OrderNo:     "ORDER-CASHIER-1",
 		Subject:     "测试商品",

--- a/internal/payment/provider/bepusdt_adapter_test.go
+++ b/internal/payment/provider/bepusdt_adapter_test.go
@@ -108,6 +108,163 @@ func TestBepusdtAdapter_CreatePayment_RedirectModeKeepsCashierURL(t *testing.T) 
 	}
 }
 
+func TestBepusdtAdapter_CreatePayment_ProviderChannelUsesConfiguredTradeType(t *testing.T) {
+	a := NewBepusdtAdapter()
+	server := newBepusdtCreatePaymentServer(t, "usdc.trc20")
+	defer server.Close()
+
+	cfg := validBepusdtConfig(server.URL)
+	cfg["trade_type"] = "usdc.trc20"
+	result, err := a.CreatePayment(context.Background(), cfg, CreateInput{
+		OrderNo:     "ORDER-PROVIDER-CHANNEL-1",
+		Subject:     "测试商品",
+		Amount:      models.NewMoneyFromDecimal(decimal.RequireFromString("28.88")),
+		ChannelType: constants.PaymentProviderBepusdt,
+		Extra:       models.JSON{"interaction_mode": constants.PaymentInteractionRedirect},
+	})
+	if err != nil {
+		t.Fatalf("CreatePayment() failed: %v", err)
+	}
+	data := result.Payload["data"].(map[string]interface{})
+	if data["trade_type"] != "usdc.trc20" {
+		t.Fatalf("trade_type = %v, want usdc.trc20", data["trade_type"])
+	}
+	if result.DisplayChannelType != "usdc.trc20" {
+		t.Fatalf("DisplayChannelType = %q, want usdc.trc20", result.DisplayChannelType)
+	}
+}
+
+func TestBepusdtAdapter_CreatePayment_LegacyChannelTypeFallback(t *testing.T) {
+	a := NewBepusdtAdapter()
+	server := newBepusdtCreatePaymentServer(t, "tron.trx")
+	defer server.Close()
+
+	cfg := validBepusdtConfig(server.URL)
+	delete(cfg, "trade_type")
+	result, err := a.CreatePayment(context.Background(), cfg, CreateInput{
+		OrderNo:     "ORDER-LEGACY-CHANNEL-1",
+		Subject:     "测试商品",
+		Amount:      models.NewMoneyFromDecimal(decimal.RequireFromString("28.88")),
+		ChannelType: constants.PaymentChannelTypeTrx,
+		Extra:       models.JSON{"interaction_mode": constants.PaymentInteractionRedirect},
+	})
+	if err != nil {
+		t.Fatalf("CreatePayment() failed: %v", err)
+	}
+	data := result.Payload["data"].(map[string]interface{})
+	if data["trade_type"] != "tron.trx" {
+		t.Fatalf("trade_type = %v, want tron.trx", data["trade_type"])
+	}
+	if result.DisplayChannelType != "tron.trx" {
+		t.Fatalf("DisplayChannelType = %q, want tron.trx", result.DisplayChannelType)
+	}
+}
+
+func TestBepusdtAdapter_ValidateConfig_ProviderChannelRequiresTradeType(t *testing.T) {
+	a := NewBepusdtAdapter()
+	cfg := validBepusdtConfig("https://bepusdt.example")
+	delete(cfg, "trade_type")
+
+	err := a.ValidateConfig(cfg, constants.PaymentProviderBepusdt)
+	if !errors.Is(err, ErrConfigInvalid) {
+		t.Fatalf("expected ErrConfigInvalid, got %v", err)
+	}
+}
+
+func TestBepusdtAdapter_CreatePayment_CashierModeUsesCreateOrder(t *testing.T) {
+	a := NewBepusdtAdapter()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/order/create-order" {
+			t.Fatalf("path = %s, want /api/v1/order/create-order", r.URL.Path)
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request failed: %v", err)
+		}
+		if _, ok := payload["trade_type"]; ok {
+			t.Fatalf("trade_type should not be sent for cashier order mode")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"status_code": 200,
+			"message": "success",
+			"data": {
+				"fiat": "CNY",
+				"trade_id": "BEP-CASHIER-1",
+				"order_id": "ORDER-CASHIER-1",
+				"amount": "28.88",
+				"expiration_time": 1200,
+				"status": 1,
+				"payment_url": "https://bepusdt.example/pay/cashier/BEP-CASHIER-1",
+				"reselect": true
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	cfg := validBepusdtConfig(server.URL)
+	cfg["order_mode"] = constants.PaymentBepusdtOrderModeCashier
+	cfg["trade_type"] = "usdt.trc20"
+	result, err := a.CreatePayment(context.Background(), cfg, CreateInput{
+		OrderNo:     "ORDER-CASHIER-1",
+		Subject:     "测试商品",
+		Amount:      models.NewMoneyFromDecimal(decimal.RequireFromString("28.88")),
+		ChannelType: constants.PaymentProviderBepusdt,
+		Extra:       models.JSON{"interaction_mode": constants.PaymentInteractionRedirect},
+	})
+	if err != nil {
+		t.Fatalf("CreatePayment() failed: %v", err)
+	}
+
+	wantURL := "https://bepusdt.example/pay/cashier/BEP-CASHIER-1"
+	if result.RedirectURL != wantURL {
+		t.Fatalf("RedirectURL = %q, want %q", result.RedirectURL, wantURL)
+	}
+	data := result.Payload["data"].(map[string]interface{})
+	if data["order_mode"] != constants.PaymentBepusdtOrderModeCashier {
+		t.Fatalf("order_mode = %v, want cashier", data["order_mode"])
+	}
+	if _, ok := data["trade_type"]; ok {
+		t.Fatalf("trade_type should be empty for cashier order mode")
+	}
+	if _, ok := data["token"]; ok {
+		t.Fatalf("token should be empty for cashier order mode")
+	}
+	if result.DisplayChannelType != "" {
+		t.Fatalf("DisplayChannelType = %q, want empty for cashier order mode", result.DisplayChannelType)
+	}
+}
+
+func TestBepusdtAdapter_CreatePayment_CashierModeRejectsQR(t *testing.T) {
+	a := NewBepusdtAdapter()
+	cfg := validBepusdtConfig("https://bepusdt.example")
+	cfg["order_mode"] = constants.PaymentBepusdtOrderModeCashier
+
+	_, err := a.CreatePayment(context.Background(), cfg, CreateInput{
+		OrderNo:     "ORDER-CASHIER-QR",
+		Amount:      models.NewMoneyFromDecimal(decimal.RequireFromString("28.88")),
+		ChannelType: constants.PaymentProviderBepusdt,
+		Extra:       models.JSON{"interaction_mode": constants.PaymentInteractionQR},
+	})
+	if !errors.Is(err, ErrConfigInvalid) {
+		t.Fatalf("expected ErrConfigInvalid, got %v", err)
+	}
+}
+
+func TestBepusdtAdapter_ValidateConfig_CashierModeRequiresCashierChannel(t *testing.T) {
+	a := NewBepusdtAdapter()
+	cfg := validBepusdtConfig("https://bepusdt.example")
+	cfg["order_mode"] = constants.PaymentBepusdtOrderModeCashier
+
+	if err := a.ValidateConfig(cfg, constants.PaymentProviderBepusdt); err != nil {
+		t.Fatalf("ValidateConfig() cashier channel failed: %v", err)
+	}
+	if err := a.ValidateConfig(cfg, constants.PaymentChannelTypeUsdtTrc20); !errors.Is(err, ErrUnsupportedChannel) {
+		t.Fatalf("expected ErrUnsupportedChannel for transaction channel in cashier mode, got %v", err)
+	}
+}
+
 func TestBepusdtAdapter_MapBepusdtError(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/payment/provider/bepusdt_adapter_test.go
+++ b/internal/payment/provider/bepusdt_adapter_test.go
@@ -134,9 +134,9 @@ func TestBepusdtAdapter_CreatePayment_ProviderChannelUsesConfiguredTradeType(t *
 	}
 }
 
-func TestBepusdtAdapter_CreatePayment_LegacyChannelTypeFallback(t *testing.T) {
+func TestBepusdtAdapter_CreatePayment_MissingTradeTypeUsesLegacyDefault(t *testing.T) {
 	a := NewBepusdtAdapter()
-	server := newBepusdtCreatePaymentServer(t, "tron.trx")
+	server := newBepusdtCreatePaymentServer(t, "usdt.trc20")
 	defer server.Close()
 
 	cfg := validBepusdtConfig(server.URL)
@@ -152,22 +152,21 @@ func TestBepusdtAdapter_CreatePayment_LegacyChannelTypeFallback(t *testing.T) {
 		t.Fatalf("CreatePayment() failed: %v", err)
 	}
 	data := result.Payload["data"].(map[string]interface{})
-	if data["trade_type"] != "tron.trx" {
-		t.Fatalf("trade_type = %v, want tron.trx", data["trade_type"])
+	if data["trade_type"] != "usdt.trc20" {
+		t.Fatalf("trade_type = %v, want usdt.trc20", data["trade_type"])
 	}
-	if result.DisplayChannelType != "tron.trx" {
-		t.Fatalf("DisplayChannelType = %q, want tron.trx", result.DisplayChannelType)
+	if result.DisplayChannelType != "usdt.trc20" {
+		t.Fatalf("DisplayChannelType = %q, want usdt.trc20", result.DisplayChannelType)
 	}
 }
 
-func TestBepusdtAdapter_ValidateConfig_ProviderChannelRequiresTradeType(t *testing.T) {
+func TestBepusdtAdapter_ValidateConfig_ProviderChannelUsesDefaultTradeType(t *testing.T) {
 	a := NewBepusdtAdapter()
 	cfg := validBepusdtConfig("https://bepusdt.example")
 	delete(cfg, "trade_type")
 
-	err := a.ValidateConfig(cfg, constants.PaymentProviderBepusdt)
-	if !errors.Is(err, ErrConfigInvalid) {
-		t.Fatalf("expected ErrConfigInvalid, got %v", err)
+	if err := a.ValidateConfig(cfg, constants.PaymentProviderBepusdt); err != nil {
+		t.Fatalf("ValidateConfig() failed: %v", err)
 	}
 }
 
@@ -286,6 +285,36 @@ func TestBepusdtAdapter_MapBepusdtError(t *testing.T) {
 			got := mapBepusdtError(tc.in)
 			if !errors.Is(got, tc.want) {
 				t.Fatalf("mapBepusdtError(%v) errors.Is %v = false, want true", tc.in, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveBepusdtTradeLabels(t *testing.T) {
+	tests := []struct {
+		tradeType string
+		chain     string
+		tokenID   string
+	}{
+		{tradeType: "usdt.trc20", chain: "tron", tokenID: "tron-usdt"},
+		{tradeType: "usdc.erc20", chain: "ethereum", tokenID: "ethereum-usdc"},
+		{tradeType: "usdt.bep20", chain: "bsc", tokenID: "bsc-usdt"},
+		{tradeType: "tron.trx", chain: "tron", tokenID: "tron-trx"},
+		{tradeType: "ethereum.eth", chain: "ethereum", tokenID: "ethereum-eth"},
+		{tradeType: "eth.eth", chain: "ethereum", tokenID: "ethereum-eth"},
+		{tradeType: "bsc.bnb", chain: "bsc", tokenID: "bsc-bnb"},
+		{tradeType: "ton.gram", chain: "ton", tokenID: "ton-gram"},
+		{tradeType: "solana.sol", chain: "solana", tokenID: "solana-sol"},
+		{tradeType: "aptos.apt", chain: "aptos", tokenID: "aptos-apt"},
+		{tradeType: "usdt.arbitrum", chain: "arbitrum", tokenID: "arbitrum-usdt"},
+		{tradeType: "usdc.solana", chain: "solana", tokenID: "solana-usdc"},
+		{tradeType: "usdt.x-layer", chain: "x-layer", tokenID: "x-layer-usdt"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.tradeType, func(t *testing.T) {
+			chain, tokenID := resolveBepusdtTradeLabels(tc.tradeType)
+			if chain != tc.chain || tokenID != tc.tokenID {
+				t.Fatalf("resolveBepusdtTradeLabels(%q) = (%q, %q), want (%q, %q)", tc.tradeType, chain, tokenID, tc.chain, tc.tokenID)
 			}
 		})
 	}

--- a/internal/payment/provider/epusdt_adapter.go
+++ b/internal/payment/provider/epusdt_adapter.go
@@ -28,7 +28,8 @@ var (
 	_ CallbackVerifier = (*epusdtAdapter)(nil)
 )
 
-// Type 返回 provider 标识。epusdt 是单 channel type provider，返回值中 channelType 部分为空。
+// Type 返回 provider 标识。epusdt 的 channel_type 统一为 epusdt，实际币种和网络保存在配置中；
+// 注册表使用空 channelType 通配，以兼容历史 usdt-trc20、trx 等渠道记录。
 func (a *epusdtAdapter) Type() string {
 	return constants.PaymentProviderEpusdt + ":"
 }
@@ -51,7 +52,7 @@ func (a *epusdtAdapter) ValidateConfig(raw models.JSON, _ string) error {
 	return err
 }
 
-// CreatePayment 创建支付。epusdt 单 channel type，不需要 IsSupportedChannelType 校验。
+// CreatePayment 创建支付。epusdt 的实际币种和网络由配置决定，不依赖 channel_type。
 func (a *epusdtAdapter) CreatePayment(ctx context.Context, raw models.JSON, input CreateInput) (*CreateResult, error) {
 	cfg, err := a.parseConfig(raw)
 	if err != nil {
@@ -77,11 +78,30 @@ func (a *epusdtAdapter) CreatePayment(ctx context.Context, raw models.JSON, inpu
 	}
 
 	return &CreateResult{
-		ProviderRef: result.TradeID,
-		RedirectURL: result.PaymentURL,
-		QRCodeURL:   result.PaymentURL, // epusdt 是 USDT 网关，PaymentURL 同时用于跳转和 QR 展示
-		Payload:     models.JSON(result.Raw),
+		ProviderRef:        result.TradeID,
+		RedirectURL:        result.PaymentURL,
+		QRCodeURL:          result.PaymentURL, // epusdt 是 USDT 网关，PaymentURL 同时用于跳转和 QR 展示
+		Payload:            models.JSON(result.Raw),
+		DisplayChannelType: epusdtDisplayChannelType(cfg),
 	}, nil
+}
+
+// epusdtDisplayChannelType 返回 epusdt 支付记录的展示用渠道类型。
+// epusdt 是单 provider 多币种/网络配置，payment.channel_type 可能只保留渠道兼容值；
+// 这里按 config_json.token/network 推导更准确的展示值，写入 display_channel_type。
+func epusdtDisplayChannelType(cfg *epusdt.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if cfg.OrderMode == constants.PaymentEpusdtOrderModeCashier {
+		return ""
+	}
+	token := strings.ToLower(strings.TrimSpace(cfg.Token))
+	network := strings.ToLower(strings.TrimSpace(cfg.Network))
+	if token == "" || network == "" {
+		return ""
+	}
+	return token + "." + network
 }
 
 // VerifyCallback 实现 CallbackVerifier。epusdt 用 JSON POST body，form 参数忽略。

--- a/internal/payment/provider/epusdt_adapter_test.go
+++ b/internal/payment/provider/epusdt_adapter_test.go
@@ -43,6 +43,48 @@ func TestEpusdtAdapter_CreatePayment_ConfigInvalidMapped(t *testing.T) {
 	}
 }
 
+func TestEpusdtDisplayChannelType(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *epusdt.Config
+		want string
+	}{
+		{name: "nil", cfg: nil, want: ""},
+		{
+			name: "cashier",
+			cfg:  &epusdt.Config{OrderMode: constants.PaymentEpusdtOrderModeCashier},
+			want: "",
+		},
+		{
+			name: "tron usdt",
+			cfg:  &epusdt.Config{Token: " USDT ", Network: " TRON "},
+			want: "usdt.tron",
+		},
+		{
+			name: "tron trx",
+			cfg:  &epusdt.Config{Token: " trx ", Network: " tron "},
+			want: "trx.tron",
+		},
+		{
+			name: "fallback payment type",
+			cfg:  &epusdt.Config{Token: "usdc", Network: "ethereum", PaymentType: "ethereum-usdc"},
+			want: "usdc.ethereum",
+		},
+		{
+			name: "unknown without payment type",
+			cfg:  &epusdt.Config{Token: "usdc", Network: "ethereum"},
+			want: "usdc.ethereum",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := epusdtDisplayChannelType(tc.cfg); got != tc.want {
+				t.Fatalf("epusdtDisplayChannelType() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestEpusdtAdapter_MapEpusdtError(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/payment/provider/types.go
+++ b/internal/payment/provider/types.go
@@ -36,12 +36,13 @@ type CreateInput struct {
 
 // CreateResult 统一支付创建结果。
 type CreateResult struct {
-	ProviderRef  string
-	RedirectURL  string
-	QRCodeURL    string
-	Payload      models.JSON
-	AmountSent   string
-	CurrencySent string
+	ProviderRef        string
+	RedirectURL        string
+	QRCodeURL          string
+	Payload            models.JSON
+	DisplayChannelType string
+	AmountSent         string
+	CurrencySent       string
 }
 
 // QueryResult 主动查询订单状态返回。

--- a/internal/repository/payment_repository.go
+++ b/internal/repository/payment_repository.go
@@ -244,7 +244,45 @@ func (r *GormPaymentRepository) ListAdmin(filter PaymentListFilter) ([]models.Pa
 	if err := query.Order("payments.id desc").Find(&payments).Error; err != nil {
 		return nil, 0, err
 	}
+	if filter.Lightweight {
+		if err := r.fillPaymentDisplayChannelTypes(payments); err != nil {
+			return nil, 0, err
+		}
+	}
 	return payments, total, nil
+}
+
+// fillPaymentDisplayChannelTypes 为 lightweight 支付列表补充展示用渠道类型。
+func (r *GormPaymentRepository) fillPaymentDisplayChannelTypes(payments []models.Payment) error {
+	if len(payments) == 0 {
+		return nil
+	}
+	ids := make([]uint, 0, len(payments))
+	indexByID := make(map[uint]int, len(payments))
+	for idx := range payments {
+		ids = append(ids, payments[idx].ID)
+		indexByID[payments[idx].ID] = idx
+	}
+	type displayRow struct {
+		ID                 uint
+		DisplayChannelType string
+	}
+	var rows []displayRow
+	displayChannelTypeExpr := jsonTextExpr(r.db, "provider_payload", "display_channel_type")
+	if err := r.db.Model(&models.Payment{}).
+		Select("id", displayChannelTypeExpr+" AS display_channel_type").
+		Where("id IN ?", ids).
+		Find(&rows).Error; err != nil {
+		return err
+	}
+	for _, row := range rows {
+		idx, ok := indexByID[row.ID]
+		if !ok {
+			continue
+		}
+		payments[idx].DisplayChannelType = strings.TrimSpace(row.DisplayChannelType)
+	}
+	return nil
 }
 
 // GetByIDForUpdate 事务中加行锁读取支付单,不存在返回 (nil, nil)。

--- a/internal/repository/payment_repository_test.go
+++ b/internal/repository/payment_repository_test.go
@@ -237,7 +237,11 @@ func TestPaymentRepositoryListAdminLightweightSkipCount(t *testing.T) {
 		t.Fatalf("create order failed: %v", err)
 	}
 
-	payload := models.JSON{"foo": "bar", "nested": map[string]interface{}{"key": "value"}}
+	payload := models.JSON{
+		"display_channel_type": "usdt.arbitrum",
+		"foo":                  "bar",
+		"nested":               map[string]interface{}{"key": "value"},
+	}
 	payment := models.Payment{
 		OrderID:         order.ID,
 		ChannelID:       1,
@@ -281,5 +285,8 @@ func TestPaymentRepositoryListAdminLightweightSkipCount(t *testing.T) {
 	}
 	if len(rows[0].ProviderPayload) != 0 {
 		t.Fatalf("provider payload should be empty in lightweight query, got %+v", rows[0].ProviderPayload)
+	}
+	if rows[0].DisplayChannelType != "usdt.arbitrum" {
+		t.Fatalf("display channel type want usdt.arbitrum got %s", rows[0].DisplayChannelType)
 	}
 }

--- a/internal/service/payment_notification_payload_test.go
+++ b/internal/service/payment_notification_payload_test.go
@@ -183,6 +183,28 @@ func TestBuildOrderNotificationPayloadKeepsBepusdtCashierChannel(t *testing.T) {
 	}
 }
 
+func TestMergeProviderPayloadPreservesDisplayChannelType(t *testing.T) {
+	existing := models.JSON{
+		"display_channel_type": "usdt.arbitrum",
+		"data":                 map[string]interface{}{"trade_id": "CREATE-1"},
+	}
+	incoming := models.JSON{
+		"trade_id": "CALLBACK-1",
+		"status":   float64(2),
+	}
+
+	merged := mergeProviderPayload(existing, incoming)
+	if got := notificationPayloadString(merged, "display_channel_type"); got != "usdt.arbitrum" {
+		t.Fatalf("display_channel_type = %q, want usdt.arbitrum", got)
+	}
+	if got := notificationPayloadString(merged, "trade_id"); got != "CALLBACK-1" {
+		t.Fatalf("callback trade_id = %q, want CALLBACK-1", got)
+	}
+	if _, ok := existing["trade_id"]; ok {
+		t.Fatal("mergeProviderPayload must not mutate existing payload")
+	}
+}
+
 func TestBuildOrderNotificationPayloadFallsBackToChildrenItems(t *testing.T) {
 	repo := newMockSettingRepo()
 	repo.store[constants.SettingKeyNotificationCenterConfig] = models.JSON{

--- a/internal/service/payment_notification_payload_test.go
+++ b/internal/service/payment_notification_payload_test.go
@@ -125,6 +125,64 @@ func TestBuildOrderNotificationPayloadIncludesCustomerAndItemSummary(t *testing.
 	}
 }
 
+func TestBuildOrderNotificationPayloadUsesDisplayChannelType(t *testing.T) {
+	svc := &PaymentService{}
+	order := &models.Order{
+		ID:          1002,
+		OrderNo:     "DJ202603230002",
+		Currency:    "usd",
+		Status:      constants.OrderStatusPaid,
+		TotalAmount: models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+	}
+	payment := &models.Payment{
+		ID:           10,
+		ProviderType: constants.PaymentProviderBepusdt,
+		ChannelType:  constants.PaymentProviderBepusdt,
+		ProviderPayload: models.JSON{
+			"display_channel_type": "usdt.arbitrum",
+		},
+	}
+
+	payload := svc.buildOrderNotificationPayload(order, payment)
+
+	if got := fmt.Sprintf("%v", payload["payment_channel"]); got != "bepusdt/usdt.arbitrum" {
+		t.Fatalf("payment_channel want bepusdt/usdt.arbitrum got %s", got)
+	}
+	if got := fmt.Sprintf("%v", payload["channel_type"]); got != "usdt.arbitrum" {
+		t.Fatalf("channel_type want usdt.arbitrum got %s", got)
+	}
+}
+
+func TestBuildOrderNotificationPayloadKeepsBepusdtCashierChannel(t *testing.T) {
+	svc := &PaymentService{}
+	order := &models.Order{
+		ID:          1003,
+		OrderNo:     "DJ202603230003",
+		Currency:    "usd",
+		Status:      constants.OrderStatusPaid,
+		TotalAmount: models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+	}
+	payment := &models.Payment{
+		ID:           11,
+		ProviderType: constants.PaymentProviderBepusdt,
+		ChannelType:  constants.PaymentProviderBepusdt,
+		ProviderPayload: models.JSON{
+			"data": map[string]interface{}{
+				"order_mode": constants.PaymentBepusdtOrderModeCashier,
+			},
+		},
+	}
+
+	payload := svc.buildOrderNotificationPayload(order, payment)
+
+	if got := fmt.Sprintf("%v", payload["payment_channel"]); got != "bepusdt/bepusdt" {
+		t.Fatalf("payment_channel want bepusdt/bepusdt got %s", got)
+	}
+	if got := fmt.Sprintf("%v", payload["channel_type"]); got != "bepusdt" {
+		t.Fatalf("channel_type want bepusdt got %s", got)
+	}
+}
+
 func TestBuildOrderNotificationPayloadFallsBackToChildrenItems(t *testing.T) {
 	repo := newMockSettingRepo()
 	repo.store[constants.SettingKeyNotificationCenterConfig] = models.JSON{

--- a/internal/service/payment_service_callback.go
+++ b/internal/service/payment_service_callback.go
@@ -877,6 +877,12 @@ func notificationPaymentChannel(order *models.Order, payment *models.Payment) (s
 	if payment != nil {
 		providerType = strings.TrimSpace(payment.ProviderType)
 		channelType = strings.TrimSpace(payment.ChannelType)
+		// display_channel_type 是创建支付时由 adapter 写入的通用展示覆盖值。
+		// 例如 BEpusdt 交易模式数据库 channel_type 固定为 bepusdt，
+		// 但通知里的支付渠道应展示为例如 bepusdt/usdt.arbitrum。
+		if displayChannelType := notificationPayloadString(payment.ProviderPayload, "display_channel_type"); displayChannelType != "" {
+			channelType = displayChannelType
+		}
 	}
 	if providerType == "" && order != nil && order.WalletPaidAmount.Decimal.GreaterThan(decimal.Zero) {
 		providerType = constants.PaymentProviderWallet
@@ -889,6 +895,20 @@ func notificationPaymentChannel(order *models.Order, payment *models.Payment) (s
 		paymentChannel = channelType
 	}
 	return providerType, channelType, paymentChannel
+}
+
+// notificationPayloadString 从通知相关 payload 中安全读取字符串字段。
+// payload 可能来自 JSON 反序列化，值类型不固定，因此统一 fmt.Sprint 后 trim；
+// 缺失或 nil 时返回空字符串，避免 fmt.Sprint(nil) 变成 "<nil>"。
+func notificationPayloadString(payload map[string]interface{}, key string) string {
+	if payload == nil {
+		return ""
+	}
+	value, ok := payload[key]
+	if !ok || value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
 }
 
 func buildNotificationOrderItemSummaries(items []models.OrderItem, locale string) (string, string, notificationOrderItemCounts) {

--- a/internal/service/payment_service_callback.go
+++ b/internal/service/payment_service_callback.go
@@ -250,7 +250,7 @@ func (s *PaymentService) applyWalletRechargePaymentUpdate(payment *models.Paymen
 		payment.ProviderRef = input.ProviderRef
 	}
 	if input.Payload != nil {
-		payment.ProviderPayload = input.Payload
+		payment.ProviderPayload = mergeProviderPayload(payment.ProviderPayload, input.Payload)
 	}
 
 	err := s.paymentRepo.Transaction(func(tx *gorm.DB) error {
@@ -345,7 +345,7 @@ func (s *PaymentService) updateCallbackMeta(payment *models.Payment, status stri
 		updated = true
 	}
 	if input.Payload != nil {
-		payment.ProviderPayload = input.Payload
+		payment.ProviderPayload = mergeProviderPayload(payment.ProviderPayload, input.Payload)
 		updated = true
 	}
 	if status != "" && payment.Status != status {
@@ -389,7 +389,7 @@ func (s *PaymentService) applyPaymentUpdate(payment *models.Payment, order *mode
 		payment.ProviderRef = input.ProviderRef
 	}
 	if input.Payload != nil {
-		payment.ProviderPayload = input.Payload
+		payment.ProviderPayload = mergeProviderPayload(payment.ProviderPayload, input.Payload)
 	}
 
 	err := s.paymentRepo.Transaction(func(tx *gorm.DB) error {
@@ -422,6 +422,22 @@ func (s *PaymentService) applyPaymentUpdate(payment *models.Payment, order *mode
 		return nil, false, err
 	}
 	return returnVal, orderPaid, nil
+}
+
+// mergeProviderPayload 合并第三方回调原文，同时保留创建支付阶段写入的展示快照等元数据。
+// 回调字段优先覆盖同名旧字段，未出现在回调中的 display_channel_type 等字段不会丢失。
+func mergeProviderPayload(existing models.JSON, incoming models.JSON) models.JSON {
+	if incoming == nil {
+		return existing
+	}
+	merged := make(models.JSON, len(existing)+len(incoming))
+	for key, value := range existing {
+		merged[key] = value
+	}
+	for key, value := range incoming {
+		merged[key] = value
+	}
+	return merged
 }
 
 // markOrderPaid 在事务内将订单更新为已支付并处理库存

--- a/internal/service/payment_service_gateway_order_test.go
+++ b/internal/service/payment_service_gateway_order_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dujiao-next/internal/constants"
 	"github.com/dujiao-next/internal/models"
 	"github.com/dujiao-next/internal/payment/provider"
+	"github.com/dujiao-next/internal/repository"
 
 	"github.com/shopspring/decimal"
 )
@@ -292,6 +293,127 @@ func TestApplyProviderPaymentStoresDisplayChannelType(t *testing.T) {
 	}
 	if got := payment.ProviderPayload["display_channel_type"]; got != "usdt.arbitrum" {
 		t.Fatalf("display_channel_type = %v, want usdt.arbitrum", got)
+	}
+}
+
+func TestPaymentDisplayChannelTypeLifecycle(t *testing.T) {
+	svc, db := setupPaymentServiceWalletTest(t)
+	now := time.Now()
+
+	order := &models.Order{
+		OrderNo:                 "DJTESTDISPLAYLIFECYCLE001",
+		UserID:                  1,
+		Status:                  constants.OrderStatusPendingPayment,
+		Currency:                "CNY",
+		OriginalAmount:          models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+		DiscountAmount:          models.NewMoneyFromDecimal(decimal.Zero),
+		PromotionDiscountAmount: models.NewMoneyFromDecimal(decimal.Zero),
+		TotalAmount:             models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+		WalletPaidAmount:        models.NewMoneyFromDecimal(decimal.Zero),
+		OnlinePaidAmount:        models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+		RefundedAmount:          models.NewMoneyFromDecimal(decimal.Zero),
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}
+	if err := db.Create(order).Error; err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	channel := &models.PaymentChannel{
+		Name:            "BEpusdt Arbitrum",
+		ProviderType:    constants.PaymentProviderBepusdt,
+		ChannelType:     constants.PaymentProviderBepusdt,
+		InteractionMode: constants.PaymentInteractionRedirect,
+		FeeRate:         models.NewMoneyFromDecimal(decimal.Zero),
+		ConfigJSON: models.JSON{
+			"notify_url": "https://api.example.com/api/v1/payments/callback",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := db.Create(channel).Error; err != nil {
+		t.Fatalf("create channel failed: %v", err)
+	}
+
+	payment := &models.Payment{
+		OrderID:         order.ID,
+		ChannelID:       channel.ID,
+		ProviderType:    channel.ProviderType,
+		ChannelType:     channel.ChannelType,
+		InteractionMode: channel.InteractionMode,
+		Amount:          models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+		FeeRate:         models.NewMoneyFromDecimal(decimal.Zero),
+		FeeAmount:       models.NewMoneyFromDecimal(decimal.Zero),
+		Currency:        "CNY",
+		Status:          constants.PaymentStatusInitiated,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := db.Create(payment).Error; err != nil {
+		t.Fatalf("create payment failed: %v", err)
+	}
+
+	svc.paymentProviderRegistry.Register(constants.PaymentProviderBepusdt, "", emptyProviderRefProvider{
+		displayChannelType: "usdt.arbitrum",
+	})
+	if err := svc.applyProviderPayment(CreatePaymentInput{
+		ClientIP: "127.0.0.1",
+		Context:  context.Background(),
+	}, order, channel, payment); err != nil {
+		t.Fatalf("create provider payment failed: %v", err)
+	}
+	if got := notificationPayloadString(payment.ProviderPayload, "display_channel_type"); got != "usdt.arbitrum" {
+		t.Fatalf("display_channel_type after create = %q, want usdt.arbitrum", got)
+	}
+
+	paidAt := time.Now()
+	if _, err := svc.HandleCallback(PaymentCallbackInput{
+		PaymentID:   payment.ID,
+		OrderNo:     payment.GatewayOrderNo,
+		ChannelID:   channel.ID,
+		Status:      constants.PaymentStatusSuccess,
+		ProviderRef: "BEP-CALLBACK-1",
+		Amount:      payment.Amount,
+		Currency:    payment.Currency,
+		PaidAt:      &paidAt,
+		Payload: models.JSON{
+			"trade_id": "BEP-CALLBACK-1",
+			"status":   float64(2),
+		},
+	}); err != nil {
+		t.Fatalf("handle callback failed: %v", err)
+	}
+
+	storedPayment, err := svc.GetPayment(payment.ID)
+	if err != nil {
+		t.Fatalf("reload payment failed: %v", err)
+	}
+	if got := notificationPayloadString(storedPayment.ProviderPayload, "display_channel_type"); got != "usdt.arbitrum" {
+		t.Fatalf("display_channel_type after callback reload = %q, want usdt.arbitrum", got)
+	}
+	if got := notificationPayloadString(storedPayment.ProviderPayload, "trade_id"); got != "BEP-CALLBACK-1" {
+		t.Fatalf("callback trade_id after reload = %q, want BEP-CALLBACK-1", got)
+	}
+
+	notificationPayload := svc.buildOrderNotificationPayload(order, storedPayment)
+	if got := notificationPayloadString(notificationPayload, "payment_channel"); got != "bepusdt/usdt.arbitrum" {
+		t.Fatalf("notification payment_channel = %q, want bepusdt/usdt.arbitrum", got)
+	}
+
+	adminPayments, _, err := svc.ListPayments(repository.PaymentListFilter{
+		Page:        1,
+		PageSize:    10,
+		OrderID:     order.ID,
+		Lightweight: true,
+	})
+	if err != nil {
+		t.Fatalf("list admin payments failed: %v", err)
+	}
+	if len(adminPayments) != 1 {
+		t.Fatalf("admin payment count = %d, want 1", len(adminPayments))
+	}
+	if got := adminPayments[0].DisplayChannelType; got != "usdt.arbitrum" {
+		t.Fatalf("admin display_channel_type = %q, want usdt.arbitrum", got)
 	}
 }
 

--- a/internal/service/payment_service_gateway_order_test.go
+++ b/internal/service/payment_service_gateway_order_test.go
@@ -596,6 +596,25 @@ func TestValidateChannelRejectsInvalidEpayInteractionMode(t *testing.T) {
 	}
 }
 
+func TestValidateChannelRejectsBepusdtCashierQR(t *testing.T) {
+	svc, _ := setupPaymentServiceWalletTest(t)
+	channel := &models.PaymentChannel{
+		ProviderType:    constants.PaymentProviderBepusdt,
+		ChannelType:     constants.PaymentProviderBepusdt,
+		InteractionMode: constants.PaymentInteractionQR,
+		ConfigJSON: models.JSON{
+			"gateway_url": "https://bepusdt.example.com",
+			"auth_token":  "token-001",
+			"order_mode":  constants.PaymentBepusdtOrderModeCashier,
+			"notify_url":  "https://api.example.com/api/v1/payments/callback",
+			"return_url":  "https://shop.example.com/pay",
+		},
+	}
+	if err := svc.ValidateChannel(channel); err == nil {
+		t.Fatal("ValidateChannel should reject bepusdt cashier + qr")
+	}
+}
+
 func TestValidateChannelAllowsUnlimitedMaxAmount(t *testing.T) {
 	svc, _ := setupPaymentServiceWalletTest(t)
 	channel := &models.PaymentChannel{

--- a/internal/service/payment_service_gateway_order_test.go
+++ b/internal/service/payment_service_gateway_order_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 type emptyProviderRefProvider struct {
-	onCreate func(provider.CreateInput)
+	onCreate           func(provider.CreateInput)
+	displayChannelType string
 }
 
 func (p emptyProviderRefProvider) Type() string {
@@ -33,7 +34,8 @@ func (p emptyProviderRefProvider) CreatePayment(_ context.Context, _ models.JSON
 		p.onCreate(input)
 	}
 	return &provider.CreateResult{
-		QRCodeURL: "weixin://wxpay/bizpayurl?pr=test",
+		QRCodeURL:          "weixin://wxpay/bizpayurl?pr=test",
+		DisplayChannelType: p.displayChannelType,
 	}, nil
 }
 
@@ -215,6 +217,81 @@ func TestApplyProviderPaymentFallsBackToWechatGatewayOrderNoWhenProviderRefEmpty
 	}
 	if payment.ProviderRef == order.OrderNo {
 		t.Fatalf("provider ref should not fall back to business order no")
+	}
+}
+
+func TestApplyProviderPaymentStoresDisplayChannelType(t *testing.T) {
+	svc, db := setupPaymentServiceWalletTest(t)
+	now := time.Now()
+
+	order := &models.Order{
+		OrderNo:                 "DJTESTDISPLAY001",
+		UserID:                  1,
+		Status:                  constants.OrderStatusPendingPayment,
+		Currency:                "CNY",
+		OriginalAmount:          models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+		DiscountAmount:          models.NewMoneyFromDecimal(decimal.Zero),
+		PromotionDiscountAmount: models.NewMoneyFromDecimal(decimal.Zero),
+		TotalAmount:             models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+		WalletPaidAmount:        models.NewMoneyFromDecimal(decimal.Zero),
+		OnlinePaidAmount:        models.NewMoneyFromDecimal(decimal.NewFromInt(10)),
+		RefundedAmount:          models.NewMoneyFromDecimal(decimal.Zero),
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}
+	if err := db.Create(order).Error; err != nil {
+		t.Fatalf("create order failed: %v", err)
+	}
+
+	channel := &models.PaymentChannel{
+		ProviderType:    constants.PaymentProviderOfficial,
+		ChannelType:     constants.PaymentChannelTypeWechat,
+		InteractionMode: constants.PaymentInteractionQR,
+		FeeRate:         models.NewMoneyFromDecimal(decimal.Zero),
+		ConfigJSON: models.JSON{
+			"notify_url": "https://api.example.com/api/v1/payments/callback",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := db.Create(channel).Error; err != nil {
+		t.Fatalf("create channel failed: %v", err)
+	}
+
+	payment := &models.Payment{
+		OrderID:         order.ID,
+		ChannelID:       channel.ID,
+		ProviderType:    channel.ProviderType,
+		ChannelType:     channel.ChannelType,
+		InteractionMode: channel.InteractionMode,
+		Amount:          models.NewMoneyFromDecimal(decimal.RequireFromString("10.00")),
+		FeeRate:         models.NewMoneyFromDecimal(decimal.Zero),
+		FeeAmount:       models.NewMoneyFromDecimal(decimal.Zero),
+		Currency:        "CNY",
+		Status:          constants.PaymentStatusInitiated,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := db.Create(payment).Error; err != nil {
+		t.Fatalf("create payment failed: %v", err)
+	}
+
+	svc.paymentProviderRegistry.Register(constants.PaymentProviderOfficial, constants.PaymentChannelTypeWechat, emptyProviderRefProvider{
+		displayChannelType: "usdt.arbitrum",
+	})
+
+	if err := svc.applyProviderPayment(CreatePaymentInput{
+		ClientIP: "127.0.0.1",
+		Context:  context.Background(),
+	}, order, channel, payment); err != nil {
+		t.Fatalf("applyProviderPayment failed: %v", err)
+	}
+
+	if payment.ProviderPayload == nil {
+		t.Fatalf("provider payload should be recorded")
+	}
+	if got := payment.ProviderPayload["display_channel_type"]; got != "usdt.arbitrum" {
+		t.Fatalf("display_channel_type = %v, want usdt.arbitrum", got)
 	}
 }
 

--- a/internal/service/payment_service_provider.go
+++ b/internal/service/payment_service_provider.go
@@ -175,6 +175,12 @@ func (s *PaymentService) ValidateChannel(channel *models.PaymentChannel) error {
 		if mode != constants.PaymentInteractionQR && mode != constants.PaymentInteractionRedirect {
 			return ErrPaymentChannelConfigInvalid
 		}
+		if providerType == constants.PaymentProviderBepusdt && mode == constants.PaymentInteractionQR {
+			orderMode := strings.ToLower(strings.TrimSpace(fmt.Sprint(channel.ConfigJSON["order_mode"])))
+			if orderMode == constants.PaymentBepusdtOrderModeCashier {
+				return ErrPaymentChannelConfigInvalid
+			}
+		}
 	}
 
 	if s.paymentProviderRegistry == nil {

--- a/internal/service/payment_service_provider.go
+++ b/internal/service/payment_service_provider.go
@@ -98,6 +98,17 @@ func (s *PaymentService) applyProviderPayment(input CreatePaymentInput, order *m
 	if result.Payload != nil {
 		payment.ProviderPayload = result.Payload
 	}
+	// DisplayChannelType 是 adapter 返回的“展示用渠道类型”。
+	// 例如 BEpusdt 新格式的 payment.channel_type 固定为 bepusdt，
+	// 但交易模式实际展示应使用 config_json.trade_type（如 usdt.arbitrum）。
+	// 这里统一写入 provider_payload.display_channel_type，供通知、后台列表等展示层读取，
+	// 避免修改 payment.channel_type 的数据库语义。
+	if displayChannelType := strings.TrimSpace(result.DisplayChannelType); displayChannelType != "" {
+		if payment.ProviderPayload == nil {
+			payment.ProviderPayload = models.JSON{}
+		}
+		payment.ProviderPayload["display_channel_type"] = displayChannelType
+	}
 	// P1.2c: 用 wrapper 转换后的 amount/currency 更新 payment 记录，
 	// 保持 DB 状态与实际发给网关的金额/币种一致（P1.2c Task 1 把 conversion 下沉到 wrapper）。
 	if strings.TrimSpace(result.CurrencySent) != "" {


### PR DESCRIPTION
为 BEpusdt 和 Epusdt 支付方式，添加“收银台”模式

1. 添加收银台模式支持。

epusdt 与 bepusdt，显示一个“订单接口模式”下拉框，可选值“(B)Epusdt 收银台”、“指定交易类型”。如果是选择收银台模式，则应隐藏 代币、网络、支付币种 不需要指定。

2. epusdt 新增/编辑渠道弹窗，不应显示“支付方式”下拉框，该下拉框无意义。

3. 目前将 bepusdt 的 `channel_type` 固定为 `bepusdt`; `epusdt` 的 `channel_type` 固定为 `epusdt`。

因为这两个支付方式，币种、网络是多链支持的，为它们建立一比一映射是不现实的，后面它们分别增加了新链支持，i18n 等维护成本较大。

4. 为了能让对应的交易类型在列表中正常显示，需要为 AdminPaymentItem 单独增加一个 `display_channel_type`，该值 `epusdt` 由 `token` 加 `network` 生成；`bepusdt` 是由 `trade_type` 生成。

5. 如果是指定交易类型，则确保 订单、支付渠道、通知、支付记录处，均可正常显示正确的交易类型，例如：`usdt.arbitrum`。如果是收银台，则应正常显示 `(B)Epusdt 收银台` i18n。

6. BEpusdt 添加“限定交易币种”输入框，可自由限定使用 BEPusdt 收银台时，订单可使用的币种。

黑白名单均可，留空则不限制。
例如：
填写 `USDT` 可仅限 `USDT`，别的币种都排除；
填写 `-BNB,-ETH` 则排除 BNB、ETH，其它剩余的币种用户可选。 


关联 admin 前端 PR: https://github.com/dujiao-next/admin/pull/59

图：

<img width="1119" height="1734" alt="screenshot_2026-07-12_14-46-30" src="https://github.com/user-attachments/assets/e5c57e74-efbf-4889-988c-25bac87f97f5" />
<hr>
<img width="1550" height="555" alt="screenshot_2026-07-12_12-50-40" src="https://github.com/user-attachments/assets/fc371627-5101-4498-8c51-8b6a44731dd0" />
<hr>
<img width="1115" height="1047" alt="screenshot_2026-07-12_16-15-57" src="https://github.com/user-attachments/assets/2b699792-bb4f-4eb0-a556-4846c3042138" />


看一下新版的 BEpusdt 收银台是什么样子的（客户可自行切换自己可以付款的支付币种、网络）：

<img width="500" height="647" alt="checkout" src="https://github.com/user-attachments/assets/83331610-5f80-463e-b013-51e964cd1c65" />



