### PR TITLE
feat: 新增 Tags API — 标签聚合、筛选与 Sitemap 索引

### DIFF
--- a/internal/http/handlers/channel/channel_catalog.go
+++ b/internal/http/handlers/channel/channel_catalog.go
@@ -130,7 +130,7 @@ func (h *Handler) GetProducts(c *gin.Context) {
 	if exact {
 		products, total, err = h.ProductService.ListPublicExact(categoryID, page, pageSize)
 	} else {
-		products, total, err = h.ProductService.ListPublic(categoryID, "", page, pageSize)
+		products, total, err = h.ProductService.ListPublic(categoryID, "", "", page, pageSize)
 	}
 	if err != nil {
 		logger.Errorw("channel_catalog_list_products", "error", err)

--- a/internal/http/handlers/public/public.go
+++ b/internal/http/handlers/public/public.go
@@ -430,9 +430,10 @@ func (h *Handler) GetProducts(c *gin.Context) {
 	// 获取筛选参数
 	categoryID := c.Query("category_id")
 	search := strings.TrimSpace(c.Query("search"))
+	tag := strings.TrimSpace(c.Query("tag"))
 	tenant := tenantFromRequest(c)
 
-	products, total, err := h.ProductService.ListPublicForTenant(tenant, h.ResellerRepo, categoryID, search, page, pageSize)
+	products, total, err := h.ProductService.ListPublicForTenant(tenant, h.ResellerRepo, categoryID, search, tag, page, pageSize)
 	if err != nil {
 		shared.RespondError(c, response.CodeInternal, "error.product_fetch_failed", err)
 		return
@@ -1001,6 +1002,17 @@ func (h *Handler) GetCategories(c *gin.Context) {
 	}
 
 	response.Success(c, dto.NewCategoryRespList(categories))
+}
+
+// GetTags 获取所有去重标签列表
+func (h *Handler) GetTags(c *gin.Context) {
+	tenant := tenantFromRequest(c)
+	tags, err := h.ProductService.ListUniqueTags(tenant, h.ResellerRepo)
+	if err != nil {
+		shared.RespondError(c, response.CodeInternal, "error.tag_fetch_failed", err)
+		return
+	}
+	response.Success(c, tags)
 }
 
 // CreateGuestOrderRequest 游客下单请求

--- a/internal/http/handlers/public/sitemap.go
+++ b/internal/http/handlers/public/sitemap.go
@@ -16,7 +16,15 @@ func (h *Handler) GetSitemap(c *gin.Context) {
 	}
 
 	baseURL := h.resolveSitemapBaseURL(c)
-	xmlStr, err := h.SitemapService.Generate(c.Request.Context(), baseURL)
+	localeURLMode := "none"
+	if h.SettingService != nil {
+		if cfg, err := h.SettingService.GetConfig(nil); err == nil {
+			if mode, ok := cfg["locale_url_mode"].(string); ok {
+				localeURLMode = mode
+			}
+		}
+	}
+	xmlStr, err := h.SitemapService.Generate(c.Request.Context(), baseURL, localeURLMode)
 	if err != nil {
 		logger.Errorw("sitemap_generate_failed", "error", err)
 		c.String(500, "internal error")

--- a/internal/models/category.go
+++ b/internal/models/category.go
@@ -25,8 +25,13 @@ func (j *JSON) Scan(value interface{}) error {
 		*j = make(JSON)
 		return nil
 	}
-	bytes, ok := value.([]byte)
-	if !ok {
+	var bytes []byte
+	switch v := value.(type) {
+	case []byte:
+		bytes = v
+	case string:
+		bytes = []byte(v)
+	default:
 		return nil
 	}
 	return json.Unmarshal(bytes, j)

--- a/internal/repository/product_repository.go
+++ b/internal/repository/product_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -29,6 +30,7 @@ type ProductRepository interface {
 	QuickUpdate(id string, fields map[string]interface{}) error
 	Transaction(fn func(tx *gorm.DB) error) error
 	WithTx(tx *gorm.DB) ProductRepository
+	ListUniqueTags() ([]string, error)
 }
 
 // GormProductRepository GORM 实现
@@ -109,6 +111,13 @@ func (r *GormProductRepository) List(filter ProductListFilter) ([]models.Product
 		} else {
 			query = query.Where(expr + " = 0")
 		}
+	}
+
+	// 按产品标签筛选（products.tags 列，非 seo_meta）
+	tag := strings.TrimSpace(filter.Tag)
+	if tag != "" {
+		expr := jsonArrayContainsExpr(r.db, "tags")
+		query = query.Where(expr, jsonArrayElementParam(r.db, tag))
 	}
 
 	var total int64
@@ -302,6 +311,40 @@ func (r *GormProductRepository) ReserveManualStock(productID uint, quantity int)
 		return 0, result.Error
 	}
 	return result.RowsAffected, nil
+}
+
+// ListUniqueTags 返回所有 active 商品的去重产品标签列表（按字母升序）。
+// 注意：读取 products.tags 产品分类标签，非 products.seo_meta SEO 标签。
+func (r *GormProductRepository) ListUniqueTags() ([]string, error) {
+	type tagRow struct {
+		Tags models.StringArray `gorm:"column:tags"`
+	}
+	var rows []tagRow
+	if err := r.db.Model(&models.Product{}).
+		Select("tags").
+		Where("is_active = ?", true).
+		Where("EXISTS (SELECT 1 FROM categories c WHERE c.id = products.category_id AND c.is_active = ? AND c.deleted_at IS NULL)", true).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	for _, row := range rows {
+		for _, t := range row.Tags {
+			t = strings.TrimSpace(t)
+			if t == "" {
+				continue
+			}
+			seen[t] = struct{}{}
+		}
+	}
+
+	result := make([]string, 0, len(seen))
+	for t := range seen {
+		result = append(result, t)
+	}
+	sort.Strings(result)
+	return result, nil
 }
 
 // ReleaseManualStock 释放手动库存占用

--- a/internal/repository/sql_dialect.go
+++ b/internal/repository/sql_dialect.go
@@ -43,6 +43,37 @@ func jsonArrayLengthExprByDialect(dialect, column string) string {
 	}
 }
 
+// jsonArrayContainsExpr 构建 JSON 数组元素包含查询表达式，兼容 sqlite 与 postgres。
+// 返回的表达式含一个 ? 占位符，匹配值需通过 jsonArrayElementParam 获取。
+func jsonArrayContainsExpr(db *gorm.DB, column string) string {
+	return jsonArrayContainsExprByDialect(dbDialectName(db), column)
+}
+
+// jsonArrayElementParam 将匹配值适配为目标数据库的 JSON 数组元素参数值。
+// PostgreSQL: 原始字符串（jsonb_array_elements_text 自动解码）。
+// SQLite:     原始字符串（json_each 的 value 列在 = 比较时返回解码值）。
+func jsonArrayElementParam(db *gorm.DB, value string) interface{} {
+	return jsonArrayElementParamByDialect(dbDialectName(db), value)
+}
+
+func jsonArrayContainsExprByDialect(dialect, column string) string {
+	switch strings.ToLower(strings.TrimSpace(dialect)) {
+	case "postgres", "postgresql":
+		return fmt.Sprintf("EXISTS (SELECT 1 FROM jsonb_array_elements_text(%s::jsonb) AS t WHERE t = ?)", column)
+	default:
+		return fmt.Sprintf("EXISTS (SELECT 1 FROM json_each(%s) WHERE json_each.value = ?)", column)
+	}
+}
+
+func jsonArrayElementParamByDialect(dialect, value string) interface{} {
+	switch strings.ToLower(strings.TrimSpace(dialect)) {
+	case "postgres", "postgresql":
+		return value
+	default:
+		return value
+	}
+}
+
 func jsonTextExprByDialect(dialect, column, key string) string {
 	switch strings.ToLower(strings.TrimSpace(dialect)) {
 	case "postgres", "postgresql":

--- a/internal/repository/types.go
+++ b/internal/repository/types.go
@@ -24,7 +24,8 @@ type ProductListFilter struct {
 	FulfillmentType    string
 	StockStatus        string
 	HasWholesalePrices *bool
-	LowStockThreshold  int // 低库存阈值
+	Tag                string // 按标签 JSON 数组包含筛选
+	LowStockThreshold  int    // 低库存阈值
 	OnlyActive         bool
 	WithCategory       bool
 	UpdatedAfter       *time.Time // 仅返回此时间之后更新的商品

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -96,6 +96,7 @@ func SetupRouter(cfg *config.Config, c *provider.Container) *gin.Engine {
 			public.GET("/posts/:slug", publicHandler.GetPostBySlug)
 			public.GET("/banners", publicHandler.GetPublicBanners)
 			public.GET("/categories", publicHandler.GetCategories)
+			public.GET("/tags", publicHandler.GetTags)
 			public.GET("/captcha/image", publicHandler.GetImageCaptcha)
 			public.POST("/affiliate/click", publicHandler.TrackAffiliateClick)
 			public.GET("/member-levels", publicHandler.GetPublicMemberLevels)

--- a/internal/service/product_reseller_public_test.go
+++ b/internal/service/product_reseller_public_test.go
@@ -138,7 +138,7 @@ func TestProductServiceListPublicForTenantExcludesResellerHiddenProductsBeforePa
 	createResellerPublicSetting(t, db, models.ResellerProductSetting{ResellerID: profile.ID, ProductID: partialSKUHidden.ID, SKUID: partialHiddenSKUs[0].ID, IsListed: false, PricingMode: models.ResellerPricingModeInherit})
 
 	tenant := ResellerTenantContext("shop.example.test", profile.ID, owner.ID, "shop.example.test")
-	rows, total, err := svc.ListPublicForTenant(tenant, resellerRepo, "", "", 1, 20)
+	rows, total, err := svc.ListPublicForTenant(tenant, resellerRepo, "", "", "", 1, 20)
 	if err != nil {
 		t.Fatalf("ListPublicForTenant failed: %v", err)
 	}

--- a/internal/service/product_service.go
+++ b/internal/service/product_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -150,7 +151,7 @@ type ProductSKUInput struct {
 }
 
 // ListPublic 获取公开商品列表
-func (s *ProductService) ListPublic(categoryID, search string, page, pageSize int) ([]models.Product, int64, error) {
+func (s *ProductService) ListPublic(categoryID, search, tag string, page, pageSize int) ([]models.Product, int64, error) {
 	categoryIDs, err := expandPublicCategoryIDs(s.categoryRepo, categoryID)
 	if err != nil {
 		return nil, 0, err
@@ -162,6 +163,7 @@ func (s *ProductService) ListPublic(categoryID, search string, page, pageSize in
 		CategoryID:   categoryID,
 		CategoryIDs:  categoryIDs,
 		Search:       search,
+		Tag:          tag,
 		OnlyActive:   true,
 		WithCategory: true,
 	}
@@ -169,9 +171,9 @@ func (s *ProductService) ListPublic(categoryID, search string, page, pageSize in
 }
 
 // ListPublicForTenant 获取当前租户上下文的公开商品列表。
-func (s *ProductService) ListPublicForTenant(tenant TenantContext, resellerRepo repository.ResellerRepository, categoryID, search string, page, pageSize int) ([]models.Product, int64, error) {
+func (s *ProductService) ListPublicForTenant(tenant TenantContext, resellerRepo repository.ResellerRepository, categoryID, search, tag string, page, pageSize int) ([]models.Product, int64, error) {
 	if !isResellerOrderContext(tenant) {
-		return s.ListPublic(categoryID, search, page, pageSize)
+		return s.ListPublic(categoryID, search, tag, page, pageSize)
 	}
 	if tenant.ResellerID == nil || resellerRepo == nil {
 		return nil, 0, ErrResellerProductNotListed
@@ -190,11 +192,59 @@ func (s *ProductService) ListPublicForTenant(tenant TenantContext, resellerRepo 
 		CategoryID:        categoryID,
 		CategoryIDs:       categoryIDs,
 		Search:            search,
+		Tag:               tag,
 		OnlyActive:        true,
 		WithCategory:      true,
 		ExcludeProductIDs: hiddenIDs,
 	}
 	return s.repo.List(filter)
+}
+
+// ListUniqueTags 返回当前租户下所有 active 商品的去重标签列表。
+func (s *ProductService) ListUniqueTags(tenant TenantContext, resellerRepo repository.ResellerRepository) ([]string, error) {
+	tags, err := s.repo.ListUniqueTags()
+	if err != nil {
+		return nil, err
+	}
+	if !isResellerOrderContext(tenant) || tenant.ResellerID == nil || resellerRepo == nil {
+		return tags, nil
+	}
+	hiddenIDs, err := resellerRepo.ListHiddenProductIDs(*tenant.ResellerID)
+	if err != nil {
+		return nil, err
+	}
+	if len(hiddenIDs) == 0 {
+		return tags, nil
+	}
+	// 分销商场景：过滤掉仅存在于被隐藏商品中的 tag
+	hiddenSet := make(map[uint]struct{}, len(hiddenIDs))
+	for _, id := range hiddenIDs {
+		hiddenSet[id] = struct{}{}
+	}
+	visibleProducts, _, err := s.repo.List(repository.ProductListFilter{
+		Page:              1,
+		PageSize:          len(hiddenIDs) + len(tags),
+		OnlyActive:        true,
+		ExcludeProductIDs: hiddenIDs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	visibleTags := make(map[string]struct{})
+	for _, p := range visibleProducts {
+		for _, t := range p.Tags {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				visibleTags[t] = struct{}{}
+			}
+		}
+	}
+	result := make([]string, 0, len(visibleTags))
+	for t := range visibleTags {
+		result = append(result, t)
+	}
+	sort.Strings(result)
+	return result, nil
 }
 
 // ListForUpstreamSync 上游同步专用：可选包含已下架商品，便于下游识别下架状态

--- a/internal/service/product_service_test.go
+++ b/internal/service/product_service_test.go
@@ -332,7 +332,7 @@ func TestProductServiceListPublicIncludesChildProductsForParentCategory(t *testi
 		t.Fatalf("create child product failed: %v", err)
 	}
 
-	products, total, err := svc.ListPublic(strconv.FormatUint(uint64(parent.ID), 10), "", 1, 20)
+	products, total, err := svc.ListPublic(strconv.FormatUint(uint64(parent.ID), 10), "", "", 1, 20)
 	if err != nil {
 		t.Fatalf("list public products failed: %v", err)
 	}
@@ -445,10 +445,12 @@ func TestProductServiceListPublicSortOrderDescending(t *testing.T) {
 		t.Fatalf("create low sort product failed: %v", err)
 	}
 
-	rows, total, err := svc.ListPublic("", "", 1, 20)
+	rows, total, err := svc.ListPublic("", "", "", 1, 20)
 	if err != nil {
 		t.Fatalf("list public products failed: %v", err)
 	}
+
+	// 验证排序：sort_order 大的在前
 	if total != 2 {
 		t.Fatalf("expected total=2, got %d", total)
 	}
@@ -507,7 +509,7 @@ func TestProductServiceListPublicSortsSKUsDescending(t *testing.T) {
 		t.Fatalf("create low sort sku failed: %v", err)
 	}
 
-	rows, total, err := svc.ListPublic("", "", 1, 20)
+	rows, total, err := svc.ListPublic("", "", "", 1, 20)
 	if err != nil {
 		t.Fatalf("list public products failed: %v", err)
 	}

--- a/internal/service/sitemap_service.go
+++ b/internal/service/sitemap_service.go
@@ -12,6 +12,16 @@ import (
 	"github.com/dujiao-next/internal/repository"
 )
 
+// localeHreflangMap 前缀模式下的 locale 段 → hreflang 值映射
+var localeHreflangMap = []struct {
+	Short string
+	Full  string
+}{
+	{"zh", "zh-CN"},
+	{"en", "en-US"},
+	{"tw", "zh-TW"},
+}
+
 // SitemapService 生成 sitemap.xml / robots.txt 内容
 type SitemapService struct {
 	productRepo  repository.ProductRepository
@@ -38,24 +48,24 @@ const (
 	sitemapMaxFetch    = 50000 // 单次拉取上限，避免极端数据量打爆内存
 )
 
-// Generate 生成 sitemap.xml 内容；baseURL 必须是不带尾斜杠的站点根（如 https://example.com）
-func (s *SitemapService) Generate(ctx context.Context, baseURL string) (string, error) {
+// Generate 生成 sitemap.xml（带缓存）
+func (s *SitemapService) Generate(ctx context.Context, baseURL, localeURLMode string) (string, error) {
 	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
 	if baseURL == "" {
-		return "", fmt.Errorf("sitemap: empty base url")
+		return "", fmt.Errorf("sitemap: baseURL is empty")
 	}
 
-	cacheKey := sitemapCachePrefix + baseURL
+	cacheKey := sitemapCachePrefix + baseURL + ":" + localeURLMode
 	if cached, err := cache.GetString(ctx, cacheKey); err == nil && cached != "" {
 		return cached, nil
 	}
 
-	entries, err := s.collectURLs(baseURL)
+	entries, err := s.collectURLs(baseURL, localeURLMode)
 	if err != nil {
 		return "", err
 	}
 
-	xmlStr, err := renderSitemapXML(entries)
+	xmlStr, err := renderSitemapXML(entries, localeURLMode)
 	if err != nil {
 		return "", err
 	}
@@ -90,22 +100,62 @@ func (s *SitemapService) GenerateRobots(baseURL string) string {
 
 // urlEntry sitemap.xml 中的单条 URL
 type urlEntry struct {
-	XMLName    xml.Name `xml:"url"`
-	Loc        string   `xml:"loc"`
-	LastMod    string   `xml:"lastmod,omitempty"`
-	ChangeFreq string   `xml:"changefreq,omitempty"`
-	Priority   string   `xml:"priority,omitempty"`
+	XMLName        xml.Name    `xml:"url"`
+	Loc            string      `xml:"loc"`
+	LastMod        string      `xml:"lastmod,omitempty"`
+	ChangeFreq     string      `xml:"changefreq,omitempty"`
+	Priority       string      `xml:"priority,omitempty"`
+	AlternateLinks []xhtmlLink `xml:"http://www.w3.org/1999/xhtml link,omitempty"`
+}
+
+type xhtmlLink struct {
+	XMLName  xml.Name `xml:"http://www.w3.org/1999/xhtml link"`
+	Rel      string   `xml:"rel,attr"`
+	Hreflang string   `xml:"hreflang,attr"`
+	Href     string   `xml:"href,attr"`
 }
 
 type urlSet struct {
-	XMLName xml.Name   `xml:"urlset"`
-	Xmlns   string     `xml:"xmlns,attr"`
-	URLs    []urlEntry `xml:"url"`
+	XMLName    xml.Name   `xml:"urlset"`
+	Xmlns      string     `xml:"xmlns,attr"`
+	XmlnsXhtml string     `xml:"xmlns:xhtml,attr,omitempty"`
+	URLs       []urlEntry `xml:"url"`
 }
 
-func (s *SitemapService) collectURLs(baseURL string) ([]urlEntry, error) {
+func (s *SitemapService) collectURLs(baseURL, localeURLMode string) ([]urlEntry, error) {
 	now := time.Now().UTC().Format("2006-01-02")
 	entries := make([]urlEntry, 0, 64)
+
+	isPrefix := localeURLMode == "prefix"
+
+	// 辅助：创建带可选 hreflang 的条目
+	makeEntry := func(path, lastMod, changeFreq, priority string) urlEntry {
+		loc := baseURL + path
+		if isPrefix {
+			loc = baseURL + "/zh" + path
+		}
+		entry := urlEntry{
+			Loc:        loc,
+			LastMod:    lastMod,
+			ChangeFreq: changeFreq,
+			Priority:   priority,
+		}
+		if isPrefix {
+			for _, lh := range localeHreflangMap {
+				entry.AlternateLinks = append(entry.AlternateLinks, xhtmlLink{
+					Rel:      "alternate",
+					Hreflang: lh.Full,
+					Href:     baseURL + "/" + lh.Short + path,
+				})
+			}
+			entry.AlternateLinks = append(entry.AlternateLinks, xhtmlLink{
+				Rel:      "alternate",
+				Hreflang: "x-default",
+				Href:     baseURL + "/zh" + path,
+			})
+		}
+		return entry
+	}
 
 	// 1. 静态页面
 	staticPages := []struct {
@@ -122,12 +172,7 @@ func (s *SitemapService) collectURLs(baseURL string) ([]urlEntry, error) {
 		{"/privacy", "yearly", "0.2"},
 	}
 	for _, p := range staticPages {
-		entries = append(entries, urlEntry{
-			Loc:        baseURL + p.Path,
-			LastMod:    now,
-			ChangeFreq: p.ChangeFreq,
-			Priority:   p.Priority,
-		})
+		entries = append(entries, makeEntry(p.Path, now, p.ChangeFreq, p.Priority))
 	}
 
 	// 2. 启用的分类
@@ -136,15 +181,15 @@ func (s *SitemapService) collectURLs(baseURL string) ([]urlEntry, error) {
 		return nil, fmt.Errorf("sitemap: list categories: %w", err)
 	}
 	for _, cat := range categories {
-		entries = append(entries, urlEntry{
-			Loc:        baseURL + "/categories/" + url.PathEscape(cat.Slug),
-			LastMod:    cat.CreatedAt.UTC().Format("2006-01-02"),
-			ChangeFreq: "weekly",
-			Priority:   "0.7",
-		})
+		entries = append(entries, makeEntry(
+			"/categories/"+url.PathEscape(cat.Slug),
+			cat.CreatedAt.UTC().Format("2006-01-02"),
+			"weekly",
+			"0.7",
+		))
 	}
 
-	// 3. 上架的商品（OnlyActive 已含分类启用过滤）
+	// 3. 上架的商品
 	products, _, err := s.productRepo.List(repository.ProductListFilter{
 		Page:       1,
 		PageSize:   sitemapMaxFetch,
@@ -154,12 +199,12 @@ func (s *SitemapService) collectURLs(baseURL string) ([]urlEntry, error) {
 		return nil, fmt.Errorf("sitemap: list products: %w", err)
 	}
 	for _, p := range products {
-		entries = append(entries, urlEntry{
-			Loc:        baseURL + "/products/" + url.PathEscape(p.Slug),
-			LastMod:    p.UpdatedAt.UTC().Format("2006-01-02"),
-			ChangeFreq: "daily",
-			Priority:   "0.8",
-		})
+		entries = append(entries, makeEntry(
+			"/products/"+url.PathEscape(p.Slug),
+			p.UpdatedAt.UTC().Format("2006-01-02"),
+			"daily",
+			"0.8",
+		))
 	}
 
 	// 4. 已发布的博客 / 公告
@@ -177,22 +222,38 @@ func (s *SitemapService) collectURLs(baseURL string) ([]urlEntry, error) {
 		if post.PublishedAt != nil {
 			lastmod = *post.PublishedAt
 		}
-		// blog 与 notice 共用 /blog/:slug 详情页（user 前台 Notice.vue 跳转到 /blog/{slug}）
-		entries = append(entries, urlEntry{
-			Loc:        baseURL + "/blog/" + url.PathEscape(post.Slug),
-			LastMod:    lastmod.UTC().Format("2006-01-02"),
-			ChangeFreq: "monthly",
-			Priority:   "0.5",
-		})
+		entries = append(entries, makeEntry(
+			"/blog/"+url.PathEscape(post.Slug),
+			lastmod.UTC().Format("2006-01-02"),
+			"monthly",
+			"0.5",
+		))
+	}
+
+	// 5. Tag 页面
+	tags, err := s.productRepo.ListUniqueTags()
+	if err != nil {
+		return nil, fmt.Errorf("sitemap: list unique tags: %w", err)
+	}
+	for _, tag := range tags {
+		entries = append(entries, makeEntry(
+			"/tag/"+url.PathEscape(tag),
+			now,
+			"daily",
+			"0.5",
+		))
 	}
 
 	return entries, nil
 }
 
-func renderSitemapXML(entries []urlEntry) (string, error) {
+func renderSitemapXML(entries []urlEntry, localeURLMode string) (string, error) {
 	set := urlSet{
 		Xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9",
 		URLs:  entries,
+	}
+	if localeURLMode == "prefix" {
+		set.XmlnsXhtml = "http://www.w3.org/1999/xhtml"
 	}
 	body, err := xml.MarshalIndent(set, "", "  ")
 	if err != nil {

--- a/internal/service/sitemap_service_test.go
+++ b/internal/service/sitemap_service_test.go
@@ -115,7 +115,7 @@ func TestSitemapServiceIncludesActiveContent(t *testing.T) {
 		t.Fatalf("create draft post: %v", err)
 	}
 
-	xmlStr, err := svc.Generate(context.Background(), "https://example.com")
+	xmlStr, err := svc.Generate(context.Background(), "https://example.com", "none")
 	if err != nil {
 		t.Fatalf("generate failed: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestSitemapServiceGenerateRobotsIncludesSitemapURL(t *testing.T) {
 
 func TestSitemapServiceGenerateRejectsEmptyBaseURL(t *testing.T) {
 	svc, _ := newSitemapServiceForTest(t)
-	if _, err := svc.Generate(context.Background(), ""); err == nil {
+	if _, err := svc.Generate(context.Background(), "", "none"); err == nil {
 		t.Fatalf("expected error for empty base url")
 	}
 }


### PR DESCRIPTION
### dujiao的商品目前是默认支持 tag的，但是 只是在商品页面进行了调用。 没有单独的tag接口。无法发挥tag的更多作用。

### 此次更新是为tag增加单独的 api接口。并优化到了sitemap里面。前端可以根据 tag 来单独调用所属分类等，可以给更多自定义空间，对有 tag 需求的来说 增加了一些 自由度。 

### 此次更新只涉及到了 api 后端。user 前端 暂时没有为 tag 设计单独页面。 有需要的可以根据接口自行修改前端 user 来实现对应功能。 

### API 调用文档

| 端点 | 方法 | 说明 |
|------|------|------|
| `/api/v1/public/tags` | GET | 获取全站产品标签列表 |
| `/api/v1/public/products?tag=xxx` | GET | 按标签筛选商品 |

**GET `/api/v1/public/tags`**

响应：`data` 为 `[]string`，字母升序，无 tag 时返回 `[]`

```json
{ "status_code": 0, "msg": "success", "data": ["包邮", "折扣", "推荐", "热门", ...] }
```

**GET `/api/v1/public/products?tag=xxx`**

响应结构与现有 `/products` 完全一致，分页 meta 不变

```bash
curl 'http://host:8080/api/v1/public/products?tag=热门'
curl 'http://host:8080/api/v1/public/products?tag=热门&category_id=10&page=1&page_size=20'
```

- `tag` 与 `category_id` / `search` / `page` / `page_size` 可自由组合（AND 关系）
- `tag=` 空值等效于不传，返回全部商品
- `tag=nonexistent` 返回 `data: [], pagination.total: 0`

**GET `/sitemap.xml`**

自动包含每个标签的 URL 条目：

```xml
<url>
  <loc>/tag/%E7%83%AD%E9%97%A8</loc>
  <changefreq>daily</changefreq>
  <priority>0.5</priority>
</url>
```