### PR TITLE
refactor: 订单详情页优先展示卡密，vault 模板游客查单入口与移动端布局优化

### DIFF
--- a/frontend/user/src/templates/vault/components/VaultOrderBody.vue
+++ b/frontend/user/src/templates/vault/components/VaultOrderBody.vue
@@ -1,5 +1,61 @@
 <template>
   <div class="grid gap-[18px]">
+    <!-- 子订单（含卡密） -->
+    <section v-if="order.children && order.children.length > 0" class="rounded-xl border bg-card p-[22px]">
+      <h2 class="mb-4 text-lg font-bold">{{ t('orderDetail.childOrdersTitle') }}</h2>
+      <div class="grid gap-4">
+        <div v-for="child in order.children" :key="child.id" class="rounded-lg border p-4">
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div class="text-[13px] text-muted-foreground">{{ t('orderDetail.childOrderNo') }}：{{ child.order_no }}</div>
+              <div class="text-[13px] text-muted-foreground">{{ t('orderDetail.childOrderAmount') }}：{{ formatMoney(child.total_amount, child.currency || order.currency) }}</div>
+            </div>
+            <Badge :variant="statusVariant(resolvedChildStatus(child))" size="sm" class="rounded-full">{{ statusLabel(resolvedChildStatus(child)) }}</Badge>
+          </div>
+
+          <h3 class="my-2.5 mt-4 text-sm font-bold">{{ t('orderDetail.childItemsTitle') }}</h3>
+          <div v-if="child.items && child.items.length" class="grid">
+            <VaultOrderItem v-for="(item, cidx) in child.items" :key="cidx" :item="item" :currency="child.currency || order.currency" />
+          </div>
+          <div v-else class="text-[13px] text-muted-foreground">{{ t('orderDetail.noItems') }}</div>
+
+          <div class="mt-3.5 border-t pt-3.5">
+            <VaultOrderFulfillment
+              v-if="child.fulfillment"
+              :title="t('orderDetail.childFulfillmentTitle')"
+              :fulfillment="child.fulfillment"
+              :items="child.items"
+              :order-no="child.order_no || order.order_no"
+              :downloading="fulfillmentDownloading"
+              @download="emit('download', $event)"
+            />
+            <div v-else class="text-[13px] text-muted-foreground">{{ t('orderDetail.childFulfillmentEmpty') }}</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 主订单发货（含卡密） -->
+    <section v-if="order.fulfillment" class="rounded-xl border bg-card p-[22px]">
+      <h2 class="mb-4 text-lg font-bold">{{ t('orderDetail.fulfillmentTitle') }}</h2>
+      <VaultOrderFulfillment
+        :fulfillment="order.fulfillment"
+        :items="order.items"
+        :order-no="order.order_no"
+        :downloading="fulfillmentDownloading"
+        @download="emit('download', $event)"
+      />
+    </section>
+
+    <!-- 商品 -->
+    <section class="rounded-xl border bg-card p-[22px]">
+      <h2 class="mb-4 text-lg font-bold">{{ t('orderDetail.itemsTitle') }}</h2>
+      <div v-if="order.items && order.items.length > 0" class="grid">
+        <VaultOrderItem v-for="(item, idx) in order.items" :key="idx" :item="item" :currency="order.currency" />
+      </div>
+      <div v-else class="text-[13px] text-muted-foreground">{{ t('orderDetail.noItems') }}</div>
+    </section>
+
     <!-- 金额明细 -->
     <section class="rounded-xl border bg-card p-[22px]">
       <h2 class="mb-4 text-lg font-bold">{{ t('orderDetail.amountTitle') }}</h2>
@@ -80,62 +136,6 @@
           <div class="mt-1.5 font-bold">{{ formatDate(order.canceled_at) }}</div>
         </div>
       </div>
-    </section>
-
-    <!-- 商品 -->
-    <section class="rounded-xl border bg-card p-[22px]">
-      <h2 class="mb-4 text-lg font-bold">{{ t('orderDetail.itemsTitle') }}</h2>
-      <div v-if="order.items && order.items.length > 0" class="grid">
-        <VaultOrderItem v-for="(item, idx) in order.items" :key="idx" :item="item" :currency="order.currency" />
-      </div>
-      <div v-else class="text-[13px] text-muted-foreground">{{ t('orderDetail.noItems') }}</div>
-    </section>
-
-    <!-- 子订单 -->
-    <section v-if="order.children && order.children.length > 0" class="rounded-xl border bg-card p-[22px]">
-      <h2 class="mb-4 text-lg font-bold">{{ t('orderDetail.childOrdersTitle') }}</h2>
-      <div class="grid gap-4">
-        <div v-for="child in order.children" :key="child.id" class="rounded-lg border p-4">
-          <div class="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <div class="text-[13px] text-muted-foreground">{{ t('orderDetail.childOrderNo') }}：{{ child.order_no }}</div>
-              <div class="text-[13px] text-muted-foreground">{{ t('orderDetail.childOrderAmount') }}：{{ formatMoney(child.total_amount, child.currency || order.currency) }}</div>
-            </div>
-            <Badge :variant="statusVariant(resolvedChildStatus(child))" size="sm" class="rounded-full">{{ statusLabel(resolvedChildStatus(child)) }}</Badge>
-          </div>
-
-          <h3 class="my-2.5 mt-4 text-sm font-bold">{{ t('orderDetail.childItemsTitle') }}</h3>
-          <div v-if="child.items && child.items.length" class="grid">
-            <VaultOrderItem v-for="(item, cidx) in child.items" :key="cidx" :item="item" :currency="child.currency || order.currency" />
-          </div>
-          <div v-else class="text-[13px] text-muted-foreground">{{ t('orderDetail.noItems') }}</div>
-
-          <div class="mt-3.5 border-t pt-3.5">
-            <VaultOrderFulfillment
-              v-if="child.fulfillment"
-              :title="t('orderDetail.childFulfillmentTitle')"
-              :fulfillment="child.fulfillment"
-              :items="child.items"
-              :order-no="child.order_no || order.order_no"
-              :downloading="fulfillmentDownloading"
-              @download="emit('download', $event)"
-            />
-            <div v-else class="text-[13px] text-muted-foreground">{{ t('orderDetail.childFulfillmentEmpty') }}</div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- 主订单发货 -->
-    <section v-if="order.fulfillment" class="rounded-xl border bg-card p-[22px]">
-      <h2 class="mb-4 text-lg font-bold">{{ t('orderDetail.fulfillmentTitle') }}</h2>
-      <VaultOrderFulfillment
-        :fulfillment="order.fulfillment"
-        :items="order.items"
-        :order-no="order.order_no"
-        :downloading="fulfillmentDownloading"
-        @download="emit('download', $event)"
-      />
     </section>
   </div>
 </template>

