### PR TITLE
feat(bepusdt): 支持 address 指定收款地址

### DIFF
--- a/internal/modules/payment/infrastructure/gateway/bepusdt/bepusdt.go
+++ b/internal/modules/payment/infrastructure/gateway/bepusdt/bepusdt.go
@@ -65,7 +65,7 @@ type Config struct {
 	Fiat       string `json:"fiat"`        // 法币类型，默认 CNY
 	NotifyURL  string `json:"notify_url"`  // 异步通知地址
 	ReturnURL  string `json:"return_url"`  // 同步跳转地址
-	Address   string `json:"address"`    // 指定收款钱包地址（可选），留空由 BEpusdt 自动分配
+	Address    string `json:"address"`     // 指定收款钱包地址（可选），留空由 BEpusdt 自动分配
 }
 
 // CreateInput 创建订单输入

--- a/internal/modules/payment/infrastructure/gateway/bepusdt/bepusdt.go
+++ b/internal/modules/payment/infrastructure/gateway/bepusdt/bepusdt.go
@@ -65,6 +65,7 @@ type Config struct {
 	Fiat       string `json:"fiat"`        // 法币类型，默认 CNY
 	NotifyURL  string `json:"notify_url"`  // 异步通知地址
 	ReturnURL  string `json:"return_url"`  // 同步跳转地址
+	Address   string `json:"address"`    // 指定收款钱包地址（可选），留空由 BEpusdt 自动分配
 }
 
 // CreateInput 创建订单输入
@@ -163,6 +164,7 @@ func (c *Config) Normalize() {
 	c.Fiat = strings.TrimSpace(c.Fiat)
 	c.NotifyURL = strings.TrimSpace(c.NotifyURL)
 	c.ReturnURL = strings.TrimSpace(c.ReturnURL)
+	c.Address = strings.TrimSpace(c.Address)
 	if c.OrderMode == "" {
 		c.OrderMode = constants.PaymentBepusdtOrderModeTransaction
 	}
@@ -213,6 +215,9 @@ func CreatePayment(ctx context.Context, cfg *Config, input CreateInput) (*Create
 	}
 	if input.Name != "" {
 		params["name"] = input.Name
+	}
+	if cfg.Address != "" {
+		params["address"] = cfg.Address
 	}
 
 	// 生成签名


### PR DESCRIPTION
BEpusdt 的 create-transaction 接口支持 address 参数来指定收款钱包地址，但目前独角这边的适配器没有读取和转发这个字段。

在后台支付渠道的高级配置里填了 address，值会存到数据库，但 Config 结构体里没有这个字段，json 反序列化的时候直接丢掉了，导致指定地址一直不生效。

改动很小：
- Config 加了 Address 字段
- Normalize 里 trim 一下
- CreatePayment 构建请求参数时带上 address