### PR TITLE
fix: 支付记录筛选改为动态获取并支持提供方+支付方式联动筛选

### DIFF
--- a/frontend/admin/src/views/admin/Payments.vue
+++ b/frontend/admin/src/views/admin/Payments.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, reactive, ref, watch } from 'vue'
+import { onMounted, reactive, ref, watch, computed } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -51,34 +51,25 @@ const detailPayment = ref<AdminPayment | null>(null)
 const exporting = ref(false)
 const exportError = ref('')
 
-// 动态获取的筛选选项
-const availableChannelTypes = ref<Array<{ value: string; label: string }>>([])
+// 动态获取的筛选选项：channelType 按 providerType 联动
+const rawChannels = ref<Array<{ provider_type: string; channel_type: string }>>([])
 const availableProviderTypes = ref<Array<{ value: string; label: string }>>([])
 
 const fetchFilterOptions = async () => {
   try {
     const response = await adminAPI.getPaymentChannels({ page: 1, page_size: 200 })
     const channels = response.data.data || []
+    rawChannels.value = channels.map((channel: any) => ({
+      provider_type: channel.provider_type,
+      channel_type: channel.channel_type,
+    }))
 
-    // 提取所有 channel_type，去重
-    const channelTypeSet = new Set<string>()
     const providerTypeSet = new Set<string>()
-
     channels.forEach((channel: any) => {
-      if (channel.channel_type) channelTypeSet.add(channel.channel_type)
       if (channel.provider_type) providerTypeSet.add(channel.provider_type)
     })
-
-    // 添加 wallet（钱包余额不在 channel 配置里）
+    // 钱包余额不在 channel 配置里，单独补充
     providerTypeSet.add('wallet')
-
-    // 转换为选项数组
-    availableChannelTypes.value = Array.from(channelTypeSet)
-      .sort()
-      .map(type => ({
-        value: type,
-        label: channelTypeLabel(type)
-      }))
 
     availableProviderTypes.value = Array.from(providerTypeSet)
       .sort()
@@ -89,6 +80,31 @@ const fetchFilterOptions = async () => {
   } catch (error) {
     console.error('Failed to fetch filter options:', error)
   }
+}
+
+const availableChannelTypes = computed(() => {
+  const selectedProvider = normalizeFilterValue(filters.providerType)
+  const channelTypeSet = new Set<string>()
+
+  rawChannels.value.forEach((channel) => {
+    if (!channel.channel_type) return
+    if (selectedProvider && channel.provider_type !== selectedProvider) return
+    channelTypeSet.add(channel.channel_type)
+  })
+
+  // wallet 特殊处理：钱包余额不在 channel 配置里
+  if (!selectedProvider || selectedProvider === 'wallet') {
+    channelTypeSet.add('balance')
+  }
+
+  return Array.from(channelTypeSet)
+    .sort()
+    .map(type => ({ value: type, label: channelTypeLabel(type) }))
+})
+
+const handleProviderTypeChange = () => {
+  filters.channelType = '__all__'
+  handleSearch()
 }
 
 const fetchPayments = async (page = 1, options: ListFetchOptions = {}) => {
@@ -349,6 +365,19 @@ watch(
           <Input v-model="filters.channelId" :placeholder="t('admin.payments.filterChannelId')" @update:modelValue="debouncedSearch" />
         </div>
         <div class="w-full md:w-40">
+          <Select v-model="filters.providerType" @update:modelValue="handleProviderTypeChange">
+            <SelectTrigger class="h-9 w-full">
+              <SelectValue :placeholder="t('admin.payments.filterProviderAll')" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">{{ t('admin.payments.filterProviderAll') }}</SelectItem>
+              <SelectItem v-for="opt in availableProviderTypes" :key="opt.value" :value="opt.value">
+                {{ opt.label }}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div class="w-full md:w-40">
           <Select v-model="filters.channelType" @update:modelValue="handleSearch">
             <SelectTrigger class="h-9 w-full">
               <SelectValue placeholder="全部支付方式" />
@@ -356,19 +385,6 @@ watch(
             <SelectContent>
               <SelectItem value="__all__">全部支付方式</SelectItem>
               <SelectItem v-for="opt in availableChannelTypes" :key="opt.value" :value="opt.value">
-                {{ opt.label }}
-              </SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <div class="w-full md:w-40">
-          <Select v-model="filters.providerType" @update:modelValue="handleSearch">
-            <SelectTrigger class="h-9 w-full">
-              <SelectValue :placeholder="t('admin.payments.filterProviderAll')" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__all__">{{ t('admin.payments.filterProviderAll') }}</SelectItem>
-              <SelectItem v-for="opt in availableProviderTypes" :key="opt.value" :value="opt.value">
                 {{ opt.label }}
               </SelectItem>
             </SelectContent>

--- a/frontend/admin/src/views/admin/Payments.vue
+++ b/frontend/admin/src/views/admin/Payments.vue
@@ -35,6 +35,7 @@ const filters = reactive({
   userId: '',
   orderId: '',
   channelId: '',
+  channelType: '__all__',
   providerType: '__all__',
   createdFrom: '',
   createdTo: '',
@@ -50,6 +51,46 @@ const detailPayment = ref<AdminPayment | null>(null)
 const exporting = ref(false)
 const exportError = ref('')
 
+// 动态获取的筛选选项
+const availableChannelTypes = ref<Array<{ value: string; label: string }>>([])
+const availableProviderTypes = ref<Array<{ value: string; label: string }>>([])
+
+const fetchFilterOptions = async () => {
+  try {
+    const response = await adminAPI.getPaymentChannels({ page: 1, page_size: 200 })
+    const channels = response.data.data || []
+
+    // 提取所有 channel_type，去重
+    const channelTypeSet = new Set<string>()
+    const providerTypeSet = new Set<string>()
+
+    channels.forEach((channel: any) => {
+      if (channel.channel_type) channelTypeSet.add(channel.channel_type)
+      if (channel.provider_type) providerTypeSet.add(channel.provider_type)
+    })
+
+    // 添加 wallet（钱包余额不在 channel 配置里）
+    providerTypeSet.add('wallet')
+
+    // 转换为选项数组
+    availableChannelTypes.value = Array.from(channelTypeSet)
+      .sort()
+      .map(type => ({
+        value: type,
+        label: channelTypeLabel(type)
+      }))
+
+    availableProviderTypes.value = Array.from(providerTypeSet)
+      .sort()
+      .map(type => ({
+        value: type,
+        label: providerTypeLabel(type)
+      }))
+  } catch (error) {
+    console.error('Failed to fetch filter options:', error)
+  }
+}
+
 const fetchPayments = async (page = 1, options: ListFetchOptions = {}) => {
   if (!options.preserveRows) loading.value = true
   try {
@@ -61,6 +102,7 @@ const fetchPayments = async (page = 1, options: ListFetchOptions = {}) => {
       order_id: filters.orderId || undefined,
       channel_id: filters.channelId || undefined,
       provider_type: normalizeFilterValue(filters.providerType) || undefined,
+      channel_type: normalizeFilterValue(filters.channelType) || undefined,
       created_from: toRFC3339(filters.createdFrom),
       created_to: toRFC3339(filters.createdTo),
     })
@@ -108,6 +150,7 @@ const handleExport = async () => {
       order_id: filters.orderId || undefined,
       channel_id: filters.channelId || undefined,
       provider_type: normalizeFilterValue(filters.providerType) || undefined,
+      channel_type: normalizeFilterValue(filters.channelType) || undefined,
       created_from: toRFC3339(filters.createdFrom),
       created_to: toRFC3339(filters.createdTo),
       status: normalizeFilterValue(filters.status) || undefined,
@@ -255,6 +298,7 @@ const formatPayload = (payload: unknown) => {
 }
 
 onMounted(() => {
+  fetchFilterOptions()
   if (route.query.user_id) {
     filters.userId = String(route.query.user_id || '')
   }
@@ -305,17 +349,28 @@ watch(
           <Input v-model="filters.channelId" :placeholder="t('admin.payments.filterChannelId')" @update:modelValue="debouncedSearch" />
         </div>
         <div class="w-full md:w-40">
+          <Select v-model="filters.channelType" @update:modelValue="handleSearch">
+            <SelectTrigger class="h-9 w-full">
+              <SelectValue placeholder="全部支付方式" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">全部支付方式</SelectItem>
+              <SelectItem v-for="opt in availableChannelTypes" :key="opt.value" :value="opt.value">
+                {{ opt.label }}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div class="w-full md:w-40">
           <Select v-model="filters.providerType" @update:modelValue="handleSearch">
             <SelectTrigger class="h-9 w-full">
               <SelectValue :placeholder="t('admin.payments.filterProviderAll')" />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="__all__">{{ t('admin.payments.filterProviderAll') }}</SelectItem>
-              <SelectItem value="wallet">{{ t('admin.paymentChannels.providerTypes.wallet') }}</SelectItem>
-              <SelectItem value="official">{{ t('admin.paymentChannels.providerTypes.official') }}</SelectItem>
-              <SelectItem value="epay">{{ t('admin.paymentChannels.providerTypes.epay') }}</SelectItem>
-              <SelectItem value="epusdt">{{ t('admin.paymentChannels.providerTypes.epusdt') }}</SelectItem>
-              <SelectItem value="tokenpay">{{ t('admin.paymentChannels.providerTypes.tokenpay') }}</SelectItem>
+              <SelectItem v-for="opt in availableProviderTypes" :key="opt.value" :value="opt.value">
+                {{ opt.label }}
+              </SelectItem>
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
## 修复问题

修复 #289 中提到的支付记录筛选项不全问题。

## 主要改动

### 1. 支付渠道筛选从硬编码改为动态获取

**问题**：原先支付提供方筛选下拉框硬编码了只有5个选项（wallet、official、epay、epusdt、tokenpay），导致 bepusdt、dujiaopay、okpay 等后端已支持的渠道无法筛选。

**解决**：通过调用现成的 `getPaymentChannels` API，动态提取所有已配置的 `provider_type` 和 `channel_type`，自动生成筛选选项。以后新增支付渠道，前端筛选下拉框会自动显示，不需要再改代码。

### 2. 支持支付提供方 + 支付方式联动筛选

**改进**：
- 原先只能按 `provider_type`（支付提供方）筛选，无法直接找"所有支付宝订单"或"所有USDT订单"
- 现在支持二级联动筛选：
  - **主筛选**：支付提供方（provider_type），如 官方渠道、TokenPay、易支付 等
  - **次筛选**：支付方式（channel_type），根据已选的提供方动态显示对应的支付方式
  - 例如选择"官方渠道"后，支付方式下拉框只会显示支付宝、微信、QQ钱包、PayPal 等属于官方的方式，不会显示 TokenPay 的 USDT 选项
- 切换提供方时自动重置支付方式为"全部"，避免筛选错乱

### 3. 钱包余额特殊处理

钱包余额（wallet provider）不在支付渠道配置表里，单独补充了 `channel_type = balance` 的映射逻辑。

## 技术细节

- 后端已支持 `channel_type` 筛选（`admin_handler.go:316`、`payment_store.go:182`），无需改动
- 前端使用 Vue `computed` 实现 `availableChannelTypes` 根据 `filters.providerType` 联动过滤
- `handleProviderTypeChange()` 在切换提供方时自动清空支付方式筛选

## 测试

- ✅ Go 后端编译通过
- ✅ Vue TypeScript 类型检查通过
- ✅ 筛选逻辑：选择不同提供方时，支付方式下拉框正确联动显示对应选项
- ✅ 导出功能同步支持 `channel_type` 参数