--- a/frontend/user/src/templates/vault/components/VaultOrderItem.vue
+++ b/frontend/user/src/templates/vault/components/VaultOrderItem.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex flex-wrap justify-between gap-3.5 border-b py-3.5 first:pt-0 last:border-b-0 last:pb-0">
-    <div class="flex min-w-0 flex-1 gap-3">
+  <div class="flex flex-wrap justify-between gap-3.5 border-b py-3.5 first:pt-0 last:border-b-0 last:pb-0 max-[640px]:flex-col">
+    <div class="flex min-w-0 flex-1 gap-3 max-[640px]:flex-none">
       <div class="grid h-[60px] w-[60px] flex-none place-items-center overflow-hidden rounded-sm border bg-secondary">
         <img
           v-if="orderItemImage(item)"
@@ -28,7 +28,7 @@
         </div>
       </div>
     </div>
-    <div class="grid min-w-[180px] content-start gap-0.5 text-right text-[12.5px] text-muted-foreground max-[640px]:min-w-0 max-[640px]:text-left">
+    <div class="grid min-w-[180px] content-start gap-0.5 text-right text-[12.5px] text-muted-foreground max-[640px]:min-w-0 max-[640px]:pl-[72px] max-[640px]:text-left">
       <div>{{ t('orderDetail.unitPriceLabel') }}：{{ formatMoney(item.original_unit_price, currency) }}</div>
       <div>{{ t('orderDetail.totalPriceLabel') }}：{{ formatMoney(item.original_total_price, currency) }}</div>
       <div v-if="hasDiscountAmount(item.coupon_discount_amount)" class="text-destructive">{{ t('orderDetail.couponDiscountLabel') }}：{{ formatDiscountMoney(item.coupon_discount_amount, currency) }}</div>

--- a/frontend/user/src/templates/vault/layout/VaultLayout.vue
+++ b/frontend/user/src/templates/vault/layout/VaultLayout.vue
@@ -28,7 +28,7 @@
 
         <div class="ml-auto flex items-center gap-2">
           <RouterLink class="grid h-10 w-10 flex-none place-items-center rounded-full bg-secondary text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary" to="/products" :aria-label="t('nav.products')"><Search class="h-[18px] w-[18px]" /></RouterLink>
-          <RouterLink class="grid h-10 w-10 flex-none place-items-center rounded-full bg-secondary text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary" to="/guest/orders" :aria-label="t('navbar.guestOrders')" :title="t('navbar.guestOrders')"><ClipboardList class="h-[18px] w-[18px]" /></RouterLink>
+          <RouterLink v-if="!userAuthStore.isAuthenticated" class="grid h-10 w-10 flex-none place-items-center rounded-full bg-secondary text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary" to="/guest/orders" :aria-label="t('navbar.guestOrders')" :title="t('navbar.guestOrders')"><ClipboardList class="h-[18px] w-[18px]" /></RouterLink>
           <button class="grid h-10 w-10 flex-none place-items-center rounded-full bg-secondary text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary" type="button" :aria-label="t('resellerConsole.common.toggleTheme')" @click="toggleTheme">
             <Sun v-if="theme === 'dark'" class="h-[18px] w-[18px]" />
             <Moon v-else class="h-[18px] w-[18px]" />
@@ -70,7 +70,7 @@
                 <RouterLink v-if="item.type === 'route'" :to="item.path" class="flex w-full items-center gap-2.5 rounded-sm px-3 py-2.5 text-sm font-semibold text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground" @click="moreOpen = false">{{ item.label }}</RouterLink>
                 <a v-else :href="item.path" :target="item.target" rel="noopener noreferrer" class="flex w-full items-center gap-2.5 rounded-sm px-3 py-2.5 text-sm font-semibold text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground" @click="moreOpen = false">{{ item.label }}</a>
               </template>
-              <RouterLink to="/guest/orders" class="flex w-full items-center gap-2.5 rounded-sm px-3 py-2.5 text-sm font-semibold text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground" @click="moreOpen = false">{{ t('navbar.guestOrders') }}</RouterLink>
+              <RouterLink v-if="!userAuthStore.isAuthenticated" to="/guest/orders" class="flex w-full items-center gap-2.5 rounded-sm px-3 py-2.5 text-sm font-semibold text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground" @click="moreOpen = false">{{ t('navbar.guestOrders') }}</RouterLink>
               <RouterLink v-if="userAuthStore.isAuthenticated" to="/me" class="flex w-full items-center gap-2.5 rounded-sm px-3 py-2.5 text-sm font-semibold text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground" @click="moreOpen = false">{{ t('navbar.personalCenter') }}</RouterLink>
               <RouterLink v-else to="/auth/login" class="flex w-full items-center gap-2.5 rounded-sm px-3 py-2.5 text-sm font-semibold text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground" @click="moreOpen = false">{{ t('navbar.login') }}</RouterLink>
               <button v-if="userAuthStore.isAuthenticated" class="flex w-full items-center gap-2.5 rounded-sm px-3 py-2.5 text-left text-sm font-semibold text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground" @click="userAuthStore.logout(); moreOpen = false">{{ t('navbar.logout') }}</button>
@@ -110,7 +110,7 @@
         <div>
           <h4 class="mb-3 text-sm font-bold">{{ t('vault.footer.support') }}</h4>
           <RouterLink v-if="aboutEnabled" to="/about" class="flex items-center gap-[7px] py-[5px] text-[14.5px] text-muted-foreground hover:text-primary"><Info class="h-4 w-4" /> {{ t('nav.about') }}</RouterLink>
-          <RouterLink to="/guest/orders" class="flex items-center gap-[7px] py-[5px] text-[14.5px] text-muted-foreground hover:text-primary"><ClipboardList class="h-4 w-4" /> {{ t('navbar.guestOrders') }}</RouterLink>
+          <RouterLink v-if="!userAuthStore.isAuthenticated" to="/guest/orders" class="flex items-center gap-[7px] py-[5px] text-[14.5px] text-muted-foreground hover:text-primary"><ClipboardList class="h-4 w-4" /> {{ t('navbar.guestOrders') }}</RouterLink>
           <a v-if="contact?.telegram" :href="contact.telegram" target="_blank" rel="noopener noreferrer" class="flex items-center gap-[7px] py-[5px] text-[14.5px] text-muted-foreground hover:text-primary"><Send class="h-4 w-4" /> Telegram</a>
           <a v-if="contact?.whatsapp" :href="contact.whatsapp" target="_blank" rel="noopener noreferrer" class="flex items-center gap-[7px] py-[5px] text-[14.5px] text-muted-foreground hover:text-primary"><MessageCircle class="h-4 w-4" /> WhatsApp</a>
         </div>

