### PR TITLE
fix(payment): 支付渠道展示的商品名统一改为订单号

### DIFF
--- a/internal/architecture/payment_service_structure_test.go
+++ b/internal/architecture/payment_service_structure_test.go
@@ -34,7 +34,7 @@ func TestPaymentServiceImplementationIsSplitByResponsibility(t *testing.T) {
 			"shouldMarkFulfilling", "shouldUseCNYPaymentCurrency", "validatePaymentAmountForChannel",
 			"validatePaymentCurrencyForChannel", "resolveExpireMinutes", "normalizePaymentStatus",
 			"isPaymentStatusValid", "shouldAutoFulfill", "isOrderFullyAutoFulfill",
-			"buildOrderSubject", "pickOrderItemTitle",
+			"buildOrderSubject",
 		},
 		"payment_service_channel_rules.go": {
 			"computeProductChannelIntersection",

--- a/internal/modules/payment/application/payment_service_gateway_order_test.go
+++ b/internal/modules/payment/application/payment_service_gateway_order_test.go
@@ -68,60 +68,19 @@ func TestBuildOrderSubject(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "legacy parent item title",
+			name: "always uses order number regardless of item titles",
 			order: &orderdomain.Order{
 				OrderNo: "DJ-LEGACY-1",
 				Items: []orderdomain.OrderItem{
 					{TitleJSON: jsonmap.JSON{"zh-CN": "父订单商品"}},
 				},
 			},
-			want: "父订单商品",
+			want: "DJ-LEGACY-1",
 		},
 		{
-			name: "current child item title",
-			order: &orderdomain.Order{
-				OrderNo: "DJ-CURRENT-1",
-				Children: []orderdomain.Order{
-					{
-						Items: []orderdomain.OrderItem{
-							{TitleJSON: jsonmap.JSON{"zh-CN": "子订单商品"}},
-						},
-					},
-				},
-			},
-			want: "子订单商品",
-		},
-		{
-			name: "first non-empty item title",
-			order: &orderdomain.Order{
-				OrderNo: "DJ-CURRENT-2",
-				Children: []orderdomain.Order{
-					{Items: []orderdomain.OrderItem{{TitleJSON: jsonmap.JSON{"zh-CN": " "}}}},
-					{Items: []orderdomain.OrderItem{{TitleJSON: jsonmap.JSON{"en-US": "Second product"}}}},
-				},
-			},
-			want: "Second product",
-		},
-		{
-			name: "parent item takes precedence",
-			order: &orderdomain.Order{
-				OrderNo: "DJ-MIXED-1",
-				Items: []orderdomain.OrderItem{
-					{TitleJSON: jsonmap.JSON{"zh-CN": "父订单商品"}},
-				},
-				Children: []orderdomain.Order{
-					{Items: []orderdomain.OrderItem{{TitleJSON: jsonmap.JSON{"zh-CN": "子订单商品"}}}},
-				},
-			},
-			want: "父订单商品",
-		},
-		{
-			name: "order number fallback",
+			name: "trims order number",
 			order: &orderdomain.Order{
 				OrderNo: " DJ-FALLBACK-1 ",
-				Children: []orderdomain.Order{
-					{Items: []orderdomain.OrderItem{{TitleJSON: jsonmap.JSON{}}}},
-				},
 			},
 			want: "DJ-FALLBACK-1",
 		},

--- a/internal/modules/payment/application/payment_service_rules.go
+++ b/internal/modules/payment/application/payment_service_rules.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/dujiao-next/internal/constants"
 	settingsapp "github.com/dujiao-next/internal/modules/settings/application"
-	"github.com/dujiao-next/internal/shared/jsonmap"
 
 	"github.com/shopspring/decimal"
 )
@@ -233,36 +232,5 @@ func buildOrderSubject(order *orderdomain.Order) string {
 	if order == nil {
 		return ""
 	}
-	for i := range order.Items {
-		if title := pickOrderItemTitle(order.Items[i].TitleJSON); title != "" {
-			return title
-		}
-	}
-	for i := range order.Children {
-		for j := range order.Children[i].Items {
-			if title := pickOrderItemTitle(order.Children[i].Items[j].TitleJSON); title != "" {
-				return title
-			}
-		}
-	}
 	return strings.TrimSpace(order.OrderNo)
-}
-
-func pickOrderItemTitle(title jsonmap.JSON) string {
-	if title == nil {
-		return ""
-	}
-	for _, key := range constants.SupportedLocales {
-		if val, ok := title[key]; ok {
-			if str, ok := val.(string); ok && strings.TrimSpace(str) != "" {
-				return strings.TrimSpace(str)
-			}
-		}
-	}
-	for _, val := range title {
-		if str, ok := val.(string); ok && strings.TrimSpace(str) != "" {
-			return strings.TrimSpace(str)
-		}
-	}
-	return ""
 }


### PR DESCRIPTION
## 背景

各支付网关（Alipay/微信支付/Stripe/PayPal/epay/epusdt/bepusdt/okpay/dujiaopay 等）共用的 `buildOrderSubject` 之前会优先取商品标题（`order.Items`/`order.Children[].Items` 的 `TitleJSON`），只有在没有标题时才回退到订单号，导致客户账单/收银台展示的是商品简介而非订单号，不便于客户和商户核对订单。

## 变更内容

- `buildOrderSubject` 统一直接返回订单号（trim 后的 `order.OrderNo`），移除按商品标题取值的逻辑，同时移除已无用的 `pickOrderItemTitle` 函数。
- 同步更新 `payment_service_gateway_order_test.go` 中的用例，反映新的统一行为。
- 同步更新 `internal/architecture/payment_service_structure_test.go` 的函数清单断言，移除已删除的 `pickOrderItemTitle`。

## 测试

- `go build ./...`
- `go test ./internal/modules/payment/... ./internal/architecture/...`