### PR TITLE
feat: 支持 none/prefix 两种 URL 语言模式

### DIFF
--- a/internal/http/handlers/public/public.go
+++ b/internal/http/handlers/public/public.go
@@ -276,6 +276,7 @@ func (h *Handler) GetConfig(c *gin.Context) {
 		"languages":                              append([]string(nil), constants.SupportedLocales...),
 		constants.SettingFieldSiteCurrency:       constants.SiteCurrencyDefault,
 		constants.SettingFieldStorefrontTemplate: constants.StorefrontTemplateDefault,
+		"locale_url_mode":                        "none",
 		"contact": map[string]interface{}{
 			"telegram": "https://telegram.me/dujiaoka",
 			"whatsapp": "https://wa.me/1234567890",

--- a/internal/http/handlers/public/sitemap.go
+++ b/internal/http/handlers/public/sitemap.go
@@ -16,7 +16,15 @@ func (h *Handler) GetSitemap(c *gin.Context) {
 	}
 
 	baseURL := h.resolveSitemapBaseURL(c)
-	xmlStr, err := h.SitemapService.Generate(c.Request.Context(), baseURL)
+	localeURLMode := "none"
+	if h.SettingService != nil {
+		if cfg, err := h.SettingService.GetConfig(nil); err == nil {
+			if mode, ok := cfg["locale_url_mode"].(string); ok {
+				localeURLMode = mode
+			}
+		}
+	}
+	xmlStr, err := h.SitemapService.Generate(c.Request.Context(), baseURL, localeURLMode)
 	if err != nil {
 		logger.Errorw("sitemap_generate_failed", "error", err)
 		c.String(500, "internal error")

--- a/internal/service/setting_normalize.go
+++ b/internal/service/setting_normalize.go
@@ -86,6 +86,7 @@ func normalizeSiteSetting(value map[string]interface{}) models.JSON {
 	normalized[constants.SettingFieldSiteCurrency] = normalizeSiteCurrency(value[constants.SettingFieldSiteCurrency])
 	normalized["template_mode"] = normalizeSiteTemplateMode(value["template_mode"])
 	normalized[constants.SettingFieldStorefrontTemplate] = normalizeStorefrontTemplate(value[constants.SettingFieldStorefrontTemplate])
+	normalized["locale_url_mode"] = normalizeLocaleURLMode(value["locale_url_mode"])
 
 	if raw, ok := value["languages"]; ok {
 		normalized["languages"] = normalizeSiteLanguages(raw)
@@ -344,6 +345,15 @@ func normalizeSiteTemplateMode(raw interface{}) string {
 		return "list"
 	}
 	return "card"
+}
+
+// normalizeLocaleURLMode 归一化 URL 语言模式，仅允许 "none" 或 "prefix"，默认 "none"。
+func normalizeLocaleURLMode(raw interface{}) string {
+	mode := normalizeSettingText(raw)
+	if mode == "prefix" {
+		return "prefix"
+	}
+	return "none"
 }
 
 // normalizeStorefrontTemplate 归一化店面模板，允许 "classic" 或 "vault"，默认 "classic"。

--- a/internal/service/sitemap_service.go
+++ b/internal/service/sitemap_service.go
@@ -12,6 +12,16 @@ import (
 	"github.com/dujiao-next/internal/repository"
 )
 
+// localeHreflang 前缀模式下的 locale 段 → hreflang 值映射
+var localeHreflangMap = []struct {
+	Short string
+	Full  string
+}{
+	{"zh", "zh-CN"},
+	{"en", "en-US"},
+	{"tw", "zh-TW"},
+}
+
 // SitemapService 生成 sitemap.xml / robots.txt 内容
 type SitemapService struct {
 	productRepo  repository.ProductRepository
@@ -39,23 +49,24 @@ const (
 )
 
 // Generate 生成 sitemap.xml 内容；baseURL 必须是不带尾斜杠的站点根（如 https://example.com）
-func (s *SitemapService) Generate(ctx context.Context, baseURL string) (string, error) {
+// localeURLMode 为 "prefix" 时使用 hreflang 多语言扩展
+func (s *SitemapService) Generate(ctx context.Context, baseURL, localeURLMode string) (string, error) {
 	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
 	if baseURL == "" {
 		return "", fmt.Errorf("sitemap: empty base url")
 	}
 
-	cacheKey := sitemapCachePrefix + baseURL
+	cacheKey := sitemapCachePrefix + baseURL + ":" + localeURLMode
 	if cached, err := cache.GetString(ctx, cacheKey); err == nil && cached != "" {
 		return cached, nil
 	}
 
-	entries, err := s.collectURLs(baseURL)
+	entries, err := s.collectURLs(baseURL, localeURLMode)
 	if err != nil {
 		return "", err
 	}
 
-	xmlStr, err := renderSitemapXML(entries)
+	xmlStr, err := renderSitemapXML(entries, localeURLMode)
 	if err != nil {
 		return "", err
 	}
@@ -95,17 +106,59 @@ type urlEntry struct {
 	LastMod    string   `xml:"lastmod,omitempty"`
 	ChangeFreq string   `xml:"changefreq,omitempty"`
 	Priority   string   `xml:"priority,omitempty"`
+	// hreflang alternate links（仅前缀模式使用）
+	AlternateLinks []xhtmlLink `xml:"http://www.w3.org/1999/xhtml link,omitempty"`
+}
+
+// xhtmlLink XML namespace-aware hreflang alternate link
+type xhtmlLink struct {
+	Rel      string `xml:"rel,attr"`
+	Hreflang string `xml:"hreflang,attr"`
+	Href     string `xml:"href,attr"`
 }
 
 type urlSet struct {
-	XMLName xml.Name   `xml:"urlset"`
-	Xmlns   string     `xml:"xmlns,attr"`
-	URLs    []urlEntry `xml:"url"`
+	XMLName    xml.Name   `xml:"urlset"`
+	Xmlns      string     `xml:"xmlns,attr"`
+	XmlnsXhtml string     `xml:"xmlns:xhtml,attr,omitempty"`
+	URLs       []urlEntry `xml:"url"`
 }
 
-func (s *SitemapService) collectURLs(baseURL string) ([]urlEntry, error) {
+func (s *SitemapService) collectURLs(baseURL, localeURLMode string) ([]urlEntry, error) {
 	now := time.Now().UTC().Format("2006-01-02")
 	entries := make([]urlEntry, 0, 64)
+
+	isPrefix := localeURLMode == "prefix"
+
+	// 辅助：创建带可选 hreflang 的条目
+	makeEntry := func(path, lastMod, changeFreq, priority string) urlEntry {
+		loc := baseURL + path
+		if isPrefix {
+			loc = baseURL + "/zh" + path
+		}
+		entry := urlEntry{
+			Loc:        loc,
+			LastMod:    lastMod,
+			ChangeFreq: changeFreq,
+			Priority:   priority,
+		}
+		if isPrefix {
+			for _, lh := range localeHreflangMap {
+				entry.AlternateLinks = append(entry.AlternateLinks, xhtmlLink{
+					Rel:      "alternate",
+					Hreflang: lh.Full,
+					Href:     baseURL + "/" + lh.Short + path,
+				})
+			}
+			// x-default
+			entry.AlternateLinks = append(entry.AlternateLinks, xhtmlLink{
+				Rel:      "alternate",
+				Hreflang: "x-default",
+				Href:     baseURL + "/zh" + path,
+			})
+		}
+		return entry
+	}
 
 	// 1. 静态页面
 	staticPages := []struct {
@@ -122,12 +175,7 @@ func (s *SitemapService) collectURLs(baseURL string) ([]urlEntry, error) {
 		{"/privacy", "yearly", "0.2"},
 	}
 	for _, p := range staticPages {
-		entries = append(entries, urlEntry{
-			Loc:        baseURL + p.Path,
-			LastMod:    now,
-			ChangeFreq: p.ChangeFreq,
-			Priority:   p.Priority,
-		})
+		entries = append(entries, makeEntry(p.Path, now, p.ChangeFreq, p.Priority))
 	}
 
 	// 2. 启用的分类
@@ -136,15 +184,15 @@ func (s *SitemapService) collectURLs(baseURL string) ([]urlEntry, error) {
 		return nil, fmt.Errorf("sitemap: list categories: %w", err)
 	}
 	for _, cat := range categories {
-		entries = append(entries, urlEntry{
-			Loc:        baseURL + "/categories/" + url.PathEscape(cat.Slug),
-			LastMod:    cat.CreatedAt.UTC().Format("2006-01-02"),
-			ChangeFreq: "weekly",
-			Priority:   "0.7",
-		})
+		entries = append(entries, makeEntry(
+			"/categories/"+url.PathEscape(cat.Slug),
+			cat.CreatedAt.UTC().Format("2006-01-02"),
+			"weekly",
+			"0.7",
+		))
 	}
 
-	// 3. 上架的商品（OnlyActive 已含分类启用过滤）
+	// 3. 上架的商品
 	products, _, err := s.productRepo.List(repository.ProductListFilter{
 		Page:       1,
 		PageSize:   sitemapMaxFetch,
@@ -154,12 +202,12 @@ func (s *SitemapService) collectURLs(baseURL string) ([]urlEntry, error) {
 		return nil, fmt.Errorf("sitemap: list products: %w", err)
 	}
 	for _, p := range products {
-		entries = append(entries, urlEntry{
-			Loc:        baseURL + "/products/" + url.PathEscape(p.Slug),
-			LastMod:    p.UpdatedAt.UTC().Format("2006-01-02"),
-			ChangeFreq: "daily",
-			Priority:   "0.8",
-		})
+		entries = append(entries, makeEntry(
+			"/products/"+url.PathEscape(p.Slug),
+			p.UpdatedAt.UTC().Format("2006-01-02"),
+			"daily",
+			"0.8",
+		))
 	}
 
 	// 4. 已发布的博客 / 公告
@@ -177,22 +225,24 @@ func (s *SitemapService) collectURLs(baseURL string) ([]urlEntry, error) {
 		if post.PublishedAt != nil {
 			lastmod = *post.PublishedAt
 		}
-		// blog 与 notice 共用 /blog/:slug 详情页（user 前台 Notice.vue 跳转到 /blog/{slug}）
-		entries = append(entries, urlEntry{
-			Loc:        baseURL + "/blog/" + url.PathEscape(post.Slug),
-			LastMod:    lastmod.UTC().Format("2006-01-02"),
-			ChangeFreq: "monthly",
-			Priority:   "0.5",
-		})
+		entries = append(entries, makeEntry(
+			"/blog/"+url.PathEscape(post.Slug),
+			lastmod.UTC().Format("2006-01-02"),
+			"monthly",
+			"0.5",
+		))
 	}
 
 	return entries, nil
 }
 
-func renderSitemapXML(entries []urlEntry) (string, error) {
+func renderSitemapXML(entries []urlEntry, localeURLMode string) (string, error) {
 	set := urlSet{
 		Xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9",
 		URLs:  entries,
+	}
+	if localeURLMode == "prefix" {
+		set.XmlnsXhtml = "http://www.w3.org/1999/xhtml"
 	}
 	body, err := xml.MarshalIndent(set, "", "  ")
 	if err != nil {

--- a/internal/service/sitemap_service_test.go
+++ b/internal/service/sitemap_service_test.go
@@ -115,7 +115,7 @@ func TestSitemapServiceIncludesActiveContent(t *testing.T) {
 		t.Fatalf("create draft post: %v", err)
 	}
 
-	xmlStr, err := svc.Generate(context.Background(), "https://example.com")
+	xmlStr, err := svc.Generate(context.Background(), "https://example.com", "none")
 	if err != nil {
 		t.Fatalf("generate failed: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestSitemapServiceGenerateRobotsIncludesSitemapURL(t *testing.T) {
 
 func TestSitemapServiceGenerateRejectsEmptyBaseURL(t *testing.T) {
 	svc, _ := newSitemapServiceForTest(t)
-	if _, err := svc.Generate(context.Background(), ""); err == nil {
+	if _, err := svc.Generate(context.Background(), "", "none"); err == nil {
 		t.Fatalf("expected error for empty base url")
 	}
 }


### PR DESCRIPTION
### 次优化主要针对的是SEO； 如果你需要更详细的，更精确的seo要求。 可以参考此功能



#### 在后台模板配置这里增加 了 URL 语言模式

1、如果选择当前的默认模式。你在前端切换语言，页面语言发生改变。但是 URL 不会发生变动，和当前的前端一致。
2、如果选择前缀模式。那网址会变成这样，拆分了 zh tw en 三个不同的路径。对应的网站语言也发生变动，更符合 seo 要求。
http://localhost:5173/tw/products/11111
http://localhost:5173/zh/products/11111
http://localhost:5173/en/products/11111

<img width="4288" height="2128" alt="image" src="https://github.com/user-attachments/assets/a7558c65-1ac8-4993-9da9-640ccb8ac2a5" />