--- a/frontend/user/src/templates/vault/layout/VaultLayout.vue
+++ b/frontend/user/src/templates/vault/layout/VaultLayout.vue
@@ -28,6 +28,7 @@
 
         <div class="ml-auto flex items-center gap-2">
           <RouterLink class="grid h-10 w-10 flex-none place-items-center rounded-full bg-secondary text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary" to="/products" :aria-label="t('nav.products')"><Search class="h-[18px] w-[18px]" /></RouterLink>
+          <RouterLink class="grid h-10 w-10 flex-none place-items-center rounded-full bg-secondary text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary" to="/guest/orders" :aria-label="t('navbar.guestOrders')" :title="t('navbar.guestOrders')"><ClipboardList class="h-[18px] w-[18px]" /></RouterLink>
           <button class="grid h-10 w-10 flex-none place-items-center rounded-full bg-secondary text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary" type="button" :aria-label="t('resellerConsole.common.toggleTheme')" @click="toggleTheme">
             <Sun v-if="theme === 'dark'" class="h-[18px] w-[18px]" />
             <Moon v-else class="h-[18px] w-[18px]" />

--- a/frontend/user/src/views/GuestOrderDetail.vue
+++ b/frontend/user/src/views/GuestOrderDetail.vue
@@ -65,157 +65,6 @@
           </div>
         </div>
 
-        <div class="rounded-2xl border bg-card shadow-sm p-6">
-          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.amountTitle') }}</h2>
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
-            <div class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountOriginal') }}</div>
-              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.original_amount,
-                order.currency) }}</div>
-            </div>
-            <div class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountDiscount') }}</div>
-              <div
-                class="font-mono mt-1"
-                :class="hasDiscountAmount(order.discount_amount) ? 'text-rose-600 dark:text-rose-300' : 'text-foreground'"
-              >
-                {{ formatDiscountMoney(order.discount_amount, order.currency) }}
-              </div>
-            </div>
-            <div class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountTotal') }}</div>
-              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.total_amount,
-                order.currency) }}</div>
-            </div>
-            <div v-if="hasDiscountAmount(order.member_discount_amount)" class="border border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-950/30 rounded-xl p-4">
-              <div class="text-xs text-amber-700 dark:text-amber-400">{{ t('orderDetail.amountMemberDiscount') }}</div>
-              <div class="text-amber-700 dark:text-amber-400 font-mono mt-1">{{ formatDiscountMoney(order.member_discount_amount,
-                order.currency) }}</div>
-            </div>
-            <div v-if="hasDiscountAmount(order.wholesale_discount_amount)" class="border border-emerald-200 bg-emerald-50/50 dark:border-emerald-800 dark:bg-emerald-950/30 rounded-xl p-4">
-              <div class="text-xs text-emerald-700 dark:text-emerald-400">{{ t('orderDetail.amountWholesaleDiscount') }}</div>
-              <div class="text-emerald-700 dark:text-emerald-400 font-mono mt-1">{{ formatDiscountMoney(order.wholesale_discount_amount,
-                order.currency) }}</div>
-            </div>
-          </div>
-        </div>
-
-        <div v-if="showRefundRecordsCard" class="rounded-2xl border bg-card shadow-sm p-6">
-          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.refundRecordsTitle') }}</h2>
-          <div v-if="refundRecords.length > 0" class="overflow-x-auto rounded-xl border">
-            <Table>
-              <TableHeader>
-                <TableRow class="bg-muted/50">
-                  <TableHead class="px-4">{{ t('orderDetail.refundRecordTime') }}</TableHead>
-                  <TableHead class="px-4">{{ t('orderDetail.refundRecordAmount') }}</TableHead>
-                  <TableHead class="px-4">{{ t('orderDetail.refundRecordReason') }}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                <TableRow
-                  v-for="(record, idx) in refundRecords"
-                  :key="`refund-record-row-${idx}`"
-                >
-                  <TableCell class="px-4 text-xs text-muted-foreground whitespace-nowrap">{{ formatDate(record.created_at) }}</TableCell>
-                  <TableCell class="px-4 font-mono text-sm text-foreground whitespace-nowrap">{{ formatMoney(record.amount, record.currency || order.currency) }}</TableCell>
-                  <TableCell class="px-4 text-xs text-muted-foreground whitespace-pre-wrap break-words">{{ refundReasonText(record.remark) }}</TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </div>
-          <div v-else class="text-sm text-muted-foreground">{{ t('orderDetail.refundRecordsEmpty') }}</div>
-        </div>
-
-        <div v-if="showTimeCard" class="rounded-2xl border bg-card shadow-sm p-6">
-          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.timeTitle') }}</h2>
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
-            <div class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.createdAtLabel') }}</div>
-              <div class="text-foreground mt-1">{{ formatDate(order.created_at) }}</div>
-            </div>
-            <div v-if="order.paid_at" class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.paidAtLabel') }}</div>
-              <div class="text-foreground mt-1">{{ formatDate(order.paid_at) }}</div>
-            </div>
-            <div v-if="order.expires_at" class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.expiresAtLabel') }}</div>
-              <div class="text-foreground mt-1">{{ formatDate(order.expires_at) }}</div>
-            </div>
-            <div v-if="order.canceled_at" class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.canceledAtLabel') }}</div>
-              <div class="text-foreground mt-1">{{ formatDate(order.canceled_at) }}</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="rounded-2xl border bg-card shadow-sm p-6">
-          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.itemsTitle') }}</h2>
-          <div v-if="order.items && order.items.length > 0" class="space-y-4">
-            <div v-for="(item, idx) in order.items" :key="idx"
-              class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4 border-b border-gray-100 pb-3 dark:border-white/5">
-              <div class="flex min-w-0 items-start gap-3">
-                <div class="h-14 w-14 shrink-0 overflow-hidden rounded-xl border border-gray-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:shadow-sm dark:border-white/10 dark:bg-black/30 sm:h-16 sm:w-16">
-                  <img
-                    v-if="orderItemImage(item)"
-                    :src="orderItemImage(item)"
-                    :alt="getLocalizedText(item.title)"
-                    loading="lazy"
-                    decoding="async"
-                    class="h-full w-full object-cover"
-                  />
-                  <div v-else class="flex h-full w-full items-center justify-center text-gray-400 dark:text-gray-500">
-                    <ImageIcon class="h-5 w-5" :stroke-width="1.5" />
-                  </div>
-                </div>
-                <div class="min-w-0">
-                  <div class="text-foreground font-medium">{{ getLocalizedText(item.title) }}</div>
-                  <div class="text-xs text-muted-foreground">{{ t('orderDetail.quantityLabel') }}：{{ item.quantity }}</div>
-                  <div v-if="orderItemSkuText(item)" class="text-xs text-muted-foreground mt-1">{{ t('orderDetail.itemSkuLabel') }}：{{ orderItemSkuText(item) }}</div>
-                  <div class="text-xs text-muted-foreground mt-1">
-                    {{ t('orderDetail.itemFulfillmentLabel') }}：{{ fulfillmentTypeLabelText(item.fulfillment_type) }}
-                  </div>
-                  <div v-if="item.tags && item.tags.length" class="mt-2 flex flex-wrap gap-2">
-                    <Badge v-for="(tag, index) in item.tags" :key="index" variant="neutral" size="sm" class="rounded-full">{{ tag }}</Badge>
-                  </div>
-                  <div v-if="manualSubmissionRows(item.manual_form_submission, item.manual_form_schema_snapshot).length"
-                    class="mt-3 rounded-xl border border-gray-200 bg-white p-3 text-xs text-gray-600 dark:border-white/10 dark:bg-black/30 dark:text-gray-300">
-                    <div class="mb-2 font-semibold text-muted-foreground">{{ t('orderDetail.manualSubmissionTitle') }}</div>
-                    <div v-for="row in manualSubmissionRows(item.manual_form_submission, item.manual_form_schema_snapshot)" :key="row.key" class="mb-1 last:mb-0">
-                      <span class="text-foreground">{{ row.label }}</span>：{{ row.value }}
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="shrink-0 pl-[4.25rem] sm:pl-0 text-left sm:text-right text-sm text-muted-foreground space-y-1">
-                <div>{{ t('orderDetail.unitPriceLabel') }}：{{ formatMoney(item.original_unit_price, order.currency) }}</div>
-                <div>{{ t('orderDetail.totalPriceLabel') }}：{{ formatMoney(item.original_total_price, order.currency) }}</div>
-                <div v-if="hasDiscountAmount(item.coupon_discount_amount)">
-                  {{ t('orderDetail.couponDiscountLabel') }}：{{ formatDiscountMoney(item.coupon_discount_amount, order.currency)
-                  }}
-                </div>
-                <div v-if="hasDiscountAmount(item.promotion_discount_amount)">
-                  {{ t('orderDetail.promotionDiscountLabel') }}：{{ formatDiscountMoney(item.promotion_discount_amount,
-                  order.currency) }}
-                </div>
-                <div v-if="hasDiscountAmount(item.wholesale_discount_amount)">
-                  {{ t('orderDetail.wholesaleDiscountLabel') }}：{{ formatDiscountMoney(item.wholesale_discount_amount,
-                  order.currency) }}
-                </div>
-                <div v-if="hasDiscountAmount(item.member_discount_amount)">
-                  {{ t('orderDetail.memberDiscountLabel') }}：{{ formatDiscountMoney(item.member_discount_amount, order.currency) }}
-                </div>
-                <div v-if="hasItemDiscount(item)" class="font-medium text-rose-600 dark:text-rose-300">
-                  {{ t('orderDetail.itemDiscountTotalLabel') }}：{{ formatItemDiscountTotal(item, order.currency) }}
-                </div>
-                <div class="font-medium text-foreground">
-                  {{ t('orderDetail.itemPaidAmountLabel') }}：{{ formatItemPaidAmount(item, order.currency) }}
-                </div>
-              </div>
-            </div>
-          </div>
-          <div v-else class="text-sm text-muted-foreground">{{ t('orderDetail.noItems') }}</div>
-        </div>
-
         <div v-if="order.children && order.children.length > 0"
           class="rounded-2xl border bg-card shadow-sm p-6">
           <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.childOrdersTitle') }}</h2>
