### PR TITLE
fix: 权限管理页角色策略表格撑破容器导致横向溢出

### DIFF
--- a/frontend/admin/src/views/admin/Authz.vue
+++ b/frontend/admin/src/views/admin/Authz.vue
@@ -868,7 +868,7 @@ onMounted(async () => {
       </div>
 
       <div class="grid grid-cols-1 xl:grid-cols-[1fr_360px] gap-4">
-        <div class="space-y-3">
+        <div class="min-w-0 space-y-3">
           <Input v-model="adminKeyword" :placeholder="text.adminSearchPlaceholder" class="h-9" />
           <div class="rounded-lg border border-border overflow-x-auto">
             <Table class="min-w-[900px]">
@@ -1005,7 +1005,7 @@ onMounted(async () => {
         </div>
       </section>
 
-      <section class="rounded-xl border border-border bg-card p-5 space-y-4 xl:col-span-2">
+      <section class="min-w-0 rounded-xl border border-border bg-card p-5 space-y-4 xl:col-span-2">
         <div class="flex items-center justify-between">
           <h2 class="text-base font-medium">{{ text.policiesTitle }}</h2>
           <span class="text-xs text-muted-foreground" v-if="selectedRole">{{ stripRolePrefix(selectedRole) }}</span>
@@ -1143,7 +1143,7 @@ onMounted(async () => {
           </div>
         </div>
 
-        <div class="space-y-3">
+        <div class="min-w-0 space-y-3">
           <div class="text-sm text-muted-foreground">{{ text.rolesLabel }}</div>
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
             <Label


### PR DESCRIPTION
## Summary
- Authz.vue（权限管理）页面在窄屏/笔记本分辨率下，"角色策略"表格会撑破外层 CSS Grid 容器，导致整个页面布局横向溢出、卡片错位。
- 根因：Grid 子项默认有隐藏的 min-width: auto（等于内部内容的最大内容宽度），表格内部套了 overflow-x-auto 想做横向滚动，但外层 Grid 容器没有显式设置 min-width: 0，导致浏览器仍按内部表格写死的 min-w-[720px] / min-w-[900px] 去撑大 Grid 轨道，而不是让内部滚动容器生效。
- 修复：给三处相关的 Grid 子容器（管理员列表区、角色策略区、管理员角色分配区）显式加上 min-w-0，使内部的 overflow-x-auto 正常生效，窄屏下表格改为可横向滚动而不是撑裂整个页面布局。

修复前
<img width="797" height="298" alt="Screenshot 2026-08-13 203514" src="https://github.com/user-attachments/assets/6bdbb9ca-0f0c-417f-bc4c-90014a1e2738" />

修复后
<img width="775" height="310" alt="Screenshot 2026-08-13 220649" src="https://github.com/user-attachments/assets/fa8d83c6-7a5c-4d15-b097-c2396d7e3b16" />



## Test plan
- [x] vue-tsc -b --noEmit 通过
- [x] vite build 构建成功
- [x] 本地对比修改前后，窄屏（如笔记本分辨率）下"角色策略"卡片不再溢出/错位