### PR TITLE
feat: 给 user 前端加了个开关。

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,11 @@ Operator subcommands ship in the same binary, so a container needs no extra tool
 Two independent SPAs, both built with Vite and embedded at release time.
 
 **Mount points.** The storefront is served at `/`; the admin panel at `web.admin_path`
-(default `/admin`). `/api`, `/uploads`, and `/health` are reserved prefixes — an unmatched
-path under them returns 404 instead of falling through to the SPA shell. Adding a new
-top-level backend prefix means updating `reservedPaths` in `internal/web/handler.go`.
+(default `/admin`). Set `web.user_spa_disabled: true` to disable the storefront SPA entirely
+(admin + API remain available; distributor storefronts are also closed). `/api`, `/uploads`,
+and `/health` are reserved prefixes — an unmatched path under them returns 404 instead of
+falling through to the SPA shell. Adding a new top-level backend prefix means updating
+`reservedPaths` in `internal/web/handler.go`.
 
 **The admin base path is resolved at runtime, not at build time.** Since `web.admin_path` is
 configurable, `pnpm run build:fullstack` only injects a `<base href="__DJ_ADMIN_BASE__/">`
@@ -168,6 +170,7 @@ Download the latest `dujiao-next_*.tar.gz` from [Releases](https://github.com/du
 tar -xzf dujiao-next_*.tar.gz
 cp config.yml.example config.yml
 # edit config.yml: set jwt.secret, user_jwt.secret, and web.admin_path
+# optionally set web.user_spa_disabled: true if only admin+API is needed
 ./dujiao-next
 ```
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -105,7 +105,11 @@ func main() {
 		if err := web.ValidateAdminPath(cfg.Web.AdminPath); err != nil {
 			stdLog.Fatalf("web.admin_path 配置错误: %v", err)
 		}
-		fmt.Println(ansiGreen + "Embedded SPAs: admin (" + cfg.Web.AdminPath + "), user (/)" + ansiReset)
+		userLabel := "user (disabled)"
+		if !cfg.Web.UserSPADisabled {
+			userLabel = "user (/)"
+		}
+		fmt.Println(ansiGreen + "Embedded SPAs: admin (" + cfg.Web.AdminPath + "), " + userLabel + ansiReset)
 	}
 
 	// fullstack 模式下若仍使用默认 admin 路径，提示安全风险

--- a/config.yml.example
+++ b/config.yml.example
@@ -172,3 +172,7 @@ web:
   # 强烈建议改成不易猜测的字符串以降低自动化扫描风险
   # 例如: "/dj-mgmt-7x9k2" 或 "/console-private"
   admin_path: "/admin"
+  # 设为 true 时不挂载用户站 SPA（主站与分销 storefront 一并关闭），
+  # /sitemap.xml 返回 404，/robots.txt 返回 Disallow: /
+  # admin + API 不受影响。默认 false（即默认启用 user SPA）
+  user_spa_disabled: false

--- a/internal/app/httpserver/route_structure_test.go
+++ b/internal/app/httpserver/route_structure_test.go
@@ -35,6 +35,14 @@ func TestSetupRouterDelegatesRouteDomains(t *testing.T) {
 	}
 }
 
+func TestSetupRouterUserSPADisabledGuardsRegisterUser(t *testing.T) {
+	source := readRouterSource(t, filepath.Join(currentRouterDirectory(t), "router.go"))
+
+	if !strings.Contains(source, "cfg.Web.UserSPADisabled") {
+		t.Error("router.go must wrap RegisterUser in cfg.Web.UserSPADisabled condition")
+	}
+}
+
 func TestRouteDomainFilesPreserveTrustBoundaries(t *testing.T) {
 	routerDirectory := currentRouterDirectory(t)
 	tests := []struct {

--- a/internal/app/httpserver/router.go
+++ b/internal/app/httpserver/router.go
@@ -219,7 +219,8 @@ func SetupRouter(cfg *config.Config, c *container.Container) *gin.Engine {
 	r.Static("/uploads", "./uploads")
 
 	// SEO 资源（动态生成）。
-	sitemaptransport.RegisterRoutes(r, sitemaptransport.NewHandler(c.SitemapService, sitemapbrand.New(c.SettingService)))
+	sitemapHandler := sitemaptransport.NewHandler(c.SitemapService, sitemapbrand.New(c.SettingService), cfg.Web.UserSPADisabled)
+	sitemaptransport.RegisterRoutes(r, sitemapHandler)
 
 	apiV1 := r.Group("/api/v1")
 	registerStorefrontRoutes(apiV1, cfg, c, publicContentHandler, publicCatalogHandler, publicCategoryHandler, userResellerHandler, userResellerProductSettingHandler, userResellerFinanceHandler, userResellerOrderHandler, userApiCredentialHandler, userAuditLogHandler, userGiftCardHandler, publicMemberLevelHandler, userProfileHandler, userEmailHandler, userPasswordHandler, userVerifyHandler, userTelegramOIDCHandler, userTelegramHandler, userLoginHandler, user2FAHandler, publicConfigHandler, userCartHandler, userOrderHandler, guestOrderHandler, orderPreviewHandler, orderCreateHandler, paymentLatestHandler, paymentWriteHandler, userWalletHandler, redisClient, loginRule, guestReadRule, guestWriteRule)
@@ -243,9 +244,14 @@ func SetupRouter(cfg *config.Config, c *container.Container) *gin.Engine {
 		if err := web.RegisterAdmin(r, cfg.Web.AdminPath, web.AdminFS()); err != nil {
 			log.Sugar().Fatalf("注册 admin SPA 失败: %v", err)
 		}
-		if err := web.RegisterUser(r, web.UserFS()); err != nil {
-			log.Sugar().Fatalf("注册 user SPA 失败: %v", err)
+
+		// user SPA：受 user_spa_disabled 控制
+		if !cfg.Web.UserSPADisabled {
+			if err := web.RegisterUser(r, web.UserFS()); err != nil {
+				log.Sugar().Fatalf("注册 user SPA 失败: %v", err)
+			}
 		}
+		// user_spa_disabled=true：不注册 user SPA，NoRoute 默认返回 404
 	}
 
 	return r

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -281,6 +281,9 @@ type WebConfig struct {
 	// AdminPath 后台访问路径前缀，例如 "/admin" 或 "/dj-mgmt-7x9k2"。
 	// 校验规则见 internal/web.ValidateAdminPath。
 	AdminPath string `mapstructure:"admin_path"`
+	// UserSPADisabled 为 true 时不挂载用户站 SPA（主站与分销 storefront 一并关闭），
+	// 只保留 admin + API。默认 false（即默认启用 user SPA）。
+	UserSPADisabled bool `mapstructure:"user_spa_disabled"`
 }
 
 // ResellerConfig 分销商模式配置。

--- a/internal/modules/sitemap/transport/http/handler.go
+++ b/internal/modules/sitemap/transport/http/handler.go
@@ -2,6 +2,7 @@ package sitemaphttp
 
 import (
 	"context"
+	"net/http"
 	"strings"
 
 	"github.com/dujiao-next/internal/logger"
@@ -22,16 +23,24 @@ type SiteBrandReader interface {
 
 // Handler 处理 SEO 静态资源请求。
 type Handler struct {
-	sitemap Generator
-	brand   SiteBrandReader
+	sitemap         Generator
+	brand           SiteBrandReader
+	userSPADisabled bool
 }
 
-func NewHandler(sitemap Generator, brand SiteBrandReader) *Handler {
-	return &Handler{sitemap: sitemap, brand: brand}
+// NewHandler 创建 Handler。
+// userSPADisabled 控制 user SPA 已关闭时的行为：
+// GetSitemap 返回 404，GetRobots 返回全站禁爬的 robots.txt。
+func NewHandler(sitemap Generator, brand SiteBrandReader, userSPADisabled bool) *Handler {
+	return &Handler{sitemap: sitemap, brand: brand, userSPADisabled: userSPADisabled}
 }
 
 // GetSitemap GET /sitemap.xml
 func (h *Handler) GetSitemap(c *gin.Context) {
+	if h != nil && h.userSPADisabled {
+		c.AbortWithStatus(http.StatusNotFound)
+		return
+	}
 	if h == nil || h.sitemap == nil {
 		c.String(503, "sitemap service unavailable")
 		return
@@ -51,6 +60,11 @@ func (h *Handler) GetSitemap(c *gin.Context) {
 
 // GetRobots GET /robots.txt
 func (h *Handler) GetRobots(c *gin.Context) {
+	if h != nil && h.userSPADisabled {
+		c.Header("Cache-Control", "public, max-age=3600")
+		c.String(http.StatusOK, "User-agent: *\nDisallow: /\n")
+		return
+	}
 	baseURL := ""
 	body := "User-agent: *\nDisallow:\n"
 	if h != nil && h.sitemap != nil {

--- a/internal/modules/sitemap/transport/http/handler_test.go
+++ b/internal/modules/sitemap/transport/http/handler_test.go
@@ -39,7 +39,7 @@ func (f fakeBrand) GetSiteURL() (string, error) {
 func TestGetSitemapUsesConfiguredSiteURL(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	gen := &fakeGenerator{xml: "<urlset/>"}
-	handler := NewHandler(gen, fakeBrand{url: "https://shop.example/"})
+	handler := NewHandler(gen, fakeBrand{url: "https://shop.example/"}, false)
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -62,7 +62,7 @@ func TestGetSitemapUsesConfiguredSiteURL(t *testing.T) {
 func TestGetSitemapFallsBackToRequestHost(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	gen := &fakeGenerator{xml: "<urlset/>"}
-	handler := NewHandler(gen, fakeBrand{url: ""})
+	handler := NewHandler(gen, fakeBrand{url: ""}, false)
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -80,7 +80,7 @@ func TestGetSitemapFallsBackToRequestHost(t *testing.T) {
 
 func TestGetSitemapUnavailableWithoutGenerator(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	handler := NewHandler(nil, nil)
+	handler := NewHandler(nil, nil, false)
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -95,7 +95,7 @@ func TestGetSitemapUnavailableWithoutGenerator(t *testing.T) {
 
 func TestGetRobotsFallsBackWhenGeneratorMissing(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	handler := NewHandler(nil, nil)
+	handler := NewHandler(nil, nil, false)
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -108,5 +108,53 @@ func TestGetRobotsFallsBackWhenGeneratorMissing(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "User-agent: *") {
 		t.Fatalf("unexpected robots body %q", w.Body.String())
+	}
+}
+
+func TestGetSitemapReturns404WhenUserSPADisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := NewHandler(&fakeGenerator{xml: "<urlset/>"}, nil, true)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
+
+	handler.GetSitemap(c)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status want 404 got %d", w.Code)
+	}
+}
+
+func TestGetRobotsReturnsDisallowWhenUserSPADisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := NewHandler(nil, nil, true)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/robots.txt", nil)
+
+	handler.GetRobots(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status want 200 got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Disallow: /") {
+		t.Fatalf("robots should disallow all, got %q", w.Body.String())
+	}
+}
+
+func TestSitemapNormalWhenUserSPANotDisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := NewHandler(&fakeGenerator{xml: "<urlset/>"}, nil, false)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
+
+	handler.GetSitemap(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status want 200 got %d", w.Code)
 	}
 }


### PR DESCRIPTION
### 设计初衷。 给user 加了个开关。 关闭之后  api依然可以通讯。但user页面访问不了。这个主要是给我这种 前端进行了自定义，完全不用dujiao-user的人使用的。 

#### 设置项 user_spa_disabled: false 开启或者关闭。 

false 是 启用前台。
true 是 关闭前台

<img width="1018" height="904" alt="image" src="https://github.com/user-attachments/assets/6be08160-31a1-4f33-94d9-4b8defc3c386" />


#### 禁用后的效果，与之前的版本一样。  显示 404 页面


<img width="2096" height="618" alt="image" src="https://github.com/user-attachments/assets/7bcd921a-75a4-4f54-9c25-11a048a46ac5" />


####  但是 api 路径依然可用

<img width="2776" height="542" alt="image" src="https://github.com/user-attachments/assets/d980e3a0-5910-49fd-9e90-4165d485af56" />