@@ -408,6 +257,157 @@
                 {{ t('orderDetail.instructionsTitle') }}
               </div>
               <div class="prose prose-sm max-w-none dark:prose-invert text-muted-foreground break-words" v-html="block.html"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="rounded-2xl border bg-card shadow-sm p-6">
+          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.itemsTitle') }}</h2>
+          <div v-if="order.items && order.items.length > 0" class="space-y-4">
+            <div v-for="(item, idx) in order.items" :key="idx"
+              class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4 border-b border-gray-100 pb-3 dark:border-white/5">
+              <div class="flex min-w-0 items-start gap-3">
+                <div class="h-14 w-14 shrink-0 overflow-hidden rounded-xl border border-gray-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:shadow-sm dark:border-white/10 dark:bg-black/30 sm:h-16 sm:w-16">
+                  <img
+                    v-if="orderItemImage(item)"
+                    :src="orderItemImage(item)"
+                    :alt="getLocalizedText(item.title)"
+                    loading="lazy"
+                    decoding="async"
+                    class="h-full w-full object-cover"
+                  />
+                  <div v-else class="flex h-full w-full items-center justify-center text-gray-400 dark:text-gray-500">
+                    <ImageIcon class="h-5 w-5" :stroke-width="1.5" />
+                  </div>
+                </div>
+                <div class="min-w-0">
+                  <div class="text-foreground font-medium">{{ getLocalizedText(item.title) }}</div>
+                  <div class="text-xs text-muted-foreground">{{ t('orderDetail.quantityLabel') }}：{{ item.quantity }}</div>
+                  <div v-if="orderItemSkuText(item)" class="text-xs text-muted-foreground mt-1">{{ t('orderDetail.itemSkuLabel') }}：{{ orderItemSkuText(item) }}</div>
+                  <div class="text-xs text-muted-foreground mt-1">
+                    {{ t('orderDetail.itemFulfillmentLabel') }}：{{ fulfillmentTypeLabelText(item.fulfillment_type) }}
+                  </div>
+                  <div v-if="item.tags && item.tags.length" class="mt-2 flex flex-wrap gap-2">
+                    <Badge v-for="(tag, index) in item.tags" :key="index" variant="neutral" size="sm" class="rounded-full">{{ tag }}</Badge>
+                  </div>
+                  <div v-if="manualSubmissionRows(item.manual_form_submission, item.manual_form_schema_snapshot).length"
+                    class="mt-3 rounded-xl border border-gray-200 bg-white p-3 text-xs text-gray-600 dark:border-white/10 dark:bg-black/30 dark:text-gray-300">
+                    <div class="mb-2 font-semibold text-muted-foreground">{{ t('orderDetail.manualSubmissionTitle') }}</div>
+                    <div v-for="row in manualSubmissionRows(item.manual_form_submission, item.manual_form_schema_snapshot)" :key="row.key" class="mb-1 last:mb-0">
+                      <span class="text-foreground">{{ row.label }}</span>：{{ row.value }}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="shrink-0 pl-[4.25rem] sm:pl-0 text-left sm:text-right text-sm text-muted-foreground space-y-1">
+                <div>{{ t('orderDetail.unitPriceLabel') }}：{{ formatMoney(item.original_unit_price, order.currency) }}</div>
+                <div>{{ t('orderDetail.totalPriceLabel') }}：{{ formatMoney(item.original_total_price, order.currency) }}</div>
+                <div v-if="hasDiscountAmount(item.coupon_discount_amount)">
+                  {{ t('orderDetail.couponDiscountLabel') }}：{{ formatDiscountMoney(item.coupon_discount_amount, order.currency)
+                  }}
+                </div>
+                <div v-if="hasDiscountAmount(item.promotion_discount_amount)">
+                  {{ t('orderDetail.promotionDiscountLabel') }}：{{ formatDiscountMoney(item.promotion_discount_amount,
+                  order.currency) }}
+                </div>
+                <div v-if="hasDiscountAmount(item.wholesale_discount_amount)">
+                  {{ t('orderDetail.wholesaleDiscountLabel') }}：{{ formatDiscountMoney(item.wholesale_discount_amount,
+                  order.currency) }}
+                </div>
+                <div v-if="hasDiscountAmount(item.member_discount_amount)">
+                  {{ t('orderDetail.memberDiscountLabel') }}：{{ formatDiscountMoney(item.member_discount_amount, order.currency) }}
+                </div>
+                <div v-if="hasItemDiscount(item)" class="font-medium text-rose-600 dark:text-rose-300">
+                  {{ t('orderDetail.itemDiscountTotalLabel') }}：{{ formatItemDiscountTotal(item, order.currency) }}
+                </div>
+                <div class="font-medium text-foreground">
+                  {{ t('orderDetail.itemPaidAmountLabel') }}：{{ formatItemPaidAmount(item, order.currency) }}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div v-else class="text-sm text-muted-foreground">{{ t('orderDetail.noItems') }}</div>
+        </div>
+
+        <div class="rounded-2xl border bg-card shadow-sm p-6">
+          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.amountTitle') }}</h2>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+            <div class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountOriginal') }}</div>
+              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.original_amount,
+                order.currency) }}</div>
+            </div>
+            <div class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountDiscount') }}</div>
+              <div
+                class="font-mono mt-1"
+                :class="hasDiscountAmount(order.discount_amount) ? 'text-rose-600 dark:text-rose-300' : 'text-foreground'"
+              >
+                {{ formatDiscountMoney(order.discount_amount, order.currency) }}
+              </div>
+            </div>
+            <div class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountTotal') }}</div>
+              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.total_amount,
+                order.currency) }}</div>
+            </div>
+            <div v-if="hasDiscountAmount(order.member_discount_amount)" class="border border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-950/30 rounded-xl p-4">
+              <div class="text-xs text-amber-700 dark:text-amber-400">{{ t('orderDetail.amountMemberDiscount') }}</div>
+              <div class="text-amber-700 dark:text-amber-400 font-mono mt-1">{{ formatDiscountMoney(order.member_discount_amount,
+                order.currency) }}</div>
+            </div>
+            <div v-if="hasDiscountAmount(order.wholesale_discount_amount)" class="border border-emerald-200 bg-emerald-50/50 dark:border-emerald-800 dark:bg-emerald-950/30 rounded-xl p-4">
+              <div class="text-xs text-emerald-700 dark:text-emerald-400">{{ t('orderDetail.amountWholesaleDiscount') }}</div>
+              <div class="text-emerald-700 dark:text-emerald-400 font-mono mt-1">{{ formatDiscountMoney(order.wholesale_discount_amount,
+                order.currency) }}</div>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="showRefundRecordsCard" class="rounded-2xl border bg-card shadow-sm p-6">
+          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.refundRecordsTitle') }}</h2>
+          <div v-if="refundRecords.length > 0" class="overflow-x-auto rounded-xl border">
+            <Table>
+              <TableHeader>
+                <TableRow class="bg-muted/50">
+                  <TableHead class="px-4">{{ t('orderDetail.refundRecordTime') }}</TableHead>
+                  <TableHead class="px-4">{{ t('orderDetail.refundRecordAmount') }}</TableHead>
+                  <TableHead class="px-4">{{ t('orderDetail.refundRecordReason') }}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow
+                  v-for="(record, idx) in refundRecords"
+                  :key="`refund-record-row-${idx}`"
+                >
+                  <TableCell class="px-4 text-xs text-muted-foreground whitespace-nowrap">{{ formatDate(record.created_at) }}</TableCell>
+                  <TableCell class="px-4 font-mono text-sm text-foreground whitespace-nowrap">{{ formatMoney(record.amount, record.currency || order.currency) }}</TableCell>
+                  <TableCell class="px-4 text-xs text-muted-foreground whitespace-pre-wrap break-words">{{ refundReasonText(record.remark) }}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </div>
+          <div v-else class="text-sm text-muted-foreground">{{ t('orderDetail.refundRecordsEmpty') }}</div>
+        </div>
+
+        <div v-if="showTimeCard" class="rounded-2xl border bg-card shadow-sm p-6">
+          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.timeTitle') }}</h2>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+            <div class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.createdAtLabel') }}</div>
+              <div class="text-foreground mt-1">{{ formatDate(order.created_at) }}</div>
+            </div>
+            <div v-if="order.paid_at" class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.paidAtLabel') }}</div>
+              <div class="text-foreground mt-1">{{ formatDate(order.paid_at) }}</div>
+            </div>
+            <div v-if="order.expires_at" class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.expiresAtLabel') }}</div>
+              <div class="text-foreground mt-1">{{ formatDate(order.expires_at) }}</div>
+            </div>
+            <div v-if="order.canceled_at" class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.canceledAtLabel') }}</div>
+              <div class="text-foreground mt-1">{{ formatDate(order.canceled_at) }}</div>
             </div>
           </div>
         </div>

