### PR TITLE
fix(style)：设置logo后Header同时显示logo和网站名称

### DIFF
--- a/frontend/user/src/components/Navbar.vue
+++ b/frontend/user/src/components/Navbar.vue
@@ -5,14 +5,14 @@
     :style="{ transitionDuration: 'var(--ui-duration-normal)' }">
     <div class="container mx-auto px-4 flex items-center justify-between gap-4">
       <!-- Logo -->
-      <router-link to="/" class="theme-wordmark group relative" :title="brandSiteName">
+      <router-link to="/" class="theme-wordmark group relative gap-3" :title="brandSiteName">
         <img
           v-if="brandLogo"
           :src="brandLogo"
           :alt="brandSiteName"
-          class="h-8 max-w-[180px] object-contain"
+          class="h-8 max-w-[180px] shrink-0 object-contain"
         />
-        <span v-else class="theme-wordmark-text">{{ brandSiteName }}</span>
+        <span class="theme-wordmark-text">{{ brandSiteName }}</span>
       </router-link>
 
       <!-- Desktop Menu -->

--- a/frontend/user/src/style.css
+++ b/frontend/user/src/style.css
@@ -302,6 +302,7 @@ html[data-telegram-mini-app="true"] body {
 
   .theme-wordmark-text {
     @apply block;
+    min-width: 0;
     font-size: 1rem;
     font-weight: 700;
     letter-spacing: -0.018em;


### PR DESCRIPTION
## 变更说明

- 修复配置 `site_logo` 后，用户端 Header 仅显示 Logo、不显示网站名称的[问题](https://github.com/dujiao-next/dujiao-next/pull/277#issuecomment-5274881510)
- Header 品牌区域调整为“左侧 Logo + 右侧网站名称”，与 Footer 保持一致
- 增加文本收缩处理，避免较长网站名称撑开导航栏
- 未配置 Logo 时仍保持只显示网站名称