### PR TITLE
fix: Stripe 换汇金额守恒误判 + Okpay HMAC-SHA256 协议升级

### DIFF
--- a/frontend/user/src/api/types.ts
+++ b/frontend/user/src/api/types.ts
@@ -470,6 +470,12 @@ export interface PaymentCreateResult {
     order_paid?: boolean
     wallet_paid_amount?: string
     online_pay_amount?: string
+    payable_amount?: string
+    // currency 是 payable_amount 的实际币种；换汇渠道下与订单币种不同，
+    // 展示 payable_amount 必须搭配这个字段，不能直接套用订单币种。
+    currency?: string
+    fee_amount?: string
+    fee_policy?: string
     payment_id?: number
     order_no?: string
     channel_id?: number

--- a/frontend/user/src/composables/usePayment.ts
+++ b/frontend/user/src/composables/usePayment.ts
@@ -391,19 +391,27 @@ export function usePayment() {
   const pollingActive = computed(() => pollTimer.value !== null)
   const orderItems = computed(() => (Array.isArray(order.value?.items) ? order.value.items : []))
   const customerFeeApplied = computed(() => isCustomerSurchargePayment(paymentResult.value) && (amountToCents(paymentResult.value?.fee_amount) || 0) > 0)
+  // payable_amount/amount/online_pay_amount/fee_amount 均为 payment.Amount 或其派生值——
+  // 换汇渠道（如 Stripe 配置了 target_currency+exchange_rate）下这是结算币种数值
+  // （如 GBP），不是订单币种（CNY）。展示时必须搭配后端返回的 paymentResult.currency，
+  // 不能直接套用 order.currency，否则会把结算币种数值显示成订单币种。
+  const payableAmountCurrency = computed(() => {
+    const currency = String(paymentResult.value?.currency || '').trim()
+    return currency || order.value?.currency
+  })
   const customerFeeAmountDisplay = computed(() => {
     if (!customerFeeApplied.value) return ''
-    return formatMoney(String(paymentResult.value?.fee_amount || '0'), order.value?.currency)
+    return formatMoney(String(paymentResult.value?.fee_amount || '0'), payableAmountCurrency.value)
   })
   const payableAmountDisplay = computed(() => {
     if (paymentResult.value?.payable_amount !== undefined && paymentResult.value?.payable_amount !== null && paymentResult.value?.payable_amount !== '') {
-      return formatMoney(String(paymentResult.value.payable_amount), order.value?.currency)
+      return formatMoney(String(paymentResult.value.payable_amount), payableAmountCurrency.value)
     }
     if (paymentResult.value?.amount !== undefined && paymentResult.value?.amount !== null && paymentResult.value?.amount !== '') {
-      return formatMoney(String(paymentResult.value.amount), order.value?.currency)
+      return formatMoney(String(paymentResult.value.amount), payableAmountCurrency.value)
     }
     if (paymentResult.value?.online_pay_amount !== undefined && paymentResult.value?.online_pay_amount !== null && paymentResult.value?.online_pay_amount !== '') {
-      return formatMoney(String(paymentResult.value.online_pay_amount), order.value?.currency)
+      return formatMoney(String(paymentResult.value.online_pay_amount), payableAmountCurrency.value)
     }
     return formatMoney(String(order.value?.total_amount ?? ''), order.value?.currency)
   })

--- a/frontend/user/src/composables/usePayment.ts
+++ b/frontend/user/src/composables/usePayment.ts
@@ -391,17 +391,22 @@ export function usePayment() {
   const pollingActive = computed(() => pollTimer.value !== null)
   const orderItems = computed(() => (Array.isArray(order.value?.items) ? order.value.items : []))
   const customerFeeApplied = computed(() => isCustomerSurchargePayment(paymentResult.value) && (amountToCents(paymentResult.value?.fee_amount) || 0) > 0)
-  // payable_amount/amount/online_pay_amount/fee_amount 均为 payment.Amount 或其派生值——
-  // 换汇渠道（如 Stripe 配置了 target_currency+exchange_rate）下这是结算币种数值
-  // （如 GBP），不是订单币种（CNY）。展示时必须搭配后端返回的 paymentResult.currency，
-  // 不能直接套用 order.currency，否则会把结算币种数值显示成订单币种。
+  // payable_amount/amount/online_pay_amount 均为 payment.Amount 或其派生值——换汇渠道
+  // （如 Stripe 配置了 target_currency+exchange_rate）下这是结算币种数值（如 GBP），
+  // 不是订单币种（CNY）。展示时必须搭配后端返回的 paymentResult.currency，不能直接
+  // 套用 order.currency，否则会把结算币种数值显示成订单币种。
+  //
+  // fee_amount 不受影响：calculatePaymentAmounts 按订单币种（CNY）算出手续费后，
+  // applyProviderPayment 只用 AmountSent/CurrencySent 覆盖 payment.Amount/Currency，
+  // 从不改写 payment.FeeAmount，所以 fee_amount 永远是订单币种数值，必须继续用
+  // order.currency 展示，不能套用 payableAmountCurrency，否则会把 CNY 手续费误标成 GBP。
   const payableAmountCurrency = computed(() => {
     const currency = String(paymentResult.value?.currency || '').trim()
     return currency || order.value?.currency
   })
   const customerFeeAmountDisplay = computed(() => {
     if (!customerFeeApplied.value) return ''
-    return formatMoney(String(paymentResult.value?.fee_amount || '0'), payableAmountCurrency.value)
+    return formatMoney(String(paymentResult.value?.fee_amount || '0'), order.value?.currency)
   })
   const payableAmountDisplay = computed(() => {
     if (paymentResult.value?.payable_amount !== undefined && paymentResult.value?.payable_amount !== null && paymentResult.value?.payable_amount !== '') {

--- a/internal/architecture/payment_service_structure_test.go
+++ b/internal/architecture/payment_service_structure_test.go
@@ -30,7 +30,7 @@ func TestPaymentServiceImplementationIsSplitByResponsibility(t *testing.T) {
 			"tenantReturnPath", "resolveTokenPayOrderUserKey",
 		},
 		"payment_service_rules.go": {
-			"normalizeOrderAmount", "calculatePaymentAmounts", "paymentCoveredOrderAmount", "pickFirstNonEmpty",
+			"normalizeOrderAmount", "calculatePaymentAmounts", "paymentCoveredOrderAmount", "paymentExchangeRate", "pickFirstNonEmpty",
 			"shouldMarkFulfilling", "shouldUseCNYPaymentCurrency", "validatePaymentAmountForChannel",
 			"validatePaymentCurrencyForChannel", "resolveExpireMinutes", "normalizePaymentStatus",
 			"isPaymentStatusValid", "shouldAutoFulfill", "isOrderFullyAutoFulfill",

--- a/internal/modules/payment/application/payment_service_callback.go
+++ b/internal/modules/payment/application/payment_service_callback.go
@@ -284,7 +284,7 @@ func (s *PaymentService) applyPaymentUpdate(payment *paymentdomain.Payment, orde
 		// 混合支付切换渠道会退回余额并抬高在线应付额，而旧链接在网关侧依然可付，
 		// 缺少这道校验就能用旧链接的小额付款换到整单商品。
 		requiredOnlineAmount := normalizeOrderAmount(lockedOrder.TotalAmount.Decimal.Sub(lockedOrder.WalletPaidAmount.Decimal))
-		coveredOnlineAmount := paymentCoveredOrderAmount(lockedPayment)
+		coveredOnlineAmount := paymentCoveredOrderAmount(lockedPayment, input.Amount.Decimal)
 		underpaid := status == constants.PaymentStatusSuccess && orderOpen &&
 			coveredOnlineAmount.LessThan(requiredOnlineAmount)
 

--- a/internal/modules/payment/application/payment_service_rules.go
+++ b/internal/modules/payment/application/payment_service_rules.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"fmt"
 	"strings"
 
 	paymentdomain "github.com/dujiao-next/internal/modules/payment/domain"
@@ -31,17 +32,68 @@ func calculatePaymentAmounts(baseAmount, feeRate, fixedFee decimal.Decimal, cust
 	return baseAmount, feeAmount, constants.PaymentFeePolicyMerchantAbsorbed
 }
 
-// paymentCoveredOrderAmount 推算一笔支付创建时承诺覆盖的订单在线应付额。
+// paymentExchangeRate 读取创建支付时存下的渠道换汇汇率快照
+// （ProviderPayload["exchange_rate"]）。存在即说明这笔支付发生过法币换汇（渠道配置了
+// target_currency + exchange_rate，见各 adapter 的 cfg.NeedsCurrencyConversion 分支），
+// applyProviderPayment 回写后 payment.Amount/Currency 已经不是订单原始币种。返回零值
+// 和 false 表示未换汇或快照缺失/无效。
+func paymentExchangeRate(payment *paymentdomain.Payment) (decimal.Decimal, bool) {
+	if payment == nil || payment.ProviderPayload == nil {
+		return decimal.Zero, false
+	}
+	rateRaw, ok := payment.ProviderPayload["exchange_rate"]
+	if !ok {
+		return decimal.Zero, false
+	}
+	rateStr := strings.TrimSpace(fmt.Sprint(rateRaw))
+	if rateStr == "" {
+		return decimal.Zero, false
+	}
+	rate, err := decimal.NewFromString(rateStr)
+	if err != nil || !rate.IsPositive() {
+		return decimal.Zero, false
+	}
+	return rate, true
+}
+
+// paymentCoveredOrderAmount 推算一笔支付回调实际覆盖的订单在线应付额（订单币种口径）。
 //
-// Amount / FeeAmount / FeePolicy 均为创建时快照：用户承担手续费的策略下 Amount
-// 含加收部分，必须扣除后才是订单侧的抵扣基数；商家承担或无手续费时 Amount 即基数。
+// callbackAmount 是本次回调携带的实际到账金额，仅在发生换汇的场景下使用（见下）。
+// Amount / FeeAmount / FeePolicy 均为创建时快照：用户承担手续费的策略下 Amount 含
+// 加收部分，必须扣除后才是订单侧的抵扣基数；商家承担或无手续费时 Amount 即基数。
 // 升级前未写入策略快照（FeePolicy 为空）且带正数手续费的历史记录，与 CreatePayment
 // 的 legacy 判定保持一致，按用户承担解释。
-func paymentCoveredOrderAmount(payment *paymentdomain.Payment) decimal.Decimal {
+//
+// 只有发生换汇的支付需要特殊处理：渠道按配置的汇率把订单原始币种（一般是 CNY）金额
+// 换算成结算币种（USD/GBP 等）下单（如 Stripe 配置 target_currency+exchange_rate），
+// applyProviderPayment 回写后 payment.Amount/Currency 变为结算币种；网关 webhook/回调
+// 本身直接返回结算币种数值，不会换算回订单币种。若直接用 payment.Amount 与订单原始
+// 币种总额比较，两个不同币种的数值硬比必然判定为金额不足。正确做法是用本次回调的
+// 实际到账金额（callbackAmount，结算币种）除以创建支付时存下的渠道汇率快照
+// ProviderPayload["exchange_rate"]，换算回订单币种。未发生换汇的渠道，回调金额本来
+// 就是订单币种，继续使用 payment.Amount 原值。
+func paymentCoveredOrderAmount(payment *paymentdomain.Payment, callbackAmount decimal.Decimal) decimal.Decimal {
 	if payment == nil {
 		return decimal.Zero
 	}
 	covered := payment.Amount.Decimal
+	if rate, ok := paymentExchangeRate(payment); ok {
+		source := callbackAmount
+		if source.IsZero() {
+			source = payment.Amount.Decimal
+		}
+		covered = source.Div(rate)
+	} else if payment.ProviderPayload != nil {
+		if raw, ok := payment.ProviderPayload["original_amount"]; ok {
+			// 缺少汇率快照（历史数据遗漏字段）时退回订单原价，保底不误判欠付，
+			// 但无法侦测网关实际少到账的情况。
+			if s := strings.TrimSpace(fmt.Sprint(raw)); s != "" {
+				if original, err := decimal.NewFromString(s); err == nil {
+					covered = original
+				}
+			}
+		}
+	}
 	fee := payment.FeeAmount.Decimal
 	switch payment.FeePolicy {
 	case constants.PaymentFeePolicyCustomerSurcharge, constants.PaymentFeePolicyLegacyCustomerSurcharge:

--- a/internal/modules/payment/application/payment_service_wallet_test.go
+++ b/internal/modules/payment/application/payment_service_wallet_test.go
@@ -1290,9 +1290,129 @@ func TestPaymentCoveredOrderAmount(t *testing.T) {
 				FeeAmount: money.FromDecimal(decimal.RequireFromString(tt.feeAmount)),
 				FeePolicy: tt.feePolicy,
 			}
-			if got := paymentCoveredOrderAmount(payment); got.String() != tt.want {
+			if got := paymentCoveredOrderAmount(payment, decimal.Zero); got.String() != tt.want {
 				t.Fatalf("paymentCoveredOrderAmount() = %s, want %s", got.String(), tt.want)
 			}
 		})
+	}
+}
+
+// TestPaymentCoveredOrderAmountWithExchangeRateFullPayment 验证换汇渠道（如 Stripe
+// 配置 target_currency=GBP、exchange_rate=0.11，订单 1 CNY 换算成 0.11 GBP 下单）
+// 足额支付时，按渠道汇率把回调金额折算回订单币种，能正确判定覆盖了订单应付额，
+// 不会拿 GBP 数值直接跟 CNY 总额硬比而误判为金额不足。
+func TestPaymentCoveredOrderAmountWithExchangeRateFullPayment(t *testing.T) {
+	payment := &paymentdomain.Payment{
+		Amount:    money.FromDecimal(decimal.RequireFromString("0.11")),
+		FeeAmount: money.FromDecimal(decimal.Zero),
+		FeePolicy: constants.PaymentFeePolicyNone,
+		Currency:  "GBP",
+		ProviderPayload: jsonmap.JSON{
+			"original_amount":   "1",
+			"original_currency": "CNY",
+			"exchange_rate":     "0.11",
+		},
+	}
+	callbackAmount := decimal.RequireFromString("0.11")
+	got := paymentCoveredOrderAmount(payment, callbackAmount)
+	want := decimal.RequireFromString("1")
+	if !got.Equal(want) {
+		t.Fatalf("paymentCoveredOrderAmount() = %s, want %s", got.String(), want.String())
+	}
+}
+
+// TestStripeExchangeRateFullPaymentFulfillsOrder 验证 Stripe 渠道配置了
+// target_currency=GBP、exchange_rate=0.11（订单 1 CNY 换算成 0.11 GBP 下单），webhook
+// 回调返回 GBP 原值 0.11 时，应按汇率折算回 1 CNY 判定为足额支付，而不是把 0.11 直接
+// 当 CNY 数值比较误判为欠款。
+func TestStripeExchangeRateFullPaymentFulfillsOrder(t *testing.T) {
+	svc, db := setupPaymentServiceWalletTest(t)
+	channel := createUnderpaidChannel(t, db, svc, "Stripe GBP", constants.PaymentChannelTypeStripe)
+	order := createUnderpaidOrder(t, db, "STRIPE_GBP_FULL", 1, 1)
+
+	now := time.Now()
+	payment := &paymentdomain.Payment{
+		OrderID: order.ID, ChannelID: channel.ID, ProviderType: channel.ProviderType, ChannelType: channel.ChannelType,
+		InteractionMode: channel.InteractionMode,
+		Amount:          money.FromDecimal(decimal.RequireFromString("0.11")),
+		FeeAmount:       money.FromDecimal(decimal.Zero), FeePolicy: constants.PaymentFeePolicyNone,
+		Currency: "GBP",
+		Status:   constants.PaymentStatusPending,
+		ProviderPayload: jsonmap.JSON{
+			"original_amount":   "1",
+			"original_currency": "CNY",
+			"exchange_rate":     "0.11",
+		},
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(payment).Error; err != nil {
+		t.Fatalf("create payment failed: %v", err)
+	}
+
+	paid, err := svc.HandleCallback(PaymentCallbackInput{
+		PaymentID: payment.ID, OrderNo: order.OrderNo, ChannelID: channel.ID,
+		Status: constants.PaymentStatusSuccess,
+		Amount: money.FromDecimal(decimal.RequireFromString("0.11")), Currency: "GBP",
+		ProviderRef: "stripe-gbp-full-ref",
+	})
+	if err != nil {
+		t.Fatalf("handle stripe gbp full payment callback failed: %v", err)
+	}
+	if paid.ExceptionCode != "" {
+		t.Fatalf("stripe gbp full payment should not be flagged, got exception_code=%s", paid.ExceptionCode)
+	}
+
+	var reloadedOrder orderdomain.Order
+	if err := db.First(&reloadedOrder, order.ID).Error; err != nil {
+		t.Fatalf("reload order failed: %v", err)
+	}
+	if reloadedOrder.Status != constants.OrderStatusPaid || reloadedOrder.PaidAt == nil {
+		t.Fatalf("stripe gbp full payment must fulfill the order, got status=%s paid_at=%v", reloadedOrder.Status, reloadedOrder.PaidAt)
+	}
+}
+
+// TestStripeExchangeRateUnderpaidCallbackRejected 验证 Stripe GBP 换汇场景（订单 1
+// CNY，应收 0.11 GBP，实际回调只有 0.05 GBP）被 validateCallbackPaymentFacts 精确
+// 匹配直接拒绝——法币网关同样不允许少付，回调金额必须精确等于创建时的 payment.Amount。
+func TestStripeExchangeRateUnderpaidCallbackRejected(t *testing.T) {
+	svc, db := setupPaymentServiceWalletTest(t)
+	channel := createUnderpaidChannel(t, db, svc, "Stripe GBP Underpaid", constants.PaymentChannelTypeStripe)
+	order := createUnderpaidOrder(t, db, "STRIPE_GBP_UNDERPAID", 1, 1)
+
+	now := time.Now()
+	payment := &paymentdomain.Payment{
+		OrderID: order.ID, ChannelID: channel.ID, ProviderType: channel.ProviderType, ChannelType: channel.ChannelType,
+		InteractionMode: channel.InteractionMode,
+		Amount:          money.FromDecimal(decimal.RequireFromString("0.11")),
+		FeeAmount:       money.FromDecimal(decimal.Zero), FeePolicy: constants.PaymentFeePolicyNone,
+		Currency: "GBP",
+		Status:   constants.PaymentStatusPending,
+		ProviderPayload: jsonmap.JSON{
+			"original_amount":   "1",
+			"original_currency": "CNY",
+			"exchange_rate":     "0.11",
+		},
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(payment).Error; err != nil {
+		t.Fatalf("create payment failed: %v", err)
+	}
+
+	_, err := svc.HandleCallback(PaymentCallbackInput{
+		PaymentID: payment.ID, OrderNo: order.OrderNo, ChannelID: channel.ID,
+		Status: constants.PaymentStatusSuccess,
+		Amount: money.FromDecimal(decimal.RequireFromString("0.05")), Currency: "GBP",
+		ProviderRef: "stripe-gbp-underpaid-ref",
+	})
+	if err != ErrPaymentAmountMismatch {
+		t.Fatalf("stripe gbp underpaid callback should be rejected with ErrPaymentAmountMismatch, got: %v", err)
+	}
+
+	var reloadedOrder orderdomain.Order
+	if err := db.First(&reloadedOrder, order.ID).Error; err != nil {
+		t.Fatalf("reload order failed: %v", err)
+	}
+	if reloadedOrder.Status != constants.OrderStatusPendingPayment || reloadedOrder.PaidAt != nil {
+		t.Fatalf("rejected stripe gbp payment must not fulfill order, got status=%s paid_at=%v", reloadedOrder.Status, reloadedOrder.PaidAt)
 	}
 }

--- a/internal/modules/payment/infrastructure/gateway/okpay/okpay.go
+++ b/internal/modules/payment/infrastructure/gateway/okpay/okpay.go
@@ -3,7 +3,9 @@ package okpay
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -12,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,6 +26,7 @@ import (
 const (
 	defaultGatewayURL = "https://api.okaypay.me/shop"
 	payLinkPath       = "/payLink"
+	nonceByteCount    = 16
 )
 
 var (
@@ -230,14 +234,18 @@ func CreatePayment(ctx context.Context, cfg *Config, input CreateInput) (*Create
 }
 
 func SignPayload(payload map[string]string, merchantID string, merchantToken string) map[string]string {
-	values := make([]OrderedPair, 0, len(payload)+1)
+	values := make([]OrderedPair, 0, len(payload)+3)
 	for key, value := range payload {
 		values = append(values, OrderedPair{
 			Key:   strings.TrimSpace(key),
 			Value: strings.TrimSpace(value),
 		})
 	}
-	values = append(values, OrderedPair{Key: "id", Value: strings.TrimSpace(merchantID)})
+	values = append(values,
+		OrderedPair{Key: "id", Value: strings.TrimSpace(merchantID)},
+		OrderedPair{Key: "timestamp", Value: strconv.FormatInt(time.Now().Unix(), 10)},
+		OrderedPair{Key: "nonce", Value: generateNonce()},
+	)
 	sort.Slice(values, func(i, j int) bool {
 		return values[i].Key < values[j].Key
 	})
@@ -254,20 +262,20 @@ func SignPayload(payload map[string]string, merchantID string, merchantToken str
 	return result
 }
 
+func generateNonce() string {
+	buf := make([]byte, nonceByteCount)
+	if _, err := rand.Read(buf); err != nil {
+		return strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return hex.EncodeToString(buf)
+}
+
 func ParseCallback(body []byte) (*CallbackData, error) {
-	var (
-		pairs []OrderedPair
-		err   error
-	)
 	trimmed := strings.TrimSpace(string(body))
-	if trimmed == "" {
+	if trimmed == "" || !strings.HasPrefix(trimmed, "{") {
 		return nil, ErrResponseInvalid
 	}
-	if strings.HasPrefix(trimmed, "{") {
-		pairs, err = parseOrderedJSON(body)
-	} else {
-		pairs = parseOrderedForm(body)
-	}
+	pairs, err := parseOrderedJSON(body)
 	if err != nil {
 		return nil, err
 	}
@@ -285,13 +293,13 @@ func ParseCallback(body []byte) (*CallbackData, error) {
 		Code:          strings.TrimSpace(raw["code"]),
 		RequestStatus: strings.TrimSpace(raw["status"]),
 		Sign:          strings.TrimSpace(raw["sign"]),
-		OrderID:       strings.TrimSpace(raw["data[order_id]"]),
-		UniqueID:      strings.TrimSpace(raw["data[unique_id]"]),
-		PayUserID:     strings.TrimSpace(raw["data[pay_user_id]"]),
-		Amount:        strings.TrimSpace(raw["data[amount]"]),
-		Coin:          strings.ToUpper(strings.TrimSpace(raw["data[coin]"])),
-		PaymentStatus: strings.TrimSpace(raw["data[status]"]),
-		Type:          strings.TrimSpace(raw["data[type]"]),
+		OrderID:       strings.TrimSpace(raw["data.order_id"]),
+		UniqueID:      strings.TrimSpace(raw["data.unique_id"]),
+		PayUserID:     strings.TrimSpace(raw["data.pay_user_id"]),
+		Amount:        strings.TrimSpace(raw["data.amount"]),
+		Coin:          strings.ToUpper(strings.TrimSpace(raw["data.coin"])),
+		PaymentStatus: strings.TrimSpace(raw["data.status"]),
+		Type:          strings.TrimSpace(raw["data.type"]),
 	}
 	if callback.Sign == "" {
 		return nil, ErrResponseInvalid
@@ -309,21 +317,11 @@ func VerifyCallback(cfg *Config, data *CallbackData) error {
 	if data.Sign == "" {
 		return ErrSignatureInvalid
 	}
-	expected := buildSignature(stripSignPairs(data.RawPairs), cfg.MerchantToken)
-	if strings.EqualFold(expected, data.Sign) {
-		return nil
-	}
-	sortedPairs := make([]OrderedPair, 0, len(data.Raw))
-	for key, value := range data.Raw {
-		if strings.EqualFold(strings.TrimSpace(key), "sign") {
-			continue
-		}
-		sortedPairs = append(sortedPairs, OrderedPair{Key: key, Value: value})
-	}
-	sort.SliceStable(sortedPairs, func(i, j int) bool {
-		return sortedPairs[i].Key < sortedPairs[j].Key
+	pairs := stripSignPairs(data.RawPairs)
+	sort.SliceStable(pairs, func(i, j int) bool {
+		return pairs[i].Key < pairs[j].Key
 	})
-	expected = buildSignature(sortedPairs, cfg.MerchantToken)
+	expected := buildSignature(pairs, cfg.MerchantToken)
 	if !strings.EqualFold(expected, data.Sign) {
 		return ErrSignatureInvalid
 	}
@@ -402,38 +400,6 @@ func postForm(ctx context.Context, endpoint string, payload map[string]string) (
 	return body, nil
 }
 
-func parseOrderedForm(body []byte) []OrderedPair {
-	raw := strings.TrimSpace(string(body))
-	if raw == "" {
-		return nil
-	}
-	items := strings.Split(raw, "&")
-	result := make([]OrderedPair, 0, len(items))
-	for _, item := range items {
-		if item == "" {
-			continue
-		}
-		parts := strings.SplitN(item, "=", 2)
-		key, err := url.QueryUnescape(parts[0])
-		if err != nil {
-			key = parts[0]
-		}
-		value := ""
-		if len(parts) == 2 {
-			if decoded, decodeErr := url.QueryUnescape(parts[1]); decodeErr == nil {
-				value = decoded
-			} else {
-				value = parts[1]
-			}
-		}
-		result = append(result, OrderedPair{
-			Key:   strings.TrimSpace(key),
-			Value: strings.TrimSpace(value),
-		})
-	}
-	return result
-}
-
 func parseOrderedJSON(body []byte) ([]OrderedPair, error) {
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.UseNumber()
@@ -472,7 +438,7 @@ func decodeJSONObject(decoder *json.Decoder, prefix string) ([]OrderedPair, erro
 
 		fullKey := key
 		if prefix != "" {
-			fullKey = prefix + "[" + key + "]"
+			fullKey = prefix + "." + key
 		}
 
 		switch token := nextToken.(type) {
@@ -586,6 +552,9 @@ func stripSignPairs(pairs []OrderedPair) []OrderedPair {
 	return result
 }
 
+// buildSignature 按官方 HMAC-SHA256 新协议构造签名原文并计算签名。
+// base 的字段值已在 ParseCallback / SignPayload 阶段以字符串形式保留（数字/布尔原样转字符串，
+// 不重新格式化），此处只需按键名 ASCII 升序拼接，值不做任何 URL 编码。
 func buildSignature(pairs []OrderedPair, merchantToken string) string {
 	filtered := make([]string, 0, len(pairs))
 	for _, item := range pairs {
@@ -596,9 +565,10 @@ func buildSignature(pairs []OrderedPair, merchantToken string) string {
 		}
 		filtered = append(filtered, key+"="+value)
 	}
-	query := strings.Join(filtered, "&")
-	sum := md5.Sum([]byte(query + "&token=" + strings.TrimSpace(merchantToken)))
-	return strings.ToUpper(hex.EncodeToString(sum[:]))
+	base := strings.Join(filtered, "&")
+	mac := hmac.New(sha256.New, []byte(strings.TrimSpace(merchantToken)))
+	mac.Write([]byte(base))
+	return strings.ToUpper(hex.EncodeToString(mac.Sum(nil)))
 }
 
 func isSupportedCoin(coin string) bool {

--- a/internal/modules/payment/infrastructure/gateway/okpay/okpay_test.go
+++ b/internal/modules/payment/infrastructure/gateway/okpay/okpay_test.go
@@ -190,4 +190,3 @@ func TestConvertAmountByRate(t *testing.T) {
 		t.Fatalf("unexpected converted amount: %s", converted.StringFixed(8))
 	}
 }
-

--- a/internal/modules/payment/infrastructure/gateway/okpay/okpay_test.go
+++ b/internal/modules/payment/infrastructure/gateway/okpay/okpay_test.go
@@ -2,35 +2,76 @@ package okpay
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
 
-func TestSignPayloadMatchesDocumentExample(t *testing.T) {
-	payload := SignPayload(map[string]string{
-		"amount":       "10",
-		"callback_url": "http://127.0.0.1/callback",
-		"coin":         "USDT",
-		"name":         "test",
-		"return_url":   "http://127.0.0.1",
-		"unique_id":    "123456",
-	}, "1", "123456")
-
-	if payload["sign"] != "7465C8F4ED1BA0C8C2DB88E792374A65" {
-		t.Fatalf("unexpected sign: %s", payload["sign"])
+// TestSignPayloadMatchesOfficialVectorA 对齐官方文档 9. 测试向量 A(请求,扁平参数)。
+// 官方 base 顺序: amount, coin, id, nonce, timestamp, unique_id(ASCII 升序)。
+func TestSignPayloadMatchesOfficialVectorA(t *testing.T) {
+	pairs := []OrderedPair{
+		{Key: "amount", Value: "100.5"},
+		{Key: "coin", Value: "USDT"},
+		{Key: "id", Value: "10001"},
+		{Key: "nonce", Value: "a1b2c3d4e5"},
+		{Key: "timestamp", Value: "1782680000"},
+		{Key: "unique_id", Value: "ORDER-20260628-001"},
+	}
+	sign := buildSignature(pairs, "TESTtoken123456789abcdefghijABCD")
+	want := "7444ADFD8E4F4DA09D752DDF9345E0EE56DC25090FCFAF675DD042830E5E3F79"
+	if sign != want {
+		t.Fatalf("unexpected sign: %s, want %s", sign, want)
 	}
 }
 
-func TestVerifyCallbackMatchesDocumentExample(t *testing.T) {
-	cfg := &Config{
-		MerchantID:    "1",
-		MerchantToken: "123456",
+// TestBuildSignatureMatchesOfficialVectorB 对齐官方文档 9. 测试向量 B(回调,含嵌套 data)。
+func TestBuildSignatureMatchesOfficialVectorB(t *testing.T) {
+	pairs := []OrderedPair{
+		{Key: "code", Value: "200"},
+		{Key: "data.amount", Value: "100.5"},
+		{Key: "data.coin", Value: "USDT"},
+		{Key: "data.order_id", Value: "abc123def456"},
+		{Key: "data.pay_user_id", Value: "123456789"},
+		{Key: "data.status", Value: "1"},
+		{Key: "data.type", Value: "deposit"},
+		{Key: "data.unique_id", Value: "ORDER-20260628-001"},
+		{Key: "id", Value: "10001"},
+		{Key: "status", Value: "success"},
 	}
-	body := "code=200&data[order_id]=ac7b86615fdb137576ae35879f7ed844&data[unique_id]=BWIN-20250922152023LDVNSyxLQko&data[pay_user_id]=7238234930&data[amount]=6.00000000&data[coin]=USDT&data[status]=1&data[type]=deposit&id=1&status=success&sign=95BE540FB7D1996770E2B4CDBC6F184D"
+	sign := buildSignature(pairs, "TESTtoken123456789abcdefghijABCD")
+	want := "64B09C8847849FA6921D8FFBDF8E406D4A8EA623E53970712350F61783403F7D"
+	if sign != want {
+		t.Fatalf("unexpected sign: %s, want %s", sign, want)
+	}
+}
+
+// TestBuildSignatureMatchesOfficialVectorC 对齐官方文档 9. 测试向量 C:
+// 保留 0/"0"/false,丢弃 null/空串,点号嵌套展开。
+func TestBuildSignatureMatchesOfficialVectorC(t *testing.T) {
+	pairs := []OrderedPair{
+		{Key: "a", Value: "0"},
+		{Key: "b", Value: "0"},
+		{Key: "e", Value: "false"},
+		{Key: "f", Value: "hello"},
+		{Key: "id", Value: "7"},
+		{Key: "nest.x", Value: "1"},
+		{Key: "nest.y", Value: "2"},
+	}
+	sign := buildSignature(pairs, "TESTtoken123456789abcdefghijABCD")
+	want := "8BC0AF979075038025DDD51B6F4A2E6CF3FF9B5B5371EB2268D303F89883E92A"
+	if sign != want {
+		t.Fatalf("unexpected sign: %s, want %s", sign, want)
+	}
+}
+
+func TestVerifyCallbackMatchesOfficialVectorB(t *testing.T) {
+	cfg := &Config{
+		MerchantID:    "10001",
+		MerchantToken: "TESTtoken123456789abcdefghijABCD",
+	}
+	body := `{"status":"success","code":200,"data":{"order_id":"abc123def456","unique_id":"ORDER-20260628-001","pay_user_id":123456789,"amount":"100.5","coin":"USDT","status":1,"type":"deposit"},"id":10001,"sign":"64B09C8847849FA6921D8FFBDF8E406D4A8EA623E53970712350F61783403F7D"}`
 	data, err := ParseCallback([]byte(body))
 	if err != nil {
 		t.Fatalf("ParseCallback failed: %v", err)
@@ -41,15 +82,43 @@ func TestVerifyCallbackMatchesDocumentExample(t *testing.T) {
 	if status := ToPaymentStatus(data.RequestStatus, data.PaymentStatus); status != "success" {
 		t.Fatalf("unexpected payment status: %s", status)
 	}
+	if data.OrderID != "abc123def456" {
+		t.Fatalf("unexpected order id: %s", data.OrderID)
+	}
+	if data.UniqueID != "ORDER-20260628-001" {
+		t.Fatalf("unexpected unique id: %s", data.UniqueID)
+	}
+}
+
+func TestVerifyCallbackRejectsBadSignature(t *testing.T) {
+	cfg := &Config{
+		MerchantID:    "10001",
+		MerchantToken: "TESTtoken123456789abcdefghijABCD",
+	}
+	body := `{"status":"success","code":200,"data":{"order_id":"abc123def456","unique_id":"ORDER-20260628-001","pay_user_id":123456789,"amount":"100.5","coin":"USDT","status":1,"type":"deposit"},"id":10001,"sign":"0000000000000000000000000000000000000000000000000000000000000000"}`
+	data, err := ParseCallback([]byte(body))
+	if err != nil {
+		t.Fatalf("ParseCallback failed: %v", err)
+	}
+	if err := VerifyCallback(cfg, data); err == nil {
+		t.Fatal("expected signature mismatch error")
+	}
+}
+
+func TestParseCallbackRejectsFormEncodedBody(t *testing.T) {
+	body := "code=200&data.order_id=abc123&status=success&sign=DEADBEEF"
+	if _, err := ParseCallback([]byte(body)); err == nil {
+		t.Fatal("expected form-encoded callback to be rejected under the JSON-only protocol")
+	}
 }
 
 func TestCreatePayment(t *testing.T) {
-	var receivedBody string
+	var receivedValues map[string][]string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("ParseForm failed: %v", err)
 		}
-		receivedBody = r.PostForm.Encode()
+		receivedValues = map[string][]string(r.PostForm)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"status":"success","code":200,"data":{"order_id":"OK-ORDER-1","pay_url":"https://pay.example.com/ok"}}`))
 	}))
@@ -78,54 +147,37 @@ func TestCreatePayment(t *testing.T) {
 	if result.PayURL != "https://pay.example.com/ok" {
 		t.Fatalf("unexpected pay url: %s", result.PayURL)
 	}
-	if !strings.Contains(receivedBody, "unique_id=DJP1001") {
-		t.Fatalf("request body should contain unique_id, got %s", receivedBody)
+	if receivedValues["unique_id"][0] != "DJP1001" {
+		t.Fatalf("request body should contain unique_id, got %v", receivedValues["unique_id"])
 	}
-	if !strings.Contains(receivedBody, "amount=131.60000000") {
-		t.Fatalf("request body should contain converted amount, got %s", receivedBody)
+	if receivedValues["amount"][0] != "131.60000000" {
+		t.Fatalf("request body should contain converted amount, got %v", receivedValues["amount"])
 	}
-	if !strings.Contains(receivedBody, "sign=") {
-		t.Fatalf("request body should contain sign, got %s", receivedBody)
+	if receivedValues["sign"][0] == "" {
+		t.Fatal("request body should contain sign")
 	}
-}
+	if receivedValues["timestamp"][0] == "" {
+		t.Fatal("request body should contain timestamp")
+	}
+	if receivedValues["nonce"][0] == "" {
+		t.Fatal("request body should contain nonce")
+	}
 
-func TestVerifyCallbackFallsBackToSortedKeys(t *testing.T) {
-	cfg := &Config{
-		MerchantID:    "1",
-		MerchantToken: "123456",
+	// 用收到的 timestamp/nonce 重新算一遍签名,确认服务端可逐字节复现。
+	pairs := []OrderedPair{
+		{Key: "amount", Value: receivedValues["amount"][0]},
+		{Key: "callback_url", Value: receivedValues["callback_url"][0]},
+		{Key: "coin", Value: receivedValues["coin"][0]},
+		{Key: "id", Value: receivedValues["id"][0]},
+		{Key: "name", Value: receivedValues["name"][0]},
+		{Key: "nonce", Value: receivedValues["nonce"][0]},
+		{Key: "return_url", Value: receivedValues["return_url"][0]},
+		{Key: "timestamp", Value: receivedValues["timestamp"][0]},
+		{Key: "unique_id", Value: receivedValues["unique_id"][0]},
 	}
-	bodyWithoutSign := "id=1&status=success&code=200&data[amount]=6.00000000&data[coin]=USDT&data[order_id]=ac7b86615fdb137576ae35879f7ed844&data[pay_user_id]=7238234930&data[status]=1&data[type]=deposit&data[unique_id]=BWIN-20250922152023LDVNSyxLQko"
-	sign := md5Hex("code=200&data[amount]=6.00000000&data[coin]=USDT&data[order_id]=ac7b86615fdb137576ae35879f7ed844&data[pay_user_id]=7238234930&data[status]=1&data[type]=deposit&data[unique_id]=BWIN-20250922152023LDVNSyxLQko&id=1&status=success&token=123456")
-	data, err := ParseCallback([]byte(bodyWithoutSign + "&sign=" + sign))
-	if err != nil {
-		t.Fatalf("ParseCallback failed: %v", err)
-	}
-	if err := VerifyCallback(cfg, data); err != nil {
-		t.Fatalf("VerifyCallback failed: %v", err)
-	}
-}
-
-func TestParseJSONCallbackAndVerify(t *testing.T) {
-	cfg := &Config{
-		MerchantID:    "1",
-		MerchantToken: "123456",
-	}
-	body := `{"code":200,"data":{"order_id":"ac7b86615fdb137576ae35879f7ed844","unique_id":"BWIN-20250922152023LDVNSyxLQko","pay_user_id":7238234930,"amount":"6.00000000","coin":"USDT","status":1,"type":"deposit"},"id":1,"status":"success","sign":"95BE540FB7D1996770E2B4CDBC6F184D"}`
-	data, err := ParseCallback([]byte(body))
-	if err != nil {
-		t.Fatalf("ParseCallback failed: %v", err)
-	}
-	if data.OrderID != "ac7b86615fdb137576ae35879f7ed844" {
-		t.Fatalf("unexpected order id: %s", data.OrderID)
-	}
-	if data.UniqueID != "BWIN-20250922152023LDVNSyxLQko" {
-		t.Fatalf("unexpected unique id: %s", data.UniqueID)
-	}
-	if data.PayUserID != "7238234930" {
-		t.Fatalf("unexpected pay user id: %s", data.PayUserID)
-	}
-	if err := VerifyCallback(cfg, data); err != nil {
-		t.Fatalf("VerifyCallback failed: %v", err)
+	expected := buildSignature(pairs, cfg.MerchantToken)
+	if !strings.EqualFold(expected, receivedValues["sign"][0]) {
+		t.Fatalf("signature does not match recomputed value: got %s want %s", receivedValues["sign"][0], expected)
 	}
 }
 
@@ -139,7 +191,3 @@ func TestConvertAmountByRate(t *testing.T) {
 	}
 }
 
-func md5Hex(raw string) string {
-	sum := md5.Sum([]byte(raw))
-	return strings.ToUpper(hex.EncodeToString(sum[:]))
-}

--- a/internal/modules/payment/integrationtest/callback/callback_test.go
+++ b/internal/modules/payment/integrationtest/callback/callback_test.go
@@ -1,7 +1,8 @@
 package paymentcallback_test
 
 import (
-	"crypto/md5"
+	"crypto/hmac"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"net/http"
@@ -187,10 +188,10 @@ func newOkpayCallbackFixture(t *testing.T) *okpayCallbackFixture {
 	}
 }
 
-func TestPaymentCallbackHandlesOkpay(t *testing.T) {
+func TestPaymentCallbackRejectsOkpayFormEncodedBody(t *testing.T) {
 	fixture := newOkpayCallbackFixture(t)
-	bodyWithoutSign := "code=200&data[order_id]=OKPAY-ORDER-1&data[unique_id]=DJP9001&data[pay_user_id]=7238234930&data[amount]=616.00000000&data[coin]=USDT&data[status]=1&data[type]=deposit&id=shop-1&status=success"
-	sign := md5HexUpper(bodyWithoutSign + "&token=token-1")
+	bodyWithoutSign := "code=200&data.order_id=OKPAY-ORDER-1&data.unique_id=DJP9001&data.pay_user_id=7238234930&data.amount=616.00000000&data.coin=USDT&data.status=1&data.type=deposit&id=shop-1&status=success"
+	sign := hmacSHA256HexUpper(bodyWithoutSign, "token-1")
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/payments/callback", strings.NewReader(bodyWithoutSign+"&sign="+sign))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -199,50 +200,9 @@ func TestPaymentCallbackHandlesOkpay(t *testing.T) {
 
 	fixture.handler.PaymentCallback(c)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected status 200, got %d", w.Code)
-	}
-	if strings.TrimSpace(w.Body.String()) != constants.OkpayCallbackSuccess {
-		t.Fatalf("unexpected response body: %s", w.Body.String())
-	}
-
-	updatedPayment, err := fixture.paymentRepo.GetByID(fixture.payment.ID)
-	if err != nil {
-		t.Fatalf("reload payment failed: %v", err)
-	}
-	if updatedPayment == nil || updatedPayment.Status != constants.PaymentStatusSuccess {
-		t.Fatalf("payment status not updated: %+v", updatedPayment)
-	}
-	updatedOrder, err := fixture.orderRepo.GetByID(fixture.order.ID)
-	if err != nil {
-		t.Fatalf("reload order failed: %v", err)
-	}
-	if updatedOrder == nil || updatedOrder.Status != constants.OrderStatusPaid {
-		t.Fatalf("order status not updated: %+v", updatedOrder)
-	}
-}
-
-func TestPaymentCallbackRejectsOkpayMismatchedMerchantOrder(t *testing.T) {
-	fixture := newOkpayCallbackFixture(t)
-	bodyWithoutSign := "code=200&data[order_id]=OKPAY-ORDER-1&data[unique_id]=WRONG-MERCHANT-ORDER&data[pay_user_id]=7238234930&data[amount]=616.00000000&data[coin]=USDT&data[status]=1&data[type]=deposit&id=shop-1&status=success"
-	sign := md5HexUpper(bodyWithoutSign + "&token=token-1")
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/payments/callback", strings.NewReader(bodyWithoutSign+"&sign="+sign))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = req
-
-	fixture.handler.PaymentCallback(c)
-
-	if strings.TrimSpace(w.Body.String()) != constants.OkpayCallbackFail {
-		t.Fatalf("mismatched merchant order must return provider failure acknowledgement, status=%d body=%s", w.Code, w.Body.String())
-	}
-	updatedPayment, err := fixture.paymentRepo.GetByID(fixture.payment.ID)
-	if err != nil {
-		t.Fatalf("reload payment failed: %v", err)
-	}
-	if updatedPayment == nil || updatedPayment.Status != constants.PaymentStatusPending {
-		t.Fatalf("mismatched callback changed payment state: %+v", updatedPayment)
+	// 新协议下 OKPay 只发 JSON 回调,form-encoded body 不应被任何 handler 识别。
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("form-encoded okpay callback should be unrecognized, got status %d body %s", w.Code, w.Body.String())
 	}
 }
 
@@ -342,16 +302,18 @@ func signedOkpayJSONCallback(amount string, coin string, token string) string {
 		amount,
 		coin,
 	)
+	// 新协议签名原文用点号展开嵌套 data,不做 URL 编码。
 	signBase := fmt.Sprintf(
-		`code=200&data[order_id]=OKPAY-ORDER-1&data[unique_id]=DJP9001&data[pay_user_id]=7238234930&data[amount]=%s&data[coin]=%s&data[status]=1&data[type]=deposit&id=shop-1&status=success`,
+		`code=200&data.amount=%s&data.coin=%s&data.order_id=OKPAY-ORDER-1&data.pay_user_id=7238234930&data.status=1&data.type=deposit&data.unique_id=DJP9001&id=shop-1&status=success`,
 		amount,
 		coin,
 	)
-	sign := md5HexUpper(signBase + "&token=" + token)
+	sign := hmacSHA256HexUpper(signBase, token)
 	return strings.TrimSuffix(bodyWithoutSign, "}") + `,"sign":"` + sign + `"}`
 }
 
-func md5HexUpper(raw string) string {
-	sum := md5.Sum([]byte(raw))
-	return strings.ToUpper(hex.EncodeToString(sum[:]))
+func hmacSHA256HexUpper(base string, token string) string {
+	mac := hmac.New(sha256.New, []byte(token))
+	mac.Write([]byte(base))
+	return strings.ToUpper(hex.EncodeToString(mac.Sum(nil)))
 }

--- a/internal/modules/payment/transport/http/callback/json_callbacks.go
+++ b/internal/modules/payment/transport/http/callback/json_callbacks.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
 	ginutil "github.com/dujiao-next/internal/platform/http/ginutil"
@@ -37,46 +36,24 @@ type okpayProbe struct {
 
 func parseOkpayProbe(body []byte) (okpayProbe, error) {
 	raw := strings.TrimSpace(string(body))
-	if raw == "" {
+	if raw == "" || !strings.HasPrefix(raw, "{") {
 		return okpayProbe{}, fmt.Errorf("empty callback")
 	}
-	if strings.HasPrefix(raw, "{") {
-		var payload struct {
-			Sign         string `json:"sign"`
-			FlatOrderID  string `json:"data[order_id]"`
-			FlatUniqueID string `json:"data[unique_id]"`
-			Data         struct {
-				OrderID  string `json:"order_id"`
-				UniqueID string `json:"unique_id"`
-			} `json:"data"`
-		}
-		if err := json.Unmarshal(body, &payload); err != nil {
-			return okpayProbe{}, err
-		}
-		return okpayProbe{
-			Sign:     strings.TrimSpace(payload.Sign),
-			OrderID:  firstNonEmpty(payload.FlatOrderID, payload.Data.OrderID),
-			UniqueID: firstNonEmpty(payload.FlatUniqueID, payload.Data.UniqueID),
-		}, nil
+	var payload struct {
+		Sign string `json:"sign"`
+		Data struct {
+			OrderID  string `json:"order_id"`
+			UniqueID string `json:"unique_id"`
+		} `json:"data"`
 	}
-	values, err := url.ParseQuery(raw)
-	if err != nil {
+	if err := json.Unmarshal(body, &payload); err != nil {
 		return okpayProbe{}, err
 	}
 	return okpayProbe{
-		Sign:     strings.TrimSpace(values.Get("sign")),
-		OrderID:  strings.TrimSpace(values.Get("data[order_id]")),
-		UniqueID: strings.TrimSpace(values.Get("data[unique_id]")),
+		Sign:     strings.TrimSpace(payload.Sign),
+		OrderID:  strings.TrimSpace(payload.Data.OrderID),
+		UniqueID: strings.TrimSpace(payload.Data.UniqueID),
 	}, nil
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
 }
 
 func (h *Handler) handleOkpayCallback(c *gin.Context) bool {

--- a/internal/modules/payment/transport/presenter/payment.go
+++ b/internal/modules/payment/transport/presenter/payment.go
@@ -14,21 +14,26 @@ type CreatePaymentResp struct {
 	WalletPaidAmount money.Amount `json:"wallet_paid_amount"`
 	OnlinePayAmount  money.Amount `json:"online_pay_amount"`
 	PayableAmount    money.Amount `json:"payable_amount"`
-	FeeAmount        money.Amount `json:"fee_amount"`
-	FeePolicy        string       `json:"fee_policy,omitempty"`
-	PaymentID        *uint        `json:"payment_id,omitempty"`
-	ChannelID        *uint        `json:"channel_id,omitempty"`
-	ProviderType     string       `json:"provider_type,omitempty"`
-	ChannelType      string       `json:"channel_type,omitempty"`
-	InteractionMode  string       `json:"interaction_mode,omitempty"`
-	PayURL           string       `json:"pay_url,omitempty"`
-	QRCode           string       `json:"qr_code,omitempty"`
-	WalletAddress    string       `json:"wallet_address,omitempty"`
-	ChainAmount      string       `json:"chain_amount,omitempty"`
-	Chain            string       `json:"chain,omitempty"`
-	TokenID          string       `json:"token_id,omitempty"`
-	ExpiresAt        *time.Time   `json:"expires_at,omitempty"`
-	ChannelName      string       `json:"channel_name,omitempty"`
+	// Currency 是 PayableAmount 的实际币种。换汇渠道（如 Stripe 配置了
+	// target_currency+exchange_rate）下 PayableAmount 是结算币种数值，与订单币种不同，
+	// 前端必须用这个字段而不是订单币种来展示 PayableAmount，否则会把结算币种数值
+	// 误标成订单币种（例如把 0.11 GBP 显示成 "0.11 CNY"）。
+	Currency        string       `json:"currency"`
+	FeeAmount       money.Amount `json:"fee_amount"`
+	FeePolicy       string       `json:"fee_policy,omitempty"`
+	PaymentID       *uint        `json:"payment_id,omitempty"`
+	ChannelID       *uint        `json:"channel_id,omitempty"`
+	ProviderType    string       `json:"provider_type,omitempty"`
+	ChannelType     string       `json:"channel_type,omitempty"`
+	InteractionMode string       `json:"interaction_mode,omitempty"`
+	PayURL          string       `json:"pay_url,omitempty"`
+	QRCode          string       `json:"qr_code,omitempty"`
+	WalletAddress   string       `json:"wallet_address,omitempty"`
+	ChainAmount     string       `json:"chain_amount,omitempty"`
+	Chain           string       `json:"chain,omitempty"`
+	TokenID         string       `json:"token_id,omitempty"`
+	ExpiresAt       *time.Time   `json:"expires_at,omitempty"`
+	ChannelName     string       `json:"channel_name,omitempty"`
 }
 
 // CreatePaymentResultView 创建支付结果视图（供 HTTP 层构造响应，避免依赖 service）。
@@ -56,6 +61,7 @@ func NewCreatePaymentResp(result *CreatePaymentResultView) CreatePaymentResp {
 		resp.PayURL = result.Payment.PayURL
 		resp.QRCode = result.Payment.QRCode
 		resp.PayableAmount = result.Payment.Amount
+		resp.Currency = result.Payment.Currency
 		resp.FeeAmount = result.Payment.FeeAmount
 		resp.FeePolicy = result.Payment.FeePolicy
 		resp.ExpiresAt = result.Payment.ExpiredAt
@@ -92,8 +98,10 @@ type LatestPaymentResp struct {
 	TokenID         string       `json:"token_id,omitempty"`
 	ExpiresAt       *time.Time   `json:"expires_at"`
 	PayableAmount   money.Amount `json:"payable_amount"`
-	FeeAmount       money.Amount `json:"fee_amount"`
-	FeePolicy       string       `json:"fee_policy,omitempty"`
+	// Currency 是 PayableAmount 的实际币种，见 CreatePaymentResp.Currency 注释。
+	Currency  string       `json:"currency"`
+	FeeAmount money.Amount `json:"fee_amount"`
+	FeePolicy string       `json:"fee_policy,omitempty"`
 }
 
 // NewLatestPaymentResp 从 Payment + Order 构造响应
@@ -115,6 +123,7 @@ func NewLatestPaymentResp(payment *paymentdomain.Payment, orderNo string) Latest
 		TokenID:         info.TokenID,
 		ExpiresAt:       payment.ExpiredAt,
 		PayableAmount:   payment.Amount,
+		Currency:        payment.Currency,
 		FeeAmount:       payment.FeeAmount,
 		FeePolicy:       payment.FeePolicy,
 	}


### PR DESCRIPTION
## Summary
- Stripe 渠道配置 `target_currency`+`exchange_rate` 换汇下单后，`payment.Amount`/`Currency` 会回写为结算币种（如 GBP），但订单金额守恒校验（`paymentCoveredOrderAmount`）此前直接拿 `payment.Amount` 与订单原始币种总额比较，两个不同币种的数值硬比会误判为金额不足。新增 `paymentExchangeRate` 检测 `ProviderPayload["exchange_rate"]` 快照，发生换汇时按汇率把回调金额折算回订单币种再比较；未换汇渠道行为不变。
- 该快照检测是通用逻辑，不针对特定 provider：Okpay adapter 在渠道配置了 `exchange_rate`（如 CNY→USDT）且发生实际换算时，同样会把 `exchange_rate`/`original_amount`/`original_currency` 写入 `payment.ProviderPayload`。因此这条修复同时修正了 Okpay 换汇渠道潜在的"金额不足"误判——此前该问题被旧版签名协议导致的认证失败挡在更前面没有暴露，本 PR 一并解决协议问题后需要这条金额守恒修复兜底。
- `CreatePaymentResp`/`LatestPaymentResp` 的 `payable_amount` 直接取自换汇后的 `payment.Amount`，但响应里没有对应币种字段，前端只能套用订单币种展示，导致把结算币种数值（如 0.11 GBP）误标成订单币种（显示成 "0.11 CNY"）。响应补充 `currency` 字段，前端 `payableAmountDisplay`/`customerFeeAmountDisplay` 改用该字段。
- Fixes #294：Okpay 商户接口已升级为新版协议，签名算法由 MD5+token 拼接改为 HMAC-SHA256，请求需额外携带 `timestamp`/`nonce` 做防重放，回调 JSON 嵌套字段展开由 `data[key]` 括号格式改为 `data.key` 点号格式。旧版签名无法通过 Okpay 认证，导致 `payLink` 请求返回 `身份认证失败`，进而报错 `okpay response invalid: missing order_id/pay_url`，订单无法创建支付链接。本次同步适配器到新协议，并移除已废弃的 form-encoded 回调解析与旧签名兼容分支。

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/modules/payment/...`（含新增 `TestPaymentCoveredOrderAmountWithExchangeRateFullPayment`、`TestStripeExchangeRateFullPaymentFulfillsOrder`、`TestStripeExchangeRateUnderpaidCallbackRejected`）
- [x] `go test ./internal/architecture/...`
- [x] `npx vue-tsc -b --noEmit`（frontend/user）
- [x] Okpay 签名算法用官方文档测试向量（timestamp/nonce 请求签名、含嵌套 data 的回调签名、0/false/null 边界情况）逐字节校验通过
- [x] `go test ./internal/modules/payment/infrastructure/gateway/okpay/... ./internal/modules/payment/integrationtest/callback/...`