--- a/frontend/user/src/views/OrderDetail.vue
+++ b/frontend/user/src/views/OrderDetail.vue
@@ -79,167 +79,6 @@
           </div>
         </div>
 
-        <div class="rounded-2xl border bg-card shadow-sm p-6">
-          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.amountTitle') }}</h2>
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
-            <div class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountOriginal') }}</div>
-              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.original_amount,
-                order.currency) }}</div>
-            </div>
-            <div class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountDiscount') }}</div>
-              <div
-                class="font-mono mt-1"
-                :class="hasDiscountAmount(order.discount_amount) ? 'text-rose-600 dark:text-rose-300' : 'text-foreground'"
-              >
-                {{ formatDiscountMoney(order.discount_amount, order.currency) }}
-              </div>
-            </div>
-            <div class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountTotal') }}</div>
-              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.total_amount,
-                order.currency) }}</div>
-            </div>
-            <div v-if="hasAmount(order.wallet_paid_amount)" class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountWalletPaid') }}</div>
-              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.wallet_paid_amount,
-                order.currency) }}</div>
-            </div>
-            <div v-if="hasAmount(order.online_paid_amount)" class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountOnlinePaid') }}</div>
-              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.online_paid_amount,
-                order.currency) }}</div>
-            </div>
-            <div v-if="hasAmount(order.refunded_amount)" class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountRefunded') }}</div>
-              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.refunded_amount,
-                order.currency) }}</div>
-            </div>
-            <div v-if="hasDiscountAmount(order.member_discount_amount)" class="border border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-950/30 rounded-xl p-4">
-              <div class="text-xs text-amber-700 dark:text-amber-400">{{ t('orderDetail.amountMemberDiscount') }}</div>
-              <div class="text-amber-700 dark:text-amber-400 font-mono mt-1">{{ formatDiscountMoney(order.member_discount_amount,
-                order.currency) }}</div>
-            </div>
-            <div v-if="hasDiscountAmount(order.wholesale_discount_amount)" class="border border-emerald-200 bg-emerald-50/50 dark:border-emerald-800 dark:bg-emerald-950/30 rounded-xl p-4">
-              <div class="text-xs text-emerald-700 dark:text-emerald-400">{{ t('orderDetail.amountWholesaleDiscount') }}</div>
-              <div class="text-emerald-700 dark:text-emerald-400 font-mono mt-1">{{ formatDiscountMoney(order.wholesale_discount_amount,
-                order.currency) }}</div>
-            </div>
-          </div>
-        </div>
-
-        <div v-if="showRefundRecordsCard" class="rounded-2xl border bg-card shadow-sm p-6">
-          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.refundRecordsTitle') }}</h2>
-          <div v-if="refundRecords.length > 0" class="overflow-x-auto rounded-xl border">
-            <Table>
-              <TableHeader>
-                <TableRow class="bg-muted/50">
-                  <TableHead class="px-4">{{ t('orderDetail.refundRecordTime') }}</TableHead>
-                  <TableHead class="px-4">{{ t('orderDetail.refundRecordAmount') }}</TableHead>
-                  <TableHead class="px-4">{{ t('orderDetail.refundRecordReason') }}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                <TableRow
-                  v-for="(record, idx) in refundRecords"
-                  :key="`refund-record-row-${idx}`"
-                >
-                  <TableCell class="px-4 text-xs text-muted-foreground whitespace-nowrap">{{ formatDate(record.created_at) }}</TableCell>
-                  <TableCell class="px-4 font-mono text-sm text-foreground whitespace-nowrap">{{ formatMoney(record.amount, record.currency || order.currency) }}</TableCell>
-                  <TableCell class="px-4 text-xs text-muted-foreground whitespace-pre-wrap break-words">{{ refundReasonText(record.remark) }}</TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </div>
-          <div v-else class="text-sm text-muted-foreground">{{ t('orderDetail.refundRecordsEmpty') }}</div>
-        </div>
-
-        <div v-if="showTimeCard" class="rounded-2xl border bg-card shadow-sm p-6">
-          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.timeTitle') }}</h2>
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
-            <div class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.createdAtLabel') }}</div>
-              <div class="text-foreground mt-1">{{ formatDate(order.created_at) }}</div>
-            </div>
-            <div v-if="order.paid_at" class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.paidAtLabel') }}</div>
-              <div class="text-foreground mt-1">{{ formatDate(order.paid_at) }}</div>
-            </div>
-            <div v-if="order.expires_at" class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.expiresAtLabel') }}</div>
-              <div class="text-foreground mt-1">{{ formatDate(order.expires_at) }}</div>
-            </div>
-            <div v-if="order.canceled_at" class="border rounded-xl p-4">
-              <div class="text-xs text-muted-foreground">{{ t('orderDetail.canceledAtLabel') }}</div>
-              <div class="text-foreground mt-1">{{ formatDate(order.canceled_at) }}</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="rounded-2xl border bg-card shadow-sm p-6">
-          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.itemsTitle') }}</h2>
-          <div v-if="order.items && order.items.length > 0" class="space-y-4">
-            <div v-for="(item, idx) in order.items" :key="idx"
-              class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4 border-b border-gray-100 pb-3 dark:border-white/5">
-              <div class="flex min-w-0 items-start gap-3">
-                <div class="h-14 w-14 shrink-0 overflow-hidden rounded-xl border border-gray-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:shadow-sm dark:border-white/10 dark:bg-black/30 sm:h-16 sm:w-16">
-                  <SmartImage
-                    :src="orderItemImage(item)"
-                    :alt="getLocalizedText(item.title)"
-                    img-class="h-full w-full object-cover"
-                  />
-                </div>
-                <div class="min-w-0">
-                  <div class="text-foreground font-medium">{{ getLocalizedText(item.title) }}</div>
-                  <div class="text-xs text-muted-foreground">{{ t('orderDetail.quantityLabel') }}：{{ item.quantity }}</div>
-                  <div v-if="orderItemSkuText(item)" class="text-xs text-muted-foreground mt-1">{{ t('orderDetail.itemSkuLabel') }}：{{ orderItemSkuText(item) }}</div>
-                  <div class="text-xs text-muted-foreground mt-1">
-                    {{ t('orderDetail.itemFulfillmentLabel') }}：{{ fulfillmentTypeLabelText(item.fulfillment_type) }}
-                  </div>
-                  <div v-if="item.tags && item.tags.length" class="mt-2 flex flex-wrap gap-2">
-                    <Badge v-for="(tag, index) in item.tags" :key="index" variant="neutral" size="sm" class="rounded-full">{{ tag }}</Badge>
-                  </div>
-                  <div v-if="manualSubmissionRows(item.manual_form_submission, item.manual_form_schema_snapshot).length"
-                    class="mt-3 rounded-xl border border-gray-200 bg-white p-3 text-xs text-gray-600 dark:border-white/10 dark:bg-black/30 dark:text-gray-300">
-                    <div class="mb-2 font-semibold text-muted-foreground">{{ t('orderDetail.manualSubmissionTitle') }}</div>
-                    <div v-for="row in manualSubmissionRows(item.manual_form_submission, item.manual_form_schema_snapshot)" :key="row.key" class="mb-1 last:mb-0">
-                      <span class="text-foreground">{{ row.label }}</span>：{{ row.value }}
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="shrink-0 pl-[4.25rem] sm:pl-0 text-left sm:text-right text-sm text-muted-foreground space-y-1">
-                <div>{{ t('orderDetail.unitPriceLabel') }}：{{ formatMoney(item.original_unit_price, order.currency) }}</div>
-                <div>{{ t('orderDetail.totalPriceLabel') }}：{{ formatMoney(item.original_total_price, order.currency) }}</div>
-                <div v-if="hasDiscountAmount(item.coupon_discount_amount)">
-                  {{ t('orderDetail.couponDiscountLabel') }}：{{ formatDiscountMoney(item.coupon_discount_amount, order.currency)
-                  }}
-                </div>
-                <div v-if="hasDiscountAmount(item.promotion_discount_amount)">
-                  {{ t('orderDetail.promotionDiscountLabel') }}：{{ formatDiscountMoney(item.promotion_discount_amount,
-                  order.currency) }}
-                </div>
-                <div v-if="hasDiscountAmount(item.wholesale_discount_amount)">
-                  {{ t('orderDetail.wholesaleDiscountLabel') }}：{{ formatDiscountMoney(item.wholesale_discount_amount,
-                  order.currency) }}
-                </div>
-                <div v-if="hasDiscountAmount(item.member_discount_amount)">
-                  {{ t('orderDetail.memberDiscountLabel') }}：{{ formatDiscountMoney(item.member_discount_amount,
-                  order.currency) }}
-                </div>
-                <div v-if="hasItemDiscount(item)" class="font-medium text-rose-600 dark:text-rose-300">
-                  {{ t('orderDetail.itemDiscountTotalLabel') }}：{{ formatItemDiscountTotal(item, order.currency) }}
-                </div>
-                <div class="font-medium text-foreground">
-                  {{ t('orderDetail.itemPaidAmountLabel') }}：{{ formatItemPaidAmount(item, order.currency) }}
-                </div>
-              </div>
-            </div>
-          </div>
-          <div v-else class="text-sm text-muted-foreground">{{ t('orderDetail.noItems') }}</div>
-        </div>
-
         <div v-if="order.children && order.children.length > 0"
           class="rounded-2xl border bg-card shadow-sm p-6">
           <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.childOrdersTitle') }}</h2>
