### PR TITLE
fix: epusdt gateway use HMAC-SHA256 signature instead of legacy MD5

### DIFF
--- a/internal/modules/payment/infrastructure/gateway/epusdt/epusdt.go
+++ b/internal/modules/payment/infrastructure/gateway/epusdt/epusdt.go
@@ -2,7 +2,8 @@ package epusdt
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/hmac"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -123,7 +124,9 @@ func ValidateConfig(cfg *Config) error {
 }
 
 // Sign 计算签名。算法：剔除 signature 与空值，key 升序，按 key=value 用 & 连接，
-// 末尾直接拼接 secret_key（无分隔符），MD5 小写 hex。
+// 用 secret_key 作为 HMAC key 对拼接串做 HMAC-SHA256，小写 hex。
+// epusdt 服务端已从旧版 MD5（拼接 secret_key 后缀）迁移到 HMAC-SHA256，且不再接受 MD5 签名，
+// 数值格式化必须与 epusdt util/sign.MapToParams 保持一致（float 去除多余尾零）。
 func Sign(params map[string]interface{}, secretKey string) string {
 	keys := make([]string, 0, len(params))
 	for k, v := range params {
@@ -139,12 +142,26 @@ func Sign(params map[string]interface{}, secretKey string) string {
 
 	pairs := make([]string, 0, len(keys))
 	for _, k := range keys {
-		pairs = append(pairs, fmt.Sprintf("%s=%v", k, params[k]))
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, formatSignValue(params[k])))
 	}
 
-	content := strings.Join(pairs, "&") + secretKey
-	sum := md5.Sum([]byte(content))
-	return strings.ToLower(hex.EncodeToString(sum[:]))
+	content := strings.Join(pairs, "&")
+	mac := hmac.New(sha256.New, []byte(secretKey))
+	_, _ = mac.Write([]byte(content))
+	return strings.ToLower(hex.EncodeToString(mac.Sum(nil)))
+}
+
+// formatSignValue 按 epusdt util/sign.MapToParams 的规则格式化签名参数值：
+// float64 用 strconv.FormatFloat(v, 'f', -1, 64) 去除多余尾零，其余按字符串原样拼接。
+func formatSignValue(v interface{}) string {
+	switch val := v.(type) {
+	case float64:
+		return strconv.FormatFloat(val, 'f', -1, 64)
+	case string:
+		return val
+	default:
+		return fmt.Sprintf("%v", val)
+	}
 }
 
 func isEmptyValue(v interface{}) bool {

--- a/internal/modules/payment/infrastructure/gateway/epusdt/epusdt_test.go
+++ b/internal/modules/payment/infrastructure/gateway/epusdt/epusdt_test.go
@@ -2,7 +2,8 @@ package epusdt
 
 import (
 	"context"
-	cmd5 "crypto/md5"
+	"crypto/hmac"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -115,7 +116,7 @@ func TestSignDeterministicAndOmitsEmptyAndSignature(t *testing.T) {
 		"signature":    "should-be-ignored",
 	}
 	got := Sign(params, "sk-test")
-	expected := md5LowerHex("amount=100&currency=cny&network=tron&notify_url=https://example.com/notify&order_id=ORD-1&pid=1000&token=usdtsk-test")
+	expected := hmacSHA256LowerHex("amount=100&currency=cny&network=tron&notify_url=https://example.com/notify&order_id=ORD-1&pid=1000&token=usdt", "sk-test")
 	if got != expected {
 		t.Fatalf("signature mismatch:\n  got:  %s\n want: %s", got, expected)
 	}
@@ -141,10 +142,11 @@ func TestToPaymentStatus(t *testing.T) {
 	}
 }
 
-// md5LowerHex 测试辅助：避免和 Sign 内部实现耦合，独立计算 MD5
-func md5LowerHex(s string) string {
-	sum := cmd5.Sum([]byte(s))
-	return hex.EncodeToString(sum[:])
+// hmacSHA256LowerHex 测试辅助：避免和 Sign 内部实现耦合，独立计算 HMAC-SHA256
+func hmacSHA256LowerHex(s, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	_, _ = mac.Write([]byte(s))
+	return hex.EncodeToString(mac.Sum(nil))
 }
 
 func TestCreatePayment_BuildsRequestAndConstructsPaymentURL(t *testing.T) {


### PR DESCRIPTION
## Summary
- epusdt/GMPay 服务端已把签名算法从 MD5 升级为 HMAC-SHA256，且不再接受旧版 MD5 签名，导致 `create-transaction` 请求返回 HTTP 401（signature verification failed）。
- `Sign()` 改为用 `secret_key` 作为 HMAC key 对拼接串做 HMAC-SHA256，替代原来的"拼接 secret_key 后缀再 MD5"方案。
- 新增 `formatSignValue`，按 epusdt `util/sign.MapToParams` 的规则格式化签名参数值（float64 去除多余尾零），避免签名串两端数值格式不一致导致验签失败。

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/modules/payment/infrastructure/gateway/epusdt/...`
- 已在生产环境验证：升级后 epusdt 渠道创建交易恢复正常（此前对应渠道持续 401）。