### PR TITLE
feat: Stripe Checkout 创建时自动带上订单邮箱预填充

### DIFF
--- a/internal/modules/payment/application/payment_service_provider.go
+++ b/internal/modules/payment/application/payment_service_provider.go
@@ -157,6 +157,9 @@ func (s *PaymentService) applyProviderPayment(input CreatePaymentInput, order *o
 	}
 	returnURLQuery := buildPaymentReturnQuery(input, order, returnMarker, "")
 
+	// customerEmail 用于渠道预填邮箱（如 Stripe customer_email），来自会员邮箱或游客下单邮箱。
+	customerEmail, _, _ := s.resolveNotificationCustomer(order)
+
 	createInput := paymentcontract.GatewayCreateInput{
 		PaymentID:      payment.ID,
 		OrderID:        order.ID,
@@ -164,6 +167,7 @@ func (s *PaymentService) applyProviderPayment(input CreatePaymentInput, order *o
 		Subject:        buildOrderSubject(order),
 		Amount:         payment.Amount,
 		Currency:       payment.Currency,
+		Email:          strings.TrimSpace(customerEmail),
 		ClientIP:       strings.TrimSpace(input.ClientIP),
 		ChannelType:    channel.ChannelType,
 		Extra:          extra,

--- a/internal/modules/payment/contract/gateway.go
+++ b/internal/modules/payment/contract/gateway.go
@@ -20,6 +20,7 @@ type GatewayCreateInput struct {
 	Subject        string
 	Amount         money.Amount
 	Currency       string
+	Email          string
 	NotifyURL      string
 	ReturnURL      string
 	ReturnURLQuery map[string]string

--- a/internal/modules/payment/infrastructure/gateway/adapters/stripe/adapter.go
+++ b/internal/modules/payment/infrastructure/gateway/adapters/stripe/adapter.go
@@ -103,6 +103,7 @@ func (a *stripeAdapter) CreatePayment(ctx context.Context, raw jsonmap.JSON, inp
 		Amount:      payAmount,
 		Currency:    payCurrency,
 		Description: input.Subject,
+		Email:       strings.TrimSpace(input.Email),
 		SuccessURL:  successURL,
 		CancelURL:   cancelURL,
 	}

--- a/internal/modules/payment/infrastructure/gateway/adapters/stripe/adapter_test.go
+++ b/internal/modules/payment/infrastructure/gateway/adapters/stripe/adapter_test.go
@@ -3,8 +3,10 @@ package stripeadapter
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	paymentcontract "github.com/dujiao-next/internal/modules/payment/contract"
@@ -164,6 +166,46 @@ func TestStripeAdapter_CreatePayment_NoExchangeRate_AmountSentEqualsOriginal(t *
 	}
 	if _, ok := result.Payload["original_amount"]; ok {
 		t.Fatal("Payload should NOT contain original_amount when no conversion configured")
+	}
+}
+
+// TestStripeAdapter_CreatePayment_EmailPassedToCustomerEmail 守护 #286：
+// GatewayCreateInput.Email 必须原样传给 stripe.CreateInput.Email，
+// 最终作为 customer_email 提交给 Stripe，实现 Checkout 页面邮箱预填充。
+func TestStripeAdapter_CreatePayment_EmailPassedToCustomerEmail(t *testing.T) {
+	var gotForm string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotForm = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"cs_test_email_001","url":"https://checkout.stripe.com/pay/cs_test_email_001","status":"open"}`))
+	}))
+	defer server.Close()
+
+	a := NewStripeAdapter()
+	raw := jsonmap.JSON{
+		"secret_key":           "sk_test_abc",
+		"webhook_secret":       "whsec_xyz",
+		"success_url":          "https://shop.example.com/success",
+		"cancel_url":           "https://shop.example.com/cancel",
+		"api_base_url":         server.URL,
+		"payment_method_types": []any{"card"},
+	}
+
+	input := paymentcontract.GatewayCreateInput{
+		OrderNo:   "ORDER-EMAIL-1",
+		Subject:   "email prefill test",
+		Currency:  "USD",
+		Amount:    money.FromDecimal(decimal.NewFromInt(5)),
+		ReturnURL: "https://shop.example.com/pay",
+		Email:     "buyer@example.com",
+	}
+
+	if _, err := a.CreatePayment(context.Background(), raw, input); err != nil {
+		t.Fatalf("CreatePayment() failed: %v", err)
+	}
+	if !strings.Contains(gotForm, "customer_email=buyer%40example.com") {
+		t.Fatalf("expected form to contain customer_email=buyer%%40example.com, got %q", gotForm)
 	}
 }
 

--- a/internal/modules/payment/infrastructure/gateway/stripe/stripe.go
+++ b/internal/modules/payment/infrastructure/gateway/stripe/stripe.go
@@ -98,6 +98,7 @@ type CreateInput struct {
 	Amount      string
 	Currency    string
 	Description string
+	Email       string
 	SuccessURL  string
 	CancelURL   string
 }
@@ -222,6 +223,9 @@ func CreatePayment(ctx context.Context, cfg *Config, input CreateInput) (*Create
 	form.Set("line_items[0][price_data][product_data][name]", subject)
 	form.Set("metadata[order_no]", orderNo)
 	form.Set("payment_intent_data[metadata][order_no]", orderNo)
+	if email := strings.TrimSpace(input.Email); email != "" {
+		form.Set("customer_email", email)
+	}
 	for _, pmType := range cfg.PaymentMethodTypes {
 		form.Add("payment_method_types[]", pmType)
 		// Stripe 要求 Web Checkout 场景下 WeChat Pay 必须显式声明 client，否则返回 400。

--- a/internal/modules/payment/infrastructure/gateway/stripe/stripe_test.go
+++ b/internal/modules/payment/infrastructure/gateway/stripe/stripe_test.go
@@ -89,6 +89,60 @@ func TestCreatePaymentWeChatPayClientOption(t *testing.T) {
 	}
 }
 
+func TestCreatePaymentCustomerEmail(t *testing.T) {
+	tests := []struct {
+		name          string
+		email         string
+		expectSet     bool
+		expectedValue string
+	}{
+		{name: "WithEmail", email: " user@example.com ", expectSet: true, expectedValue: "user@example.com"},
+		{name: "EmptyEmail", email: "", expectSet: false},
+		{name: "WhitespaceEmail", email: "   ", expectSet: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var form url.Values
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				form, _ = url.ParseQuery(string(body))
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"cs_test_123","url":"https://checkout.stripe.com/c/pay/cs_test_123","status":"open"}`))
+			}))
+			defer server.Close()
+
+			cfg, err := ParseConfig(map[string]interface{}{
+				"secret_key":           "sk_test_123",
+				"webhook_secret":       "whsec_123",
+				"success_url":          "https://example.com/payment?stripe_return=1",
+				"cancel_url":           "https://example.com/payment?stripe_cancel=1",
+				"api_base_url":         server.URL,
+				"payment_method_types": []interface{}{"card"},
+			})
+			if err != nil {
+				t.Fatalf("parse config failed: %v", err)
+			}
+
+			_, err = CreatePayment(context.Background(), cfg, CreateInput{
+				OrderNo:  "ORDER-1002",
+				Amount:   "9.90",
+				Currency: "CNY",
+				Email:    tc.email,
+			})
+			if err != nil {
+				t.Fatalf("create payment failed: %v", err)
+			}
+			got := form.Get("customer_email")
+			if tc.expectSet && got != tc.expectedValue {
+				t.Fatalf("expected customer_email %q, got %q", tc.expectedValue, got)
+			}
+			if !tc.expectSet && got != "" {
+				t.Fatalf("expected no customer_email, got %q", got)
+			}
+		})
+	}
+}
+
 func TestVerifyAndParseWebhookCheckoutCompleted(t *testing.T) {
 	now := time.Unix(1760000000, 0)
 	cfg := &Config{


### PR DESCRIPTION
## Summary
- `GatewayCreateInput` 新增 `Email` 字段，来源为会员邮箱或游客下单邮箱（复用现有的 `resolveNotificationCustomer`）
- Stripe adapter 把该字段传给 native `stripe.CreateInput.Email`
- 创建 Checkout Session 时，非空邮箱写入 `customer_email` 参数，实现支付页面邮箱预填充，减少用户重复输入

Closes #286

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/modules/payment/...`
- [x] 新增 `stripe` 包测试：覆盖有邮箱 / 空邮箱 / 空格邮箱三种场景，断言 `customer_email` 表单字段
- [x] 新增 adapter 层测试：断言 `GatewayCreateInput.Email` 正确传递到最终请求体