@@ -426,6 +265,167 @@
                 {{ t('orderDetail.instructionsTitle') }}
               </div>
               <div class="prose prose-sm max-w-none dark:prose-invert text-muted-foreground break-words" v-html="block.html"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="rounded-2xl border bg-card shadow-sm p-6">
+          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.itemsTitle') }}</h2>
+          <div v-if="order.items && order.items.length > 0" class="space-y-4">
+            <div v-for="(item, idx) in order.items" :key="idx"
+              class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4 border-b border-gray-100 pb-3 dark:border-white/5">
+              <div class="flex min-w-0 items-start gap-3">
+                <div class="h-14 w-14 shrink-0 overflow-hidden rounded-xl border border-gray-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:shadow-sm dark:border-white/10 dark:bg-black/30 sm:h-16 sm:w-16">
+                  <SmartImage
+                    :src="orderItemImage(item)"
+                    :alt="getLocalizedText(item.title)"
+                    img-class="h-full w-full object-cover"
+                  />
+                </div>
+                <div class="min-w-0">
+                  <div class="text-foreground font-medium">{{ getLocalizedText(item.title) }}</div>
+                  <div class="text-xs text-muted-foreground">{{ t('orderDetail.quantityLabel') }}：{{ item.quantity }}</div>
+                  <div v-if="orderItemSkuText(item)" class="text-xs text-muted-foreground mt-1">{{ t('orderDetail.itemSkuLabel') }}：{{ orderItemSkuText(item) }}</div>
+                  <div class="text-xs text-muted-foreground mt-1">
+                    {{ t('orderDetail.itemFulfillmentLabel') }}：{{ fulfillmentTypeLabelText(item.fulfillment_type) }}
+                  </div>
+                  <div v-if="item.tags && item.tags.length" class="mt-2 flex flex-wrap gap-2">
+                    <Badge v-for="(tag, index) in item.tags" :key="index" variant="neutral" size="sm" class="rounded-full">{{ tag }}</Badge>
+                  </div>
+                  <div v-if="manualSubmissionRows(item.manual_form_submission, item.manual_form_schema_snapshot).length"
+                    class="mt-3 rounded-xl border border-gray-200 bg-white p-3 text-xs text-gray-600 dark:border-white/10 dark:bg-black/30 dark:text-gray-300">
+                    <div class="mb-2 font-semibold text-muted-foreground">{{ t('orderDetail.manualSubmissionTitle') }}</div>
+                    <div v-for="row in manualSubmissionRows(item.manual_form_submission, item.manual_form_schema_snapshot)" :key="row.key" class="mb-1 last:mb-0">
+                      <span class="text-foreground">{{ row.label }}</span>：{{ row.value }}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="shrink-0 pl-[4.25rem] sm:pl-0 text-left sm:text-right text-sm text-muted-foreground space-y-1">
+                <div>{{ t('orderDetail.unitPriceLabel') }}：{{ formatMoney(item.original_unit_price, order.currency) }}</div>
+                <div>{{ t('orderDetail.totalPriceLabel') }}：{{ formatMoney(item.original_total_price, order.currency) }}</div>
+                <div v-if="hasDiscountAmount(item.coupon_discount_amount)">
+                  {{ t('orderDetail.couponDiscountLabel') }}：{{ formatDiscountMoney(item.coupon_discount_amount, order.currency)
+                  }}
+                </div>
+                <div v-if="hasDiscountAmount(item.promotion_discount_amount)">
+                  {{ t('orderDetail.promotionDiscountLabel') }}：{{ formatDiscountMoney(item.promotion_discount_amount,
+                  order.currency) }}
+                </div>
+                <div v-if="hasDiscountAmount(item.wholesale_discount_amount)">
+                  {{ t('orderDetail.wholesaleDiscountLabel') }}：{{ formatDiscountMoney(item.wholesale_discount_amount,
+                  order.currency) }}
+                </div>
+                <div v-if="hasDiscountAmount(item.member_discount_amount)">
+                  {{ t('orderDetail.memberDiscountLabel') }}：{{ formatDiscountMoney(item.member_discount_amount,
+                  order.currency) }}
+                </div>
+                <div v-if="hasItemDiscount(item)" class="font-medium text-rose-600 dark:text-rose-300">
+                  {{ t('orderDetail.itemDiscountTotalLabel') }}：{{ formatItemDiscountTotal(item, order.currency) }}
+                </div>
+                <div class="font-medium text-foreground">
+                  {{ t('orderDetail.itemPaidAmountLabel') }}：{{ formatItemPaidAmount(item, order.currency) }}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div v-else class="text-sm text-muted-foreground">{{ t('orderDetail.noItems') }}</div>
+        </div>
+
+        <div class="rounded-2xl border bg-card shadow-sm p-6">
+          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.amountTitle') }}</h2>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+            <div class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountOriginal') }}</div>
+              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.original_amount,
+                order.currency) }}</div>
+            </div>
+            <div class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountDiscount') }}</div>
+              <div
+                class="font-mono mt-1"
+                :class="hasDiscountAmount(order.discount_amount) ? 'text-rose-600 dark:text-rose-300' : 'text-foreground'"
+              >
+                {{ formatDiscountMoney(order.discount_amount, order.currency) }}
+              </div>
+            </div>
+            <div class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountTotal') }}</div>
+              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.total_amount,
+                order.currency) }}</div>
+            </div>
+            <div v-if="hasAmount(order.wallet_paid_amount)" class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountWalletPaid') }}</div>
+              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.wallet_paid_amount,
+                order.currency) }}</div>
+            </div>
+            <div v-if="hasAmount(order.online_paid_amount)" class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountOnlinePaid') }}</div>
+              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.online_paid_amount,
+                order.currency) }}</div>
+            </div>
+            <div v-if="hasAmount(order.refunded_amount)" class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.amountRefunded') }}</div>
+              <div class="text-foreground font-mono mt-1">{{ formatMoney(order.refunded_amount,
+                order.currency) }}</div>
+            </div>
+            <div v-if="hasDiscountAmount(order.member_discount_amount)" class="border border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-950/30 rounded-xl p-4">
+              <div class="text-xs text-amber-700 dark:text-amber-400">{{ t('orderDetail.amountMemberDiscount') }}</div>
+              <div class="text-amber-700 dark:text-amber-400 font-mono mt-1">{{ formatDiscountMoney(order.member_discount_amount,
+                order.currency) }}</div>
+            </div>
+            <div v-if="hasDiscountAmount(order.wholesale_discount_amount)" class="border border-emerald-200 bg-emerald-50/50 dark:border-emerald-800 dark:bg-emerald-950/30 rounded-xl p-4">
+              <div class="text-xs text-emerald-700 dark:text-emerald-400">{{ t('orderDetail.amountWholesaleDiscount') }}</div>
+              <div class="text-emerald-700 dark:text-emerald-400 font-mono mt-1">{{ formatDiscountMoney(order.wholesale_discount_amount,
+                order.currency) }}</div>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="showRefundRecordsCard" class="rounded-2xl border bg-card shadow-sm p-6">
+          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.refundRecordsTitle') }}</h2>
+          <div v-if="refundRecords.length > 0" class="overflow-x-auto rounded-xl border">
+            <Table>
+              <TableHeader>
+                <TableRow class="bg-muted/50">
+                  <TableHead class="px-4">{{ t('orderDetail.refundRecordTime') }}</TableHead>
+                  <TableHead class="px-4">{{ t('orderDetail.refundRecordAmount') }}</TableHead>
+                  <TableHead class="px-4">{{ t('orderDetail.refundRecordReason') }}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow
+                  v-for="(record, idx) in refundRecords"
+                  :key="`refund-record-row-${idx}`"
+                >
+                  <TableCell class="px-4 text-xs text-muted-foreground whitespace-nowrap">{{ formatDate(record.created_at) }}</TableCell>
+                  <TableCell class="px-4 font-mono text-sm text-foreground whitespace-nowrap">{{ formatMoney(record.amount, record.currency || order.currency) }}</TableCell>
+                  <TableCell class="px-4 text-xs text-muted-foreground whitespace-pre-wrap break-words">{{ refundReasonText(record.remark) }}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </div>
+          <div v-else class="text-sm text-muted-foreground">{{ t('orderDetail.refundRecordsEmpty') }}</div>
+        </div>
+
+        <div v-if="showTimeCard" class="rounded-2xl border bg-card shadow-sm p-6">
+          <h2 class="text-lg font-bold mb-4">{{ t('orderDetail.timeTitle') }}</h2>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+            <div class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.createdAtLabel') }}</div>
+              <div class="text-foreground mt-1">{{ formatDate(order.created_at) }}</div>
+            </div>
+            <div v-if="order.paid_at" class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.paidAtLabel') }}</div>
+              <div class="text-foreground mt-1">{{ formatDate(order.paid_at) }}</div>
+            </div>
+            <div v-if="order.expires_at" class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.expiresAtLabel') }}</div>
+              <div class="text-foreground mt-1">{{ formatDate(order.expires_at) }}</div>
+            </div>
+            <div v-if="order.canceled_at" class="border rounded-xl p-4">
+              <div class="text-xs text-muted-foreground">{{ t('orderDetail.canceledAtLabel') }}</div>
+              <div class="text-foreground mt-1">{{ formatDate(order.canceled_at) }}</div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- 订单详情页（经典模板 `OrderDetail.vue` / `GuestOrderDetail.vue`，以及 vault 模板共用的 `VaultOrderBody.vue`）中，子订单卡密与订单级发货信息（含复制按钮、使用说明）原本排在金额明细、退款记录、时间信息之后，用户支付完成后需要滑动很久才能看到卡密
- 调整卡片顺序为：订单头 → 子订单（卡密）→ 发货信息（卡密）→ 商品清单 → 金额明细 → 退款记录 → 时间信息，让用户第一屏就能看到并复制卡密、查看使用说明
- vault 模板顶栏右上角新增游客查单入口图标，并与经典模板 `Navbar.vue` 对齐：登录后隐藏顶栏/移动端更多菜单/页脚的游客查单入口
- 修复 vault 模板订单明细商品条目在移动端被挤压的问题：左侧商品信息 `flex-1 min-w-0` 可无限压缩、右侧价格块 `min-w-[180px]` 硬占空间，导致窄屏下标题竖排；≤640px 改为上下堆叠布局（与经典模板 `flex-col sm:flex-row` 方案一致），桌面端不变

## Test plan
- [x] `vue-tsc --noEmit` 通过
- [x] 移动端订单明细上下布局本地验证
- [x] 验证单商品订单 / 拆分子订单两种场景下卡密展示位置
- [x] 登录/未登录状态下 vault 顶栏与页脚游客查单入口显隐