### PR TITLE
fix(dashboard): 修复零成本商品利润统计并支持退款冲回成本

### DIFF
--- a/frontend/admin/src/i18n/index.ts
+++ b/frontend/admin/src/i18n/index.ts
@@ -3252,7 +3252,12 @@ const messages = {
         },
         dashboard: {
           title: '仪表盘规则',
-          subtitle: '配置首页告警阈值和排行榜数量',
+          subtitle: '配置首页财务统计口径、告警阈值和排行榜数量',
+          accounting: {
+            title: '财务统计规则',
+            refundReversesCost: '退款时冲回成本',
+            refundReversesCostHint: '开启后按退款金额占订单实付金额的比例冲回成本；全额退款冲回全部成本。',
+          },
           alert: {
             title: '告警规则',
             lowStockThreshold: '低库存阈值（件）',
@@ -7629,7 +7634,12 @@ const messages = {
         },
         dashboard: {
           title: '儀表板規則',
-          subtitle: '配置首頁告警門檻與排行榜數量',
+          subtitle: '配置首頁財務統計口徑、告警門檻與排行榜數量',
+          accounting: {
+            title: '財務統計規則',
+            refundReversesCost: '退款時沖回成本',
+            refundReversesCostHint: '開啟後依退款金額占訂單實付金額的比例沖回成本；全額退款沖回全部成本。',
+          },
           alert: {
             title: '告警規則',
             lowStockThreshold: '低庫存門檻（件）',
@@ -12006,7 +12016,12 @@ const messages = {
         },
         dashboard: {
           title: 'Dashboard Rules',
-          subtitle: 'Configure homepage alert thresholds and ranking limits',
+          subtitle: 'Configure financial metrics, alert thresholds, and ranking limits',
+          accounting: {
+            title: 'Financial Metrics',
+            refundReversesCost: 'Reverse cost on refund',
+            refundReversesCostHint: 'When enabled, cost is reversed in proportion to the refunded share of the paid order amount; full refunds reverse all cost.',
+          },
           alert: {
             title: 'Alert Rules',
             lowStockThreshold: 'Low-stock threshold (units)',

--- a/frontend/admin/src/views/admin/Settings.vue
+++ b/frontend/admin/src/views/admin/Settings.vue
@@ -304,6 +304,9 @@ const orderEmailTemplateData = reactive({
 })
 
 const dashboardForm = reactive({
+  accounting: {
+    refund_reverses_cost: false,
+  },
   alert: {
     low_stock_threshold: 5,
     out_of_stock_products_threshold: 1,
@@ -533,8 +536,10 @@ const fetchSettings = async () => {
 
     if (dashboardRes.data && dashboardRes.data.data) {
       const dashboard = dashboardRes.data.data as Record<string, unknown>
+      const dashAccounting = dashboard.accounting as Record<string, unknown> | undefined
       const dashAlert = dashboard.alert as Record<string, unknown> | undefined
       const dashRanking = dashboard.ranking as Record<string, unknown> | undefined
+      dashboardForm.accounting.refund_reverses_cost = dashAccounting?.refund_reverses_cost === true
       dashboardForm.alert.low_stock_threshold = clampNumber(dashAlert?.low_stock_threshold, 1, 500, 5)
       dashboardForm.alert.out_of_stock_products_threshold = clampNumber(dashAlert?.out_of_stock_products_threshold, 1, 10000, 1)
       dashboardForm.alert.pending_payment_orders_threshold = clampNumber(dashAlert?.pending_payment_orders_threshold, 1, 100000, 20)
@@ -712,6 +717,9 @@ const saveGoogleAuthSettings = async () => {
 
 const saveDashboardSettings = async () => {
   const normalized = {
+    accounting: {
+      refund_reverses_cost: dashboardForm.accounting.refund_reverses_cost === true,
+    },
     alert: {
       low_stock_threshold: clampNumber(dashboardForm.alert.low_stock_threshold, 1, 500, 5),
       out_of_stock_products_threshold: clampNumber(dashboardForm.alert.out_of_stock_products_threshold, 1, 10000, 1),
@@ -724,6 +732,7 @@ const saveDashboardSettings = async () => {
     },
   }
 
+  dashboardForm.accounting.refund_reverses_cost = normalized.accounting.refund_reverses_cost
   dashboardForm.alert.low_stock_threshold = normalized.alert.low_stock_threshold
   dashboardForm.alert.out_of_stock_products_threshold = normalized.alert.out_of_stock_products_threshold
   dashboardForm.alert.pending_payment_orders_threshold = normalized.alert.pending_payment_orders_threshold
@@ -1454,6 +1463,21 @@ onMounted(() => {
         </div>
 
         <div class="space-y-6 p-6">
+          <div class="rounded-xl border border-border">
+            <div class="border-b border-border bg-muted/30 px-4 py-3">
+              <h3 class="text-sm font-semibold">{{ t('admin.settings.dashboard.accounting.title') }}</h3>
+            </div>
+            <div class="p-4">
+              <div class="flex flex-col gap-3 rounded-lg border border-border bg-muted/20 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                <div class="space-y-1">
+                  <Label for="dashboard-refund-reverses-cost" class="text-sm font-medium">{{ t('admin.settings.dashboard.accounting.refundReversesCost') }}</Label>
+                  <p class="text-xs text-muted-foreground">{{ t('admin.settings.dashboard.accounting.refundReversesCostHint') }}</p>
+                </div>
+                <Switch id="dashboard-refund-reverses-cost" v-model="dashboardForm.accounting.refund_reverses_cost" />
+              </div>
+            </div>
+          </div>
+
           <div class="rounded-xl border border-border">
             <div class="border-b border-border bg-muted/30 px-4 py-3">
               <h3 class="text-sm font-semibold">{{ t('admin.settings.dashboard.alert.title') }}</h3>

--- a/internal/modules/dashboard/application/service.go
+++ b/internal/modules/dashboard/application/service.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -40,7 +41,7 @@ func (s *Service) GetOverview(ctx context.Context, input reportingdomain.Query) 
 
 	setting := s.loadSetting()
 
-	cacheKey := fmt.Sprintf("dashboard:overview:%s:%d:%d:%s:%d:%d:%d:%d",
+	cacheKey := fmt.Sprintf("dashboard:overview:%s:%d:%d:%s:%d:%d:%d:%d:%t",
 		window.Range,
 		window.StartAt.Unix(),
 		window.EndAt.Unix(),
@@ -49,6 +50,7 @@ func (s *Service) GetOverview(ctx context.Context, input reportingdomain.Query) 
 		setting.Alert.OutOfStockProductsThreshold,
 		setting.Alert.PendingPaymentOrdersThreshold,
 		setting.Alert.PaymentsFailedThreshold,
+		setting.Accounting.RefundReversesCost,
 	)
 	if !input.ForceRefresh {
 		var cached OverviewResponse
@@ -75,7 +77,8 @@ func (s *Service) GetOverview(ctx context.Context, input reportingdomain.Query) 
 		return nil, err
 	}
 
-	totalProfit := profitOverview.TotalRevenue - profitOverview.TotalCost
+	totalCost := effectiveDashboardCost(profitOverview.TotalCost, profitOverview.RefundedCost, setting.Accounting.RefundReversesCost)
+	totalProfit := profitOverview.TotalRevenue - totalCost
 	profitMargin := 0.0
 	if profitOverview.TotalRevenue > 0 {
 		profitMargin = totalProfit / profitOverview.TotalRevenue * 100
@@ -109,7 +112,7 @@ func (s *Service) GetOverview(ctx context.Context, input reportingdomain.Query) 
 			PendingPaymentOrders: overview.PendingPaymentOrders,
 			ProcessingOrders:     overview.ProcessingOrders,
 			GMVPaid:              formatMoneyValue(overview.GMVPaid),
-			TotalCost:            formatMoneyValue(profitOverview.TotalCost),
+			TotalCost:            formatMoneyValue(totalCost),
 			TotalProfit:          formatMoneyValue(totalProfit),
 			ProfitMargin:         formatPercentValue(profitMargin),
 			PaymentsTotal:        overview.PaymentsTotal,
@@ -174,7 +177,8 @@ func (s *Service) GetTrends(ctx context.Context, input reportingdomain.Query) (*
 		return nil, err
 	}
 
-	cacheKey := fmt.Sprintf("dashboard:trends:%s:%d:%d:%s", window.Range, window.StartAt.Unix(), window.EndAt.Unix(), window.Timezone)
+	setting := s.loadSetting()
+	cacheKey := fmt.Sprintf("dashboard:trends:%s:%d:%d:%s:%t", window.Range, window.StartAt.Unix(), window.EndAt.Unix(), window.Timezone, setting.Accounting.RefundReversesCost)
 	if !input.ForceRefresh {
 		var cached TrendResponse
 		hit, cacheErr := cache.GetJSON(ctx, cacheKey, &cached)
@@ -215,7 +219,8 @@ func (s *Service) GetTrends(ctx context.Context, input reportingdomain.Query) (*
 		orderItem := orderMap[day]
 		paymentItem := paymentMap[day]
 		profitItem := profitMap[day]
-		dayProfit := profitItem.Revenue - profitItem.Cost
+		dayCost := effectiveDashboardCost(profitItem.Cost, profitItem.RefundedCost, setting.Accounting.RefundReversesCost)
+		dayProfit := profitItem.Revenue - dayCost
 		points = append(points, TrendPoint{
 			Date:            day,
 			OrdersTotal:     orderItem.OrdersTotal,
@@ -347,6 +352,17 @@ func formatMoneyValue(value float64) string {
 
 func formatPercentValue(value float64) string {
 	return fmt.Sprintf("%.2f", value)
+}
+
+func effectiveDashboardCost(totalCost, refundedCost float64, refundReversesCost bool) float64 {
+	if !refundReversesCost {
+		return totalCost
+	}
+	result := totalCost - refundedCost
+	if math.Abs(result) < 0.000001 {
+		return 0
+	}
+	return result
 }
 
 func buildDashboardAlerts(overview dashboardcontract.OverviewRow, stockStats dashboardcontract.StockStatsRow, alertSetting settingsstorefront.DashboardAlertSetting) []AlertItem {

--- a/internal/modules/dashboard/application/service_test.go
+++ b/internal/modules/dashboard/application/service_test.go
@@ -7,11 +7,14 @@ import (
 
 	dashboardcontract "github.com/dujiao-next/internal/modules/dashboard/contract"
 	reportingdomain "github.com/dujiao-next/internal/modules/reporting/domain"
+	settingsstorefront "github.com/dujiao-next/internal/modules/settings/schema/storefront"
 )
 
 type dashboardServiceRepoStub struct {
-	overview dashboardcontract.OverviewRow
-	stock    dashboardcontract.StockStatsRow
+	overview       dashboardcontract.OverviewRow
+	profitOverview dashboardcontract.ProfitOverviewRow
+	profitTrends   []dashboardcontract.ProfitTrendRow
+	stock          dashboardcontract.StockStatsRow
 }
 
 func (s dashboardServiceRepoStub) GetOverview(startAt, endAt time.Time) (dashboardcontract.OverviewRow, error) {
@@ -43,11 +46,11 @@ func (s dashboardServiceRepoStub) GetTopProducts(startAt, endAt time.Time, limit
 }
 
 func (s dashboardServiceRepoStub) GetProfitOverview(startAt, endAt time.Time) (dashboardcontract.ProfitOverviewRow, error) {
-	return dashboardcontract.ProfitOverviewRow{}, nil
+	return s.profitOverview, nil
 }
 
 func (s dashboardServiceRepoStub) GetProfitTrends(startAt, endAt time.Time) ([]dashboardcontract.ProfitTrendRow, error) {
-	return []dashboardcontract.ProfitTrendRow{}, nil
+	return s.profitTrends, nil
 }
 
 func (s dashboardServiceRepoStub) GetTopChannels(startAt, endAt time.Time, limit int) ([]dashboardcontract.ChannelRankingRow, error) {
@@ -56,6 +59,14 @@ func (s dashboardServiceRepoStub) GetTopChannels(startAt, endAt time.Time, limit
 
 func (s dashboardServiceRepoStub) GetTotalUserBalance() (float64, error) {
 	return 0, nil
+}
+
+type dashboardSettingReaderStub struct {
+	setting settingsstorefront.DashboardSetting
+}
+
+func (s dashboardSettingReaderStub) GetDashboardSetting() (settingsstorefront.DashboardSetting, error) {
+	return s.setting, nil
 }
 
 func TestDashboardOverviewUsesPaidOrdersForPaymentConversionRate(t *testing.T) {
@@ -117,4 +128,50 @@ func TestDashboardOverviewBuildsInventoryAlertsFromStockStats(t *testing.T) {
 	}
 }
 
+func TestDashboardOverviewAppliesRefundCostPolicy(t *testing.T) {
+	repo := dashboardServiceRepoStub{
+		profitOverview: dashboardcontract.ProfitOverviewRow{
+			TotalRevenue: 0,
+			TotalCost:    3,
+			RefundedCost: 3,
+		},
+	}
+	query := reportingdomain.Query{
+		Range:        "today",
+		Timezone:     "Asia/Shanghai",
+		ForceRefresh: true,
+	}
+
+	withoutReversal, err := NewService(repo, nil).GetOverview(context.Background(), query)
+	if err != nil {
+		t.Fatalf("get overview without cost reversal failed: %v", err)
+	}
+	if withoutReversal.KPI.TotalCost != "3.00" || withoutReversal.KPI.TotalProfit != "-3.00" {
+		t.Fatalf("unexpected metrics without cost reversal: %+v", withoutReversal.KPI)
+	}
+
+	setting := settingsstorefront.DefaultDashboardSetting()
+	setting.Accounting.RefundReversesCost = true
+	withReversal, err := NewService(repo, dashboardSettingReaderStub{setting: setting}).GetOverview(context.Background(), query)
+	if err != nil {
+		t.Fatalf("get overview with cost reversal failed: %v", err)
+	}
+	if withReversal.KPI.TotalCost != "0.00" || withReversal.KPI.TotalProfit != "0.00" {
+		t.Fatalf("unexpected metrics with cost reversal: %+v", withReversal.KPI)
+	}
+}
+
+func TestEffectiveDashboardCostSupportsCrossPeriodRefundAdjustment(t *testing.T) {
+	if got := effectiveDashboardCost(20, 12, false); got != 20 {
+		t.Fatalf("disabled cost reversal want 20 got %.2f", got)
+	}
+	if got := effectiveDashboardCost(20, 12, true); got != 8 {
+		t.Fatalf("enabled cost reversal want 8 got %.2f", got)
+	}
+	if got := effectiveDashboardCost(0, 12, true); got != -12 {
+		t.Fatalf("cross-period cost reversal want -12 got %.2f", got)
+	}
+}
+
 var _ dashboardcontract.Repository = dashboardServiceRepoStub{}
+var _ dashboardcontract.SettingReader = dashboardSettingReaderStub{}

--- a/internal/modules/dashboard/contract/ports.go
+++ b/internal/modules/dashboard/contract/ports.go
@@ -63,12 +63,14 @@ type PaymentTrendRow struct {
 type ProfitOverviewRow struct {
 	TotalRevenue float64
 	TotalCost    float64
+	RefundedCost float64
 }
 
 type ProfitTrendRow struct {
-	Day     string
-	Revenue float64
-	Cost    float64
+	Day          string
+	Revenue      float64
+	Cost         float64
+	RefundedCost float64
 }
 
 type StockStatsRow struct {

--- a/internal/modules/dashboard/infrastructure/gormstore/profit.go
+++ b/internal/modules/dashboard/infrastructure/gormstore/profit.go
@@ -3,7 +3,6 @@ package gormstore
 import (
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	orderdomain "github.com/dujiao-next/internal/modules/order/domain"
@@ -17,6 +16,110 @@ func profitOrderStatuses() []string {
 	return append(statuses, constants.OrderStatusRefunded)
 }
 
+type refundAdjustmentRow struct {
+	Day          string
+	RefundAmount float64
+	RefundedCost float64
+}
+
+type refundAggregateRow struct {
+	Day          string
+	OrderID      uint
+	RefundAmount float64 `gorm:"column:refund_amount"`
+}
+
+// getRefundAdjustments 按退款发生日计算退款金额与同比例冲回的成本。
+// 父订单本身没有订单项，因此其成本基数包含自身及直接子订单的订单项成本。
+func (r *Store) getRefundAdjustments(startAt, endAt time.Time) ([]refundAdjustmentRow, error) {
+	refundDayExpr := dateGroupExpr(r.db, "order_refund_records.created_at", startAt.Location(), startAt)
+	refundRows := make([]refundAggregateRow, 0)
+	if err := r.db.Model(&orderdomain.OrderRefundRecord{}).
+		Select(fmt.Sprintf(`
+			%s as day,
+			order_refund_records.order_id as order_id,
+			COALESCE(SUM(order_refund_records.amount), 0) as refund_amount
+		`, refundDayExpr)).
+		Where("order_refund_records.deleted_at IS NULL AND order_refund_records.created_at >= ? AND order_refund_records.created_at < ?", startAt, endAt).
+		Group(fmt.Sprintf("%s, order_refund_records.order_id", refundDayExpr)).
+		Scan(&refundRows).Error; err != nil {
+		return nil, err
+	}
+	if len(refundRows) == 0 {
+		return []refundAdjustmentRow{}, nil
+	}
+
+	orderIDs := make([]uint, 0, len(refundRows))
+	seenOrderIDs := make(map[uint]struct{}, len(refundRows))
+	for _, row := range refundRows {
+		if row.OrderID == 0 {
+			continue
+		}
+		if _, exists := seenOrderIDs[row.OrderID]; exists {
+			continue
+		}
+		seenOrderIDs[row.OrderID] = struct{}{}
+		orderIDs = append(orderIDs, row.OrderID)
+	}
+
+	type refundOrderRow struct {
+		ID          uint
+		TotalAmount float64 `gorm:"column:total_amount"`
+	}
+	orderRows := make([]refundOrderRow, 0, len(orderIDs))
+	if err := r.db.Model(&orderdomain.Order{}).
+		Select("id, total_amount").
+		Where("deleted_at IS NULL AND id IN ?", orderIDs).
+		Scan(&orderRows).Error; err != nil {
+		return nil, err
+	}
+	orderTotalByID := make(map[uint]float64, len(orderRows))
+	for _, row := range orderRows {
+		orderTotalByID[row.ID] = row.TotalAmount
+	}
+
+	type orderCostRow struct {
+		OrderID   uint
+		ParentID  *uint
+		TotalCost float64 `gorm:"column:total_cost"`
+	}
+	costRows := make([]orderCostRow, 0)
+	if err := r.db.Model(&orderdomain.OrderItem{}).
+		Select(`
+			orders.id as order_id,
+			orders.parent_id as parent_id,
+			COALESCE(SUM(order_items.cost_price * order_items.quantity), 0) as total_cost
+		`).
+		Joins("JOIN orders ON orders.id = order_items.order_id").
+		Where("order_items.deleted_at IS NULL AND orders.deleted_at IS NULL AND (orders.id IN ? OR orders.parent_id IN ?)", orderIDs, orderIDs).
+		Group("orders.id, orders.parent_id").
+		Scan(&costRows).Error; err != nil {
+		return nil, err
+	}
+	directCostByOrderID := make(map[uint]float64, len(costRows))
+	childCostByParentID := make(map[uint]float64, len(costRows))
+	for _, row := range costRows {
+		directCostByOrderID[row.OrderID] += row.TotalCost
+		if row.ParentID != nil {
+			childCostByParentID[*row.ParentID] += row.TotalCost
+		}
+	}
+
+	adjustments := make([]refundAdjustmentRow, 0, len(refundRows))
+	for _, row := range refundRows {
+		adjustment := refundAdjustmentRow{
+			Day:          row.Day,
+			RefundAmount: row.RefundAmount,
+		}
+		orderTotal := orderTotalByID[row.OrderID]
+		if orderTotal > 0 && row.RefundAmount > 0 {
+			costBasis := directCostByOrderID[row.OrderID] + childCostByParentID[row.OrderID]
+			adjustment.RefundedCost = costBasis * row.RefundAmount / orderTotal
+		}
+		adjustments = append(adjustments, adjustment)
+	}
+	return adjustments, nil
+}
+
 // GetProfitOverview 获取利润总览统计
 func (r *Store) GetProfitOverview(startAt, endAt time.Time) (dashboard.ProfitOverviewRow, error) {
 	result := dashboard.ProfitOverviewRow{}
@@ -26,19 +129,19 @@ func (r *Store) GetProfitOverview(startAt, endAt time.Time) (dashboard.ProfitOve
 			COALESCE(SUM(order_items.cost_price * order_items.quantity), 0) as total_cost
 		`).
 		Joins("JOIN orders ON orders.id = order_items.order_id").
-		Where("order_items.deleted_at IS NULL AND orders.deleted_at IS NULL AND order_items.cost_price > 0 AND orders.created_at >= ? AND orders.created_at < ? AND orders.status IN ?", startAt, endAt, profitOrderStatuses()).
+		Where("order_items.deleted_at IS NULL AND orders.deleted_at IS NULL AND orders.created_at >= ? AND orders.created_at < ? AND orders.status IN ?", startAt, endAt, profitOrderStatuses()).
 		Scan(&result).Error; err != nil {
 		return result, err
 	}
 
-	var refundedAmount float64
-	if err := r.db.Model(&orderdomain.OrderRefundRecord{}).
-		Select("COALESCE(SUM(amount), 0)").
-		Where("deleted_at IS NULL AND created_at >= ? AND created_at < ?", startAt, endAt).
-		Scan(&refundedAmount).Error; err != nil {
+	refundAdjustments, err := r.getRefundAdjustments(startAt, endAt)
+	if err != nil {
 		return result, err
 	}
-	result.TotalRevenue -= refundedAmount
+	for _, adjustment := range refundAdjustments {
+		result.TotalRevenue -= adjustment.RefundAmount
+		result.RefundedCost += adjustment.RefundedCost
+	}
 	return result, nil
 }
 
@@ -53,26 +156,14 @@ func (r *Store) GetProfitTrends(startAt, endAt time.Time) ([]dashboard.ProfitTre
 		COALESCE(SUM(order_items.cost_price * order_items.quantity), 0) as cost
 	`, orderDayExpr)).
 		Joins("JOIN orders ON orders.id = order_items.order_id").
-		Where("order_items.deleted_at IS NULL AND orders.deleted_at IS NULL AND order_items.cost_price > 0 AND orders.created_at >= ? AND orders.created_at < ? AND orders.status IN ?", startAt, endAt, profitOrderStatuses()).
+		Where("order_items.deleted_at IS NULL AND orders.deleted_at IS NULL AND orders.created_at >= ? AND orders.created_at < ? AND orders.status IN ?", startAt, endAt, profitOrderStatuses()).
 		Group(orderDayExpr).
 		Scan(&rows).Error; err != nil {
 		return nil, err
 	}
 
-	type refundTrendRow struct {
-		Day          string
-		RefundAmount float64 `gorm:"column:refund_amount"`
-	}
-	refundRows := make([]refundTrendRow, 0)
-	refundDayExpr := dateGroupExpr(r.db, "created_at", startAt.Location(), startAt)
-	if err := r.db.Model(&orderdomain.OrderRefundRecord{}).
-		Select(fmt.Sprintf(`
-			%s as day,
-			COALESCE(SUM(amount), 0) as refund_amount
-		`, refundDayExpr)).
-		Where("deleted_at IS NULL AND created_at >= ? AND created_at < ?", startAt, endAt).
-		Group(refundDayExpr).
-		Scan(&refundRows).Error; err != nil {
+	refundRows, err := r.getRefundAdjustments(startAt, endAt)
+	if err != nil {
 		return nil, err
 	}
 
@@ -81,13 +172,14 @@ func (r *Store) GetProfitTrends(startAt, endAt time.Time) ([]dashboard.ProfitTre
 		byDay[row.Day] = row
 	}
 	for _, refundRow := range refundRows {
-		day := strings.TrimSpace(refundRow.Day)
+		day := refundRow.Day
 		if day == "" {
 			continue
 		}
 		row := byDay[day]
 		row.Day = day
 		row.Revenue -= refundRow.RefundAmount
+		row.RefundedCost += refundRow.RefundedCost
 		byDay[day] = row
 	}
 

--- a/internal/modules/dashboard/infrastructure/gormstore/profit_test.go
+++ b/internal/modules/dashboard/infrastructure/gormstore/profit_test.go
@@ -1,6 +1,7 @@
 package gormstore
 
 import (
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -83,6 +84,9 @@ func TestGetProfitOverviewDeductsRefundRecords(t *testing.T) {
 	if math.Abs(result.TotalCost-90) > 0.000001 {
 		t.Fatalf("total cost want 90 got %.2f", result.TotalCost)
 	}
+	if math.Abs(result.RefundedCost-52.5) > 0.000001 {
+		t.Fatalf("refunded cost want 52.5 got %.2f", result.RefundedCost)
+	}
 }
 
 func TestGetProfitTrendsDeductsRefundRecords(t *testing.T) {
@@ -154,10 +158,10 @@ func TestGetProfitTrendsDeductsRefundRecords(t *testing.T) {
 	}
 	day1 := "2026-03-01"
 	day2 := "2026-03-02"
-	if math.Abs(rowMap[day1].Revenue-0) > 0.000001 || math.Abs(rowMap[day1].Cost-30) > 0.000001 {
+	if math.Abs(rowMap[day1].Revenue-0) > 0.000001 || math.Abs(rowMap[day1].Cost-30) > 0.000001 || math.Abs(rowMap[day1].RefundedCost-30) > 0.000001 {
 		t.Fatalf("unexpected day1 row: %+v", rowMap[day1])
 	}
-	if math.Abs(rowMap[day2].Revenue-60) > 0.000001 || math.Abs(rowMap[day2].Cost-40) > 0.000001 {
+	if math.Abs(rowMap[day2].Revenue-60) > 0.000001 || math.Abs(rowMap[day2].Cost-40) > 0.000001 || math.Abs(rowMap[day2].RefundedCost-16) > 0.000001 {
 		t.Fatalf("unexpected day2 row: %+v", rowMap[day2])
 	}
 }
@@ -263,6 +267,9 @@ func TestGetProfitOverviewDeductsInWindowRefundForOutOfWindowOrder(t *testing.T)
 	}
 	if math.Abs(result.TotalCost-20) > 0.000001 {
 		t.Fatalf("total cost want 20 got %.2f", result.TotalCost)
+	}
+	if math.Abs(result.RefundedCost-20) > 0.000001 {
+		t.Fatalf("refunded cost want 20 got %.2f", result.RefundedCost)
 	}
 }
 
@@ -370,7 +377,148 @@ func TestGetProfitTrendsIncludesRefundOnlyDayInWindow(t *testing.T) {
 	if math.Abs(rowMap["2026-03-01"].Revenue-80) > 0.000001 || math.Abs(rowMap["2026-03-01"].Cost-30) > 0.000001 {
 		t.Fatalf("unexpected 2026-03-01 row: %+v", rowMap["2026-03-01"])
 	}
-	if math.Abs(rowMap["2026-03-02"].Revenue-(-30)) > 0.000001 || math.Abs(rowMap["2026-03-02"].Cost-0) > 0.000001 {
+	if math.Abs(rowMap["2026-03-02"].Revenue-(-30)) > 0.000001 || math.Abs(rowMap["2026-03-02"].Cost-0) > 0.000001 || math.Abs(rowMap["2026-03-02"].RefundedCost-12) > 0.000001 {
 		t.Fatalf("unexpected 2026-03-02 row: %+v", rowMap["2026-03-02"])
+	}
+}
+
+func TestProfitMetricsIncludeZeroCostRevenueAndCalculateRefundedCost(t *testing.T) {
+	repo, db := setupDashboardRepositoryTest(t)
+	now := time.Date(2026, 4, 6, 10, 0, 0, 0, time.UTC)
+
+	category := createDashboardCategory(t, db, "dashboard-zero-cost-refund-category")
+	product := &productdomain.Product{
+		CategoryID:      category.ID,
+		Slug:            "dashboard-zero-cost-refund-product",
+		TitleJSON:       jsonmap.JSON{"zh-CN": "零成本退款商品"},
+		PriceAmount:     money.FromDecimal(decimal.NewFromInt(49)),
+		PurchaseType:    constants.ProductPurchaseMember,
+		FulfillmentType: constants.FulfillmentTypeManual,
+		IsActive:        true,
+	}
+	if err := db.Create(product).Error; err != nil {
+		t.Fatalf("create product failed: %v", err)
+	}
+
+	orders := make([]*orderdomain.Order, 0, 4)
+	for index := 0; index < 3; index++ {
+		orders = append(orders, createDashboardProfitOrderWithItem(
+			t,
+			db,
+			product,
+			fmt.Sprintf("DJ-PROFIT-COST-ONE-%d", index+1),
+			constants.OrderStatusRefunded,
+			1,
+			1,
+			"成本一元商品",
+			now,
+		))
+	}
+	orders = append(orders, createDashboardProfitOrderWithItem(
+		t,
+		db,
+		product,
+		"DJ-PROFIT-ZERO-COST",
+		constants.OrderStatusRefunded,
+		49,
+		0,
+		"零成本商品",
+		now,
+	))
+
+	for _, order := range orders {
+		if err := db.Create(&orderdomain.OrderRefundRecord{
+			UserID:    1,
+			OrderID:   order.ID,
+			Type:      constants.OrderRefundTypeManual,
+			Amount:    order.TotalAmount,
+			Currency:  "CNY",
+			CreatedAt: now,
+			UpdatedAt: now,
+		}).Error; err != nil {
+			t.Fatalf("create refund record failed: %v", err)
+		}
+	}
+
+	startAt := now.Add(-time.Hour)
+	endAt := now.Add(time.Hour)
+	overview, err := repo.GetProfitOverview(startAt, endAt)
+	if err != nil {
+		t.Fatalf("get profit overview failed: %v", err)
+	}
+	if math.Abs(overview.TotalRevenue) > 0.000001 || math.Abs(overview.TotalCost-3) > 0.000001 || math.Abs(overview.RefundedCost-3) > 0.000001 {
+		t.Fatalf("unexpected zero-cost refund overview: %+v", overview)
+	}
+
+	trends, err := repo.GetProfitTrends(startAt, endAt)
+	if err != nil {
+		t.Fatalf("get profit trends failed: %v", err)
+	}
+	if len(trends) != 1 {
+		t.Fatalf("profit trend rows want 1 got %d", len(trends))
+	}
+	if math.Abs(trends[0].Revenue) > 0.000001 || math.Abs(trends[0].Cost-3) > 0.000001 || math.Abs(trends[0].RefundedCost-3) > 0.000001 {
+		t.Fatalf("unexpected zero-cost refund trend: %+v", trends[0])
+	}
+}
+
+func TestRefundedCostUsesParentOrderChildrenCostBasis(t *testing.T) {
+	repo, db := setupDashboardRepositoryTest(t)
+	now := time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC)
+
+	category := createDashboardCategory(t, db, "dashboard-parent-refund-cost-category")
+	product := &productdomain.Product{
+		CategoryID:      category.ID,
+		Slug:            "dashboard-parent-refund-cost-product",
+		TitleJSON:       jsonmap.JSON{"zh-CN": "父订单退款成本商品"},
+		PriceAmount:     money.FromDecimal(decimal.NewFromInt(100)),
+		PurchaseType:    constants.ProductPurchaseMember,
+		FulfillmentType: constants.FulfillmentTypeManual,
+		IsActive:        true,
+	}
+	if err := db.Create(product).Error; err != nil {
+		t.Fatalf("create product failed: %v", err)
+	}
+
+	parent := &orderdomain.Order{
+		OrderNo:        "DJ-PROFIT-PARENT-REFUND",
+		UserID:         1,
+		Status:         constants.OrderStatusPartiallyRefunded,
+		Currency:       "CNY",
+		OriginalAmount: money.FromDecimal(decimal.NewFromInt(100)),
+		TotalAmount:    money.FromDecimal(decimal.NewFromInt(100)),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := db.Create(parent).Error; err != nil {
+		t.Fatalf("create parent order failed: %v", err)
+	}
+	children := []*orderdomain.Order{
+		createDashboardProfitOrderWithItem(t, db, product, "DJ-PROFIT-PARENT-CHILD-1", constants.OrderStatusPartiallyRefunded, 40, 10, "子订单一", now),
+		createDashboardProfitOrderWithItem(t, db, product, "DJ-PROFIT-PARENT-CHILD-2", constants.OrderStatusPartiallyRefunded, 60, 30, "子订单二", now),
+	}
+	for _, child := range children {
+		if err := db.Model(&orderdomain.Order{}).Where("id = ?", child.ID).Update("parent_id", parent.ID).Error; err != nil {
+			t.Fatalf("attach child order failed: %v", err)
+		}
+	}
+	if err := db.Create(&orderdomain.OrderRefundRecord{
+		UserID:    1,
+		OrderID:   parent.ID,
+		Type:      constants.OrderRefundTypeManual,
+		Amount:    money.FromDecimal(decimal.NewFromInt(50)),
+		Currency:  "CNY",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error; err != nil {
+		t.Fatalf("create parent refund record failed: %v", err)
+	}
+
+	result, err := repo.GetProfitOverview(now.Add(-time.Hour), now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("get parent refund profit overview failed: %v", err)
+	}
+	if math.Abs(result.TotalRevenue-50) > 0.000001 || math.Abs(result.TotalCost-40) > 0.000001 || math.Abs(result.RefundedCost-20) > 0.000001 {
+		t.Fatalf("unexpected parent refund metrics: %+v", result)
 	}
 }

--- a/internal/modules/settings/application/dashboard_test.go
+++ b/internal/modules/settings/application/dashboard_test.go
@@ -21,6 +21,9 @@ func TestUpdateDashboardSettingNormalized(t *testing.T) {
 			"top_products_limit": 999,
 			"top_channels_limit": -1,
 		},
+		"accounting": map[string]interface{}{
+			"refund_reverses_cost": true,
+		},
 	}
 
 	result, err := svc.Update(constants.SettingKeyDashboardConfig, input)
@@ -36,6 +39,10 @@ func TestUpdateDashboardSettingNormalized(t *testing.T) {
 	if !ok {
 		t.Fatalf("invalid ranking payload type: %T", result["ranking"])
 	}
+	accounting, ok := result["accounting"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("invalid accounting payload type: %T", result["accounting"])
+	}
 
 	assertSettingIntValue(t, alert, "low_stock_threshold", 5)
 	assertSettingIntValue(t, alert, "out_of_stock_products_threshold", 1)
@@ -43,6 +50,7 @@ func TestUpdateDashboardSettingNormalized(t *testing.T) {
 	assertSettingIntValue(t, alert, "payments_failed_threshold", 10)
 	assertSettingIntValue(t, ranking, "top_products_limit", 5)
 	assertSettingIntValue(t, ranking, "top_channels_limit", 5)
+	assertSettingBoolValue(t, accounting, "refund_reverses_cost", true)
 }
 
 func TestUpdateDashboardSettingFallbackWhenMissing(t *testing.T) {
@@ -62,6 +70,10 @@ func TestUpdateDashboardSettingFallbackWhenMissing(t *testing.T) {
 	if !ok {
 		t.Fatalf("invalid ranking payload type: %T", result["ranking"])
 	}
+	accounting, ok := result["accounting"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("invalid accounting payload type: %T", result["accounting"])
+	}
 
 	assertSettingIntValue(t, alert, "low_stock_threshold", 5)
 	assertSettingIntValue(t, alert, "out_of_stock_products_threshold", 1)
@@ -69,6 +81,7 @@ func TestUpdateDashboardSettingFallbackWhenMissing(t *testing.T) {
 	assertSettingIntValue(t, alert, "payments_failed_threshold", 10)
 	assertSettingIntValue(t, ranking, "top_products_limit", 5)
 	assertSettingIntValue(t, ranking, "top_channels_limit", 5)
+	assertSettingBoolValue(t, accounting, "refund_reverses_cost", false)
 }
 
 func assertSettingIntValue(t *testing.T, data map[string]interface{}, key string, expected int) {
@@ -83,5 +96,20 @@ func assertSettingIntValue(t *testing.T, data map[string]interface{}, key string
 	}
 	if parsed != expected {
 		t.Fatalf("unexpected value for %s, expected %d got %d", key, expected, parsed)
+	}
+}
+
+func assertSettingBoolValue(t *testing.T, data map[string]interface{}, key string, expected bool) {
+	t.Helper()
+	value, exists := data[key]
+	if !exists {
+		t.Fatalf("missing key %s", key)
+	}
+	parsed, ok := value.(bool)
+	if !ok {
+		t.Fatalf("key %s has unexpected type %T", key, value)
+	}
+	if parsed != expected {
+		t.Fatalf("unexpected value for %s, expected %t got %t", key, expected, parsed)
 	}
 }

--- a/internal/modules/settings/schema/integration/typed_codec_test.go
+++ b/internal/modules/settings/schema/integration/typed_codec_test.go
@@ -24,6 +24,9 @@ func TestDashboardSettingCodecPreservesDefaultsAndAcceptedNumberShapes(t *testin
 			"top_products_limit": float64(8),
 			"top_channels_limit": "9",
 		},
+		"accounting": map[string]interface{}{
+			"refund_reverses_cost": "yes",
+		},
 	}, fallback)
 
 	if decoded.Alert.LowStockThreshold != 7 || decoded.Alert.OutOfStockProductsThreshold != 2 {
@@ -35,6 +38,9 @@ func TestDashboardSettingCodecPreservesDefaultsAndAcceptedNumberShapes(t *testin
 	if decoded.Ranking.TopProductsLimit != 8 || decoded.Ranking.TopChannelsLimit != 9 {
 		t.Fatalf("dashboard ranking decode mismatch: %#v", decoded.Ranking)
 	}
+	if !decoded.Accounting.RefundReversesCost {
+		t.Fatalf("dashboard accounting decode mismatch: %#v", decoded.Accounting)
+	}
 
 	encoded := settingsstorefront.EncodeDashboardSetting(decoded)
 	if !reflect.DeepEqual(encoded["alert"], map[string]interface{}{
@@ -44,6 +50,11 @@ func TestDashboardSettingCodecPreservesDefaultsAndAcceptedNumberShapes(t *testin
 		"payments_failed_threshold":        int64(10),
 	}) {
 		t.Fatalf("dashboard encode mismatch: %#v", encoded)
+	}
+	if !reflect.DeepEqual(encoded["accounting"], map[string]interface{}{
+		"refund_reverses_cost": true,
+	}) {
+		t.Fatalf("dashboard accounting encode mismatch: %#v", encoded)
 	}
 }
 
@@ -131,7 +142,7 @@ func TestUpstreamSyncCodecPreservesFallbackAndBounds(t *testing.T) {
 
 func TestTypedSettingJSONNormalizersComposeDefaultDecodeAndEncode(t *testing.T) {
 	dashboard := settingsstorefront.NormalizeDashboardSettingJSON(jsonmap.JSON{})
-	if dashboard["alert"] == nil || dashboard["ranking"] == nil {
+	if dashboard["alert"] == nil || dashboard["ranking"] == nil || dashboard["accounting"] == nil {
 		t.Fatalf("dashboard JSON normalizer omitted defaults: %#v", dashboard)
 	}
 	affiliate := NormalizeAffiliateSettingJSON(jsonmap.JSON{"commission_rate": 101})

--- a/internal/modules/settings/schema/storefront/dashboard.go
+++ b/internal/modules/settings/schema/storefront/dashboard.go
@@ -19,10 +19,16 @@ type DashboardRankingSetting struct {
 	TopChannelsLimit int `json:"top_channels_limit"`
 }
 
+// DashboardAccountingSetting 描述仪表盘财务统计口径。
+type DashboardAccountingSetting struct {
+	RefundReversesCost bool `json:"refund_reverses_cost"`
+}
+
 // DashboardSetting 是仪表盘设置的 typed representation。
 type DashboardSetting struct {
-	Alert   DashboardAlertSetting   `json:"alert"`
-	Ranking DashboardRankingSetting `json:"ranking"`
+	Alert      DashboardAlertSetting      `json:"alert"`
+	Ranking    DashboardRankingSetting    `json:"ranking"`
+	Accounting DashboardAccountingSetting `json:"accounting"`
 }
 
 // DefaultDashboardSetting 返回稳定的仪表盘默认设置。
@@ -37,6 +43,9 @@ func DefaultDashboardSetting() DashboardSetting {
 		Ranking: DashboardRankingSetting{
 			TopProductsLimit: 5,
 			TopChannelsLimit: 5,
+		},
+		Accounting: DashboardAccountingSetting{
+			RefundReversesCost: false,
 		},
 	})
 }
@@ -89,6 +98,13 @@ func DecodeDashboardSetting(raw jsonmap.JSON, fallback DashboardSetting) Dashboa
 			result.Ranking.TopChannelsLimit = parsed
 		}
 	}
+	if accounting, ok := raw["accounting"].(map[string]interface{}); ok {
+		result.Accounting.RefundReversesCost = settingsvalue.ReadBool(
+			accounting,
+			"refund_reverses_cost",
+			result.Accounting.RefundReversesCost,
+		)
+	}
 	return NormalizeDashboardSetting(result)
 }
 
@@ -105,6 +121,9 @@ func EncodeDashboardSetting(setting DashboardSetting) jsonmap.JSON {
 		"ranking": map[string]interface{}{
 			"top_products_limit": normalized.Ranking.TopProductsLimit,
 			"top_channels_limit": normalized.Ranking.TopChannelsLimit,
+		},
+		"accounting": map[string]interface{}{
+			"refund_reverses_cost": normalized.Accounting.RefundReversesCost,
 		},
 	}
 }


### PR DESCRIPTION
## 背景

仪表盘利润统计会过滤 `cost_price = 0` 的订单项，导致零成本商品的销售收入未被计入，但退款金额仍会被扣除。

例如：

- 3 笔售价 1 元、成本 1 元的订单支付后退款
- 1 笔售价 50 元、成本 0 元的订单支付后退款

原统计结果为：

- 总成本：3.00
- 总利润：-53.00

其中 50 元零成本商品的收入被过滤，但退款仍被扣除。

## 修改内容

- 修复零成本订单项收入未计入利润统计的问题
- 同步修复利润总览和利润趋势计算
- 新增“退款时冲回成本”仪表盘设置
- 默认关闭新开关，保持原有成本统计口径
- 开启后：
  - 全额退款冲回全部成本
  - 部分退款按退款金额占订单实付金额的比例冲回成本
  - 父订单退款使用其子订单总成本作为计算基数
  - 跨周期退款在退款发生周期体现成本调整
- 将退款成本设置加入仪表盘缓存键，避免切换设置后命中旧缓存
- 添加简体中文、繁体中文和英文文案

## 修复后的结果

对于上述测试数据：

| 设置 | 总成本 | 总利润 |
| --- | ---: | ---: |
| 不冲回成本 | 3.00 | -3.00 |
| 冲回成本 | 0.00 | 0.00 |

## 兼容性

- 新开关默认关闭
- 不需要数据库迁移
- 不需要回填历史数据
- 仪表盘根据现有订单和退款记录动态重新计算

## 测试

- [x] `go test ./...`
- [x] 管理端 TypeScript 类型检查
- [x] 管理端单元测试（28 tests）
- [x] Vite 生产构建
- [x] 零成本商品支付及退款场景
- [x] 部分退款成本冲回
- [x] 父子订单退款
- [x] 跨周期退款