### PR TITLE
fix(order): PostgreSQL 下 guest credential backfill 的 pgx 类型推断错误

### DIFF
--- a/internal/modules/order/infrastructure/gormstore/order_store.go
+++ b/internal/modules/order/infrastructure/gormstore/order_store.go
@@ -168,7 +168,7 @@ func guestCredentialBackfillCandidateSQL(dialect string) (string, []interface{})
 		return "(guest_password NOT LIKE ? OR LENGTH(guest_password) <> ? OR SUBSTR(guest_password, ?) GLOB ?)",
 			[]interface{}{prefixPattern, expectedLength, hashStart, "*[^0-9A-Fa-f]*"}
 	case "postgres":
-		return "(guest_password NOT LIKE ? OR LENGTH(guest_password) <> ? OR SUBSTRING(guest_password FROM ?) !~ ?)",
+		return "(guest_password NOT LIKE ? OR LENGTH(guest_password) <> ? OR SUBSTRING(guest_password FROM ?::integer) !~ ?)",
 			[]interface{}{prefixPattern, expectedLength, hashStart, "^[0-9A-Fa-f]+$"}
 	default:
 		return "1 = 1", nil


### PR DESCRIPTION
## Summary
- `guestCredentialBackfillCandidateSQL` 的 postgres 分支里，`SUBSTRING(guest_password FROM ?)` 的整数参数在 pgx 扩展查询协议下会被误推断为 `text` 类型，导致启动时 `BackfillGuestCredentialHashes` 报错：
  `unable to encode 13 into text format for text (OID 25): cannot find encode plan`
- 显式转型为 `?::integer` 消除该歧义，SQLite 分支不受影响。

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/modules/order/infrastructure/gormstore/...`
- 已在生产环境（Postgres 16）验证：修复前该 backfill 会在每次服务启动时崩溃重试；修复后正常完成一次性迁移。