### PR TITLE
feat: 管理后台商品列表增加"商品状态"筛选（已上架/已下架/全部）

### DIFF
--- a/internal/http/handlers/admin/admin_product.go
+++ b/internal/http/handlers/admin/admin_product.go
@@ -40,7 +40,7 @@ func (h *Handler) GetAdminProducts(c *gin.Context) {
 	}
 
 	lowStockThreshold := h.SettingService.GetDashboardLowStockThreshold()
-	products, total, err := h.ProductService.ListAdmin(categoryID, search, fulfillmentType, stockStatus, hasWholesalePrices, lowStockThreshold, page, pageSize)
+	products, total, err := h.ProductService.ListAdmin(categoryID, search, fulfillmentType, stockStatus, hasWholesalePrices, lowStockThreshold, page, pageSize, normalizeActiveStatus(c.Query("active_status")))
 	if err != nil {
 		shared.RespondError(c, response.CodeInternal, "error.product_fetch_failed", err)
 		return
@@ -74,6 +74,18 @@ func parseWholesaleFilter(raw string) (*bool, error) {
 			return nil, err
 		}
 		return &parsed, nil
+	}
+}
+
+func normalizeActiveStatus(raw string) string {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	switch value {
+	case "active", "listed":
+		return "active"
+	case "inactive", "unlisted":
+		return "inactive"
+	default:
+		return ""
 	}
 }
 

--- a/internal/repository/product_repository.go
+++ b/internal/repository/product_repository.go
@@ -68,6 +68,9 @@ func (r *GormProductRepository) List(filter ProductListFilter) ([]models.Product
 			return db.Order("sort_order DESC, id ASC")
 		})
 	}
+	if filter.ActiveStatus != "" {
+		query = query.Where("products.is_active = ?", filter.ActiveStatus == "active")
+	}
 	if len(filter.CategoryIDs) > 0 {
 		query = query.Where("category_id IN ?", filter.CategoryIDs)
 	} else if filter.CategoryID != "" {

--- a/internal/repository/types.go
+++ b/internal/repository/types.go
@@ -26,6 +26,7 @@ type ProductListFilter struct {
 	HasWholesalePrices *bool
 	LowStockThreshold  int // 低库存阈值
 	OnlyActive         bool
+	ActiveStatus       string // ""=全部, "active"=已上架, "inactive"=已下架
 	WithCategory       bool
 	UpdatedAfter       *time.Time // 仅返回此时间之后更新的商品
 }

--- a/internal/service/product_service.go
+++ b/internal/service/product_service.go
@@ -259,7 +259,7 @@ func (s *ProductService) GetPublicBySlugForTenant(tenant TenantContext, reseller
 }
 
 // ListAdmin 获取后台商品列表
-func (s *ProductService) ListAdmin(categoryID, search, fulfillmentType, stockStatus string, hasWholesalePrices *bool, lowStockThreshold int, page, pageSize int) ([]models.Product, int64, error) {
+func (s *ProductService) ListAdmin(categoryID, search, fulfillmentType, stockStatus string, hasWholesalePrices *bool, lowStockThreshold int, page, pageSize int, activeStatus string) ([]models.Product, int64, error) {
 	filter := repository.ProductListFilter{
 		Page:               page,
 		PageSize:           pageSize,
@@ -270,6 +270,7 @@ func (s *ProductService) ListAdmin(categoryID, search, fulfillmentType, stockSta
 		HasWholesalePrices: hasWholesalePrices,
 		LowStockThreshold:  lowStockThreshold,
 		OnlyActive:         false,
+		ActiveStatus:       activeStatus,
 		WithCategory:       true,
 	}
 	return s.repo.List(filter)


### PR DESCRIPTION
### 商品列表 新增上下架状态筛选
这个功能的初衷是这样的，
因为我产品比较多，出现了  
有库存，但是商品下架状态。
没库存。但是是上架状态的情况。

在产品比较少的情况下，手动筛还行。产品多的情形下，单从库存状态来筛选是完全不够的。
所以增加了上下架状态筛选。 给了更多的筛选条件。

<img width="3620" height="1194" alt="image" src="https://github.com/user-attachments/assets/72dc0664-3253-4e87-b107-d2d90e57dd86" />


