### PR TITLE
fix(paypal): 使用原始 Webhook 请求体进行签名验证

### DIFF
--- a/internal/modules/payment/infrastructure/gateway/adapters/paypal/adapter.go
+++ b/internal/modules/payment/infrastructure/gateway/adapters/paypal/adapter.go
@@ -174,7 +174,7 @@ func (a *paypalAdapter) ParseWebhook(ctx context.Context, raw jsonmap.JSON, head
 		httpHeaders.Set(k, v)
 	}
 
-	if err := paypal.VerifyWebhookSignature(ctx, cfg, httpHeaders, event); err != nil {
+	if err := paypal.VerifyWebhookSignature(ctx, cfg, httpHeaders, body); err != nil {
 		return nil, mapPaypalError(err)
 	}
 

--- a/internal/modules/payment/infrastructure/gateway/paypal/paypal.go
+++ b/internal/modules/payment/infrastructure/gateway/paypal/paypal.go
@@ -110,6 +110,16 @@ type WebhookEvent struct {
 	Raw        map[string]interface{}
 }
 
+type webhookVerifyRequest struct {
+	TransmissionID   string          `json:"transmission_id"`
+	TransmissionTime string          `json:"transmission_time"`
+	CertURL          string          `json:"cert_url"`
+	AuthAlgo         string          `json:"auth_algo"`
+	TransmissionSig  string          `json:"transmission_sig"`
+	WebhookID        string          `json:"webhook_id"`
+	WebhookEvent     json.RawMessage `json:"webhook_event"`
+}
+
 // ParseConfig 解析配置。
 func ParseConfig(raw map[string]interface{}) (*Config, error) {
 	return common.ParseConfig[Config](raw, ErrConfigInvalid)
@@ -272,32 +282,48 @@ func CaptureOrder(ctx context.Context, cfg *Config, orderID string) (*CaptureRes
 }
 
 // VerifyWebhookSignature 校验 PayPal Webhook 签名。
-func VerifyWebhookSignature(
-	ctx context.Context,
-	cfg *Config,
-	headers http.Header,
-	rawEvent []byte,
-) error {
+func VerifyWebhookSignature(ctx context.Context, cfg *Config, headers http.Header, rawEvent []byte) error {
 	if cfg == nil {
 		return fmt.Errorf("%w: config is nil", ErrConfigInvalid)
 	}
-
-	if strings.TrimSpace(cfg.WebhookID) == "" {
+	webhookID := strings.TrimSpace(cfg.WebhookID)
+	if webhookID == "" {
 		return fmt.Errorf("%w: webhook_id is required", ErrConfigInvalid)
 	}
-
 	if len(rawEvent) == 0 {
-		return fmt.Errorf(
-			"%w: webhook event is empty",
-			ErrWebhookVerifyFailed,
-		)
+		return fmt.Errorf("%w: webhook event is empty", ErrWebhookVerifyFailed)
+	}
+	if !json.Valid(rawEvent) {
+		return fmt.Errorf("%w: webhook event is invalid JSON", ErrWebhookVerifyFailed)
 	}
 
-	if !json.Valid(rawEvent) {
-		return fmt.Errorf(
-			"%w: webhook event is invalid JSON",
-			ErrWebhookVerifyFailed,
-		)
+	payload := webhookVerifyRequest{
+		TransmissionID:   strings.TrimSpace(headers.Get("Paypal-Transmission-Id")),
+		TransmissionTime: strings.TrimSpace(headers.Get("Paypal-Transmission-Time")),
+		CertURL:          strings.TrimSpace(headers.Get("Paypal-Cert-Url")),
+		AuthAlgo:         strings.TrimSpace(headers.Get("Paypal-Auth-Algo")),
+		TransmissionSig:  strings.TrimSpace(headers.Get("Paypal-Transmission-Sig")),
+		WebhookID:        webhookID,
+		WebhookEvent:     json.RawMessage(rawEvent),
+	}
+
+	for name, value := range map[string]string{
+		"transmission_id":   payload.TransmissionID,
+		"transmission_time": payload.TransmissionTime,
+		"cert_url":          payload.CertURL,
+		"auth_algo":         payload.AuthAlgo,
+		"transmission_sig":  payload.TransmissionSig,
+	} {
+		if value == "" {
+			return fmt.Errorf("%w: missing %s", ErrWebhookVerifyFailed, name)
+		}
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(payload); err != nil {
+		return fmt.Errorf("%w: marshal verify payload failed", ErrWebhookVerifyFailed)
 	}
 
 	token, err := getAccessToken(ctx, cfg)
@@ -305,109 +331,20 @@ func VerifyWebhookSignature(
 		return err
 	}
 
-	fields := map[string]string{
-		"transmission_id": strings.TrimSpace(
-			headers.Get("Paypal-Transmission-Id"),
-		),
-		"transmission_time": strings.TrimSpace(
-			headers.Get("Paypal-Transmission-Time"),
-		),
-		"cert_url": strings.TrimSpace(
-			headers.Get("Paypal-Cert-Url"),
-		),
-		"auth_algo": strings.TrimSpace(
-			headers.Get("Paypal-Auth-Algo"),
-		),
-		"transmission_sig": strings.TrimSpace(
-			headers.Get("Paypal-Transmission-Sig"),
-		),
-		"webhook_id": strings.TrimSpace(cfg.WebhookID),
-	}
-
-	for key, value := range fields {
-		if strings.TrimSpace(value) == "" {
-			return fmt.Errorf(
-				"%w: missing %s",
-				ErrWebhookVerifyFailed,
-				key,
-			)
-		}
-	}
-
-	prefix, err := json.Marshal(fields)
-	if err != nil {
-		return fmt.Errorf(
-			"%w: marshal verify metadata failed",
-			ErrWebhookVerifyFailed,
-		)
-	}
-
-	if len(prefix) == 0 || prefix[len(prefix)-1] != '}' {
-		return fmt.Errorf(
-			"%w: invalid verify metadata",
-			ErrWebhookVerifyFailed,
-		)
-	}
-
-	// 去掉元数据 JSON 最后的 }，直接嵌入 PayPal 原始事件内容。
-	verifyBody := make(
-		[]byte,
-		0,
-		len(prefix)+len(rawEvent)+20,
-	)
-
-	verifyBody = append(
-		verifyBody,
-		prefix[:len(prefix)-1]...,
-	)
-	verifyBody = append(
-		verifyBody,
-		[]byte(`,"webhook_event":`)...,
-	)
-	verifyBody = append(verifyBody, rawEvent...)
-	verifyBody = append(verifyBody, '}')
-
-	respBody, statusCode, err := doJSONRequest(
-		ctx,
-		cfg,
-		http.MethodPost,
-		"/v1/notifications/verify-webhook-signature",
-		token,
-		verifyBody,
-	)
+	respBody, statusCode, err := doJSONRequest(ctx, cfg, http.MethodPost, "/v1/notifications/verify-webhook-signature", token, buf.Bytes())
 	if err != nil {
 		return err
 	}
-
 	if statusCode < 200 || statusCode >= 300 {
-		return fmt.Errorf(
-			"%w: verify status %d",
-			ErrWebhookVerifyFailed,
-			statusCode,
-		)
+		return fmt.Errorf("%w: verify status %d", ErrWebhookVerifyFailed, statusCode)
 	}
-
 	var resp map[string]interface{}
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return fmt.Errorf(
-			"%w: decode verify response failed",
-			ErrWebhookVerifyFailed,
-		)
+		return fmt.Errorf("%w: decode verify response failed", ErrWebhookVerifyFailed)
 	}
-
-	status := strings.ToUpper(
-		strings.TrimSpace(
-			readString(resp, "verification_status"),
-		),
-	)
-
-	if status != paypalWebhookVerifyStatusSuccess {
-		return fmt.Errorf(
-			"%w: verify result is not success",
-			ErrWebhookVerifyFailed,
-		)
+	if strings.ToUpper(strings.TrimSpace(readString(resp, "verification_status"))) != paypalWebhookVerifyStatusSuccess {
+		return fmt.Errorf("%w: verify result is not success", ErrWebhookVerifyFailed)
 	}
-
 	return nil
 }
 

--- a/internal/modules/payment/infrastructure/gateway/paypal/paypal.go
+++ b/internal/modules/payment/infrastructure/gateway/paypal/paypal.go
@@ -110,14 +110,13 @@ type WebhookEvent struct {
 	Raw        map[string]interface{}
 }
 
-type webhookVerifyRequest struct {
-	TransmissionID   string          `json:"transmission_id"`
-	TransmissionTime string          `json:"transmission_time"`
-	CertURL          string          `json:"cert_url"`
-	AuthAlgo         string          `json:"auth_algo"`
-	TransmissionSig  string          `json:"transmission_sig"`
-	WebhookID        string          `json:"webhook_id"`
-	WebhookEvent     json.RawMessage `json:"webhook_event"`
+type webhookVerifyMetadata struct {
+	TransmissionID   string `json:"transmission_id"`
+	TransmissionTime string `json:"transmission_time"`
+	CertURL          string `json:"cert_url"`
+	AuthAlgo         string `json:"auth_algo"`
+	TransmissionSig  string `json:"transmission_sig"`
+	WebhookID        string `json:"webhook_id"`
 }
 
 // ParseConfig 解析配置。
@@ -297,32 +296,29 @@ func VerifyWebhookSignature(ctx context.Context, cfg *Config, headers http.Heade
 		return fmt.Errorf("%w: webhook event is invalid JSON", ErrWebhookVerifyFailed)
 	}
 
-	payload := webhookVerifyRequest{
+	metadata := webhookVerifyMetadata{
 		TransmissionID:   strings.TrimSpace(headers.Get("Paypal-Transmission-Id")),
 		TransmissionTime: strings.TrimSpace(headers.Get("Paypal-Transmission-Time")),
 		CertURL:          strings.TrimSpace(headers.Get("Paypal-Cert-Url")),
 		AuthAlgo:         strings.TrimSpace(headers.Get("Paypal-Auth-Algo")),
 		TransmissionSig:  strings.TrimSpace(headers.Get("Paypal-Transmission-Sig")),
 		WebhookID:        webhookID,
-		WebhookEvent:     json.RawMessage(rawEvent),
 	}
 
 	for name, value := range map[string]string{
-		"transmission_id":   payload.TransmissionID,
-		"transmission_time": payload.TransmissionTime,
-		"cert_url":          payload.CertURL,
-		"auth_algo":         payload.AuthAlgo,
-		"transmission_sig":  payload.TransmissionSig,
+		"transmission_id":   metadata.TransmissionID,
+		"transmission_time": metadata.TransmissionTime,
+		"cert_url":          metadata.CertURL,
+		"auth_algo":         metadata.AuthAlgo,
+		"transmission_sig":  metadata.TransmissionSig,
 	} {
 		if value == "" {
 			return fmt.Errorf("%w: missing %s", ErrWebhookVerifyFailed, name)
 		}
 	}
 
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(payload); err != nil {
+	verifyBody, err := marshalWebhookVerifyRequest(metadata, rawEvent)
+	if err != nil {
 		return fmt.Errorf("%w: marshal verify payload failed", ErrWebhookVerifyFailed)
 	}
 
@@ -331,7 +327,7 @@ func VerifyWebhookSignature(ctx context.Context, cfg *Config, headers http.Heade
 		return err
 	}
 
-	respBody, statusCode, err := doJSONRequest(ctx, cfg, http.MethodPost, "/v1/notifications/verify-webhook-signature", token, buf.Bytes())
+	respBody, statusCode, err := doJSONRequest(ctx, cfg, http.MethodPost, "/v1/notifications/verify-webhook-signature", token, verifyBody)
 	if err != nil {
 		return err
 	}
@@ -346,6 +342,24 @@ func VerifyWebhookSignature(ctx context.Context, cfg *Config, headers http.Heade
 		return fmt.Errorf("%w: verify result is not success", ErrWebhookVerifyFailed)
 	}
 	return nil
+}
+
+func marshalWebhookVerifyRequest(metadata webhookVerifyMetadata, rawEvent []byte) ([]byte, error) {
+	encodedMetadata, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, err
+	}
+	if len(encodedMetadata) == 0 || encodedMetadata[len(encodedMetadata)-1] != '}' {
+		return nil, errors.New("paypal verify metadata is not a JSON object")
+	}
+
+	const eventField = `,"webhook_event":`
+	body := make([]byte, 0, len(encodedMetadata)+len(eventField)+len(rawEvent))
+	body = append(body, encodedMetadata[:len(encodedMetadata)-1]...)
+	body = append(body, eventField...)
+	body = append(body, rawEvent...)
+	body = append(body, '}')
+	return body, nil
 }
 
 // ParseWebhookEvent 解析 Webhook 事件。

--- a/internal/modules/payment/infrastructure/gateway/paypal/paypal.go
+++ b/internal/modules/payment/infrastructure/gateway/paypal/paypal.go
@@ -272,53 +272,142 @@ func CaptureOrder(ctx context.Context, cfg *Config, orderID string) (*CaptureRes
 }
 
 // VerifyWebhookSignature 校验 PayPal Webhook 签名。
-func VerifyWebhookSignature(ctx context.Context, cfg *Config, headers http.Header, event map[string]interface{}) error {
+func VerifyWebhookSignature(
+	ctx context.Context,
+	cfg *Config,
+	headers http.Header,
+	rawEvent []byte,
+) error {
 	if cfg == nil {
 		return fmt.Errorf("%w: config is nil", ErrConfigInvalid)
 	}
+
 	if strings.TrimSpace(cfg.WebhookID) == "" {
 		return fmt.Errorf("%w: webhook_id is required", ErrConfigInvalid)
 	}
+
+	if len(rawEvent) == 0 {
+		return fmt.Errorf(
+			"%w: webhook event is empty",
+			ErrWebhookVerifyFailed,
+		)
+	}
+
+	if !json.Valid(rawEvent) {
+		return fmt.Errorf(
+			"%w: webhook event is invalid JSON",
+			ErrWebhookVerifyFailed,
+		)
+	}
+
 	token, err := getAccessToken(ctx, cfg)
 	if err != nil {
 		return err
 	}
 
-	payload := map[string]interface{}{
-		"transmission_id":   strings.TrimSpace(headers.Get("Paypal-Transmission-Id")),
-		"transmission_time": strings.TrimSpace(headers.Get("Paypal-Transmission-Time")),
-		"cert_url":          strings.TrimSpace(headers.Get("Paypal-Cert-Url")),
-		"auth_algo":         strings.TrimSpace(headers.Get("Paypal-Auth-Algo")),
-		"transmission_sig":  strings.TrimSpace(headers.Get("Paypal-Transmission-Sig")),
-		"webhook_id":        strings.TrimSpace(cfg.WebhookID),
-		"webhook_event":     event,
+	fields := map[string]string{
+		"transmission_id": strings.TrimSpace(
+			headers.Get("Paypal-Transmission-Id"),
+		),
+		"transmission_time": strings.TrimSpace(
+			headers.Get("Paypal-Transmission-Time"),
+		),
+		"cert_url": strings.TrimSpace(
+			headers.Get("Paypal-Cert-Url"),
+		),
+		"auth_algo": strings.TrimSpace(
+			headers.Get("Paypal-Auth-Algo"),
+		),
+		"transmission_sig": strings.TrimSpace(
+			headers.Get("Paypal-Transmission-Sig"),
+		),
+		"webhook_id": strings.TrimSpace(cfg.WebhookID),
 	}
 
-	for _, key := range []string{"transmission_id", "transmission_time", "cert_url", "auth_algo", "transmission_sig"} {
-		if strings.TrimSpace(readString(payload, key)) == "" {
-			return fmt.Errorf("%w: missing %s", ErrWebhookVerifyFailed, key)
+	for key, value := range fields {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf(
+				"%w: missing %s",
+				ErrWebhookVerifyFailed,
+				key,
+			)
 		}
 	}
 
-	body, err := json.Marshal(payload)
+	prefix, err := json.Marshal(fields)
 	if err != nil {
-		return fmt.Errorf("%w: marshal verify payload failed", ErrWebhookVerifyFailed)
+		return fmt.Errorf(
+			"%w: marshal verify metadata failed",
+			ErrWebhookVerifyFailed,
+		)
 	}
 
-	respBody, statusCode, err := doJSONRequest(ctx, cfg, http.MethodPost, "/v1/notifications/verify-webhook-signature", token, body)
+	if len(prefix) == 0 || prefix[len(prefix)-1] != '}' {
+		return fmt.Errorf(
+			"%w: invalid verify metadata",
+			ErrWebhookVerifyFailed,
+		)
+	}
+
+	// 去掉元数据 JSON 最后的 }，直接嵌入 PayPal 原始事件内容。
+	verifyBody := make(
+		[]byte,
+		0,
+		len(prefix)+len(rawEvent)+20,
+	)
+
+	verifyBody = append(
+		verifyBody,
+		prefix[:len(prefix)-1]...,
+	)
+	verifyBody = append(
+		verifyBody,
+		[]byte(`,"webhook_event":`)...,
+	)
+	verifyBody = append(verifyBody, rawEvent...)
+	verifyBody = append(verifyBody, '}')
+
+	respBody, statusCode, err := doJSONRequest(
+		ctx,
+		cfg,
+		http.MethodPost,
+		"/v1/notifications/verify-webhook-signature",
+		token,
+		verifyBody,
+	)
 	if err != nil {
 		return err
 	}
+
 	if statusCode < 200 || statusCode >= 300 {
-		return fmt.Errorf("%w: verify status %d", ErrWebhookVerifyFailed, statusCode)
+		return fmt.Errorf(
+			"%w: verify status %d",
+			ErrWebhookVerifyFailed,
+			statusCode,
+		)
 	}
+
 	var resp map[string]interface{}
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return fmt.Errorf("%w: decode verify response failed", ErrWebhookVerifyFailed)
+		return fmt.Errorf(
+			"%w: decode verify response failed",
+			ErrWebhookVerifyFailed,
+		)
 	}
-	if strings.ToUpper(strings.TrimSpace(readString(resp, "verification_status"))) != paypalWebhookVerifyStatusSuccess {
-		return fmt.Errorf("%w: verify result is not success", ErrWebhookVerifyFailed)
+
+	status := strings.ToUpper(
+		strings.TrimSpace(
+			readString(resp, "verification_status"),
+		),
+	)
+
+	if status != paypalWebhookVerifyStatusSuccess {
+		return fmt.Errorf(
+			"%w: verify result is not success",
+			ErrWebhookVerifyFailed,
+		)
 	}
+
 	return nil
 }
 

--- a/internal/modules/payment/infrastructure/gateway/paypal/paypal_test.go
+++ b/internal/modules/payment/infrastructure/gateway/paypal/paypal_test.go
@@ -1,9 +1,12 @@
 package paypal
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/dujiao-next/internal/constants"
@@ -48,6 +51,37 @@ func TestVerifyWebhookSignatureRequiresWebhookID(t *testing.T) {
 	err := VerifyWebhookSignature(context.Background(), cfg, http.Header{}, []byte(`{}`))
 	if !errors.Is(err, ErrConfigInvalid) {
 		t.Fatalf("VerifyWebhookSignature should require webhook_id, got: %v", err)
+	}
+}
+
+func TestVerifyWebhookSignaturePreservesRawEvent(t *testing.T) {
+	raw := []byte(`{"id":"WH-1","event_type":"PAYMENT.CAPTURE.COMPLETED","summary":"A&B <x>"}`)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/oauth2/token":
+			_, _ = w.Write([]byte(`{"access_token":"test-token"}`))
+		case "/v1/notifications/verify-webhook-signature":
+			body, _ := io.ReadAll(r.Body)
+			if !bytes.Contains(body, raw) {
+				t.Errorf("webhook_event changed:\nrequest: %s\n  event: %s", body, raw)
+			}
+			_, _ = w.Write([]byte(`{"verification_status":"SUCCESS"}`))
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &Config{ClientID: "client-id", ClientSecret: "client-secret", BaseURL: server.URL, WebhookID: "WH-ID"}
+	headers := http.Header{}
+	headers.Set("Paypal-Transmission-Id", "transmission-id")
+	headers.Set("Paypal-Transmission-Time", "2026-07-29T12:00:00Z")
+	headers.Set("Paypal-Cert-Url", "https://api.paypal.com/cert?foo=1&bar=2")
+	headers.Set("Paypal-Auth-Algo", "SHA256withRSA")
+	headers.Set("Paypal-Transmission-Sig", "signature")
+
+	if err := VerifyWebhookSignature(context.Background(), cfg, headers, raw); err != nil {
+		t.Fatalf("VerifyWebhookSignature failed: %v", err)
 	}
 }
 

--- a/internal/modules/payment/infrastructure/gateway/paypal/paypal_test.go
+++ b/internal/modules/payment/infrastructure/gateway/paypal/paypal_test.go
@@ -55,14 +55,16 @@ func TestVerifyWebhookSignatureRequiresWebhookID(t *testing.T) {
 }
 
 func TestVerifyWebhookSignaturePreservesRawEvent(t *testing.T) {
-	raw := []byte(`{"id":"WH-1","event_type":"PAYMENT.CAPTURE.COMPLETED","summary":"A&B <x>"}`)
+	raw := []byte("{\n  \"id\": \"WH-1\",\n  \"event_type\": \"PAYMENT.CAPTURE.COMPLETED\",\n  \"summary\": \"A&B <x>\"\n}\n")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/oauth2/token":
 			_, _ = w.Write([]byte(`{"access_token":"test-token"}`))
 		case "/v1/notifications/verify-webhook-signature":
 			body, _ := io.ReadAll(r.Body)
-			if !bytes.Contains(body, raw) {
+			wantSuffix := append([]byte(`"webhook_event":`), raw...)
+			wantSuffix = append(wantSuffix, '}')
+			if !bytes.HasSuffix(body, wantSuffix) {
 				t.Errorf("webhook_event changed:\nrequest: %s\n  event: %s", body, raw)
 			}
 			_, _ = w.Write([]byte(`{"verification_status":"SUCCESS"}`))

--- a/internal/modules/payment/infrastructure/gateway/paypal/paypal_test.go
+++ b/internal/modules/payment/infrastructure/gateway/paypal/paypal_test.go
@@ -45,7 +45,7 @@ func TestVerifyWebhookSignatureRequiresWebhookID(t *testing.T) {
 		CancelURL:    "https://example.com/payment?order_id=1",
 	}
 
-	err := VerifyWebhookSignature(context.Background(), cfg, http.Header{}, map[string]interface{}{})
+	err := VerifyWebhookSignature(context.Background(), cfg, http.Header{}, []byte(`{}`))
 	if !errors.Is(err, ErrConfigInvalid) {
 		t.Fatalf("VerifyWebhookSignature should require webhook_id, got: %v", err)
 	}


### PR DESCRIPTION
> 本 PR 修复由 GPT-5.6 Sol进行原因排查和代码修复，已实际部署并测试确认验签问题已成功解决
> 若作者介意 AI 代码可直接关闭此 PR

## 问题概述

修复 PayPal Webhook 签名验证失败的问题。

此前，PayPal 已经成功完成收款，但系统在处理
`PAYMENT.CAPTURE.COMPLETED` 回调时会报错：

```text
paypal webhook verify failed: verify result is not success
```

导致支付回调无法继续处理，订单状态也可能无法正常更新。

## 问题原因

原有实现会先将 PayPal Webhook 请求体反序列化为：

```go
map[string]interface{}
```

随后在调用 PayPal Webhook 验签接口时，再将该对象重新序列化为 JSON。

处理流程类似：

```go
var event map[string]interface{}
json.Unmarshal(body, &event)

paypal.VerifyWebhookSignature(ctx, cfg, headers, event)
```

而验签函数内部又会执行一次：

```go
json.Marshal(event)
```

经过反序列化和重新序列化后，JSON 的字段顺序和表现形式可能与
PayPal 实际发送的原始请求体不同。

这会导致 PayPal 验签接口返回：

```json
{
  "verification_status": "FAILURE"
}
```

即使 Webhook ID、Client ID、Client Secret 和请求头配置均正确，
合法的 Webhook 仍可能无法通过验证。

## 修改内容

- 将 `VerifyWebhookSignature` 的事件参数由
  `map[string]interface{}` 修改为原始请求体 `[]byte`
- 从 PayPal Provider Adapter 直接传递原始 Webhook 请求体
- 构造验签请求时，直接将原始 JSON 字节写入 `webhook_event`
- 避免对 Webhook 事件进行反序列化后再重新序列化
- 增加原始请求体为空和 JSON 格式合法性的检查
- 更新受影响的单元测试

## 修改前

```go
var event map[string]interface{}
if err := json.Unmarshal(body, &event); err != nil {
    return nil, err
}

if err := paypal.VerifyWebhookSignature(
    ctx,
    cfg,
    httpHeaders,
    event,
); err != nil {
    return nil, err
}
```

验签函数会再次序列化 `event`，PayPal 收到的 `webhook_event`
不再是原始请求内容。

## 修改后

```go
if err := paypal.VerifyWebhookSignature(
    ctx,
    cfg,
    httpHeaders,
    body,
); err != nil {
    return nil, err
}
```

验签请求中的 `webhook_event` 直接使用 PayPal 实际发送的原始请求体，
不再经过二次序列化。

业务处理所需的事件解析逻辑仍然保留，不影响后续读取事件类型、订单号、
金额和支付状态。

## 验证结果

使用 PayPal Live 环境中的真实
`PAYMENT.CAPTURE.COMPLETED` Webhook 进行测试。

修改前：

```text
payment_webhook_parse_failed
paypal webhook verify failed: verify result is not success
```

修改后：

```text
payment_webhook_parsed
status: success
```

Webhook 已成功通过 PayPal 验签，并能够继续匹配对应支付记录。

## 安全性

本次修改没有跳过、关闭或弱化 PayPal Webhook 签名验证。

相反，本次修改确保验签时使用 PayPal 实际发送的原始事件内容，
使验签流程符合 PayPal Webhook 验证接口的要求。

## 兼容性

- 不涉及数据库变更
- 不涉及配置项变更
- 不涉及对外 API 变更
- 仅调整内部 `VerifyWebhookSignature` 函数的参数类型
- 用户现有的 PayPal 通道配置无